### PR TITLE
Change to gelu default from relu which is what we actually used before

### DIFF
--- a/scripts/singlecell/geneformer/pretrain.py
+++ b/scripts/singlecell/geneformer/pretrain.py
@@ -183,10 +183,10 @@ def main(
         gradient_accumulation_fusion=False,  # THIS BREAKS STUFF, leave False
         layernorm_zero_centered_gamma=False,  # TODO(@jstjohn) check this
         layernorm_epsilon=1.0e-12,
-        activation_func=F.relu,  # TODO(@jstjohn) check this
+        activation_func=F.gelu,  # TODO(@jstjohn) check this
         qk_layernorm=True,  # TODO(@jstjohn) check this
         apply_residual_connection_post_layernorm=False,  # False is new default, True was BERT pub.
-        bias_activation_fusion=False,  # TODO(@jstjohn) check this
+        bias_activation_fusion=True,  # TODO(@jstjohn) check this
         bias_dropout_fusion=True,  # TODO(@jstjohn) check this
         get_attention_mask_from_fusion=False,
         attention_dropout=0.1,


### PR DESCRIPTION
* Update geneformer pretrain defaults to match our bionemo1 defaults. 
* Verify on slurm run that these defaults are better than the previous defaults: https://wandb.ai/clara-discovery/bionemo2-ea-geneformer-test-bcp