### PR TITLE
Checkpointing example with Geneformer

### DIFF
--- a/sub-packages/bionemo-geneformer/src/bionemo/geneformer/tokenizer/gene_tokenizer.py
+++ b/sub-packages/bionemo-geneformer/src/bionemo/geneformer/tokenizer/gene_tokenizer.py
@@ -19,6 +19,8 @@ import os
 from copy import deepcopy
 from typing import Dict, List, Sequence, Tuple, TypeVar, Union
 
+from nemo.lightning import io
+
 from bionemo.geneformer.tokenizer.label2id_tokenizer import Label2IDTokenizer
 
 
@@ -27,7 +29,7 @@ __all__: Sequence[str] = ("GeneTokenizer",)
 T = TypeVar("T", bound="GeneTokenizer")
 
 
-class GeneTokenizer(Label2IDTokenizer):
+class GeneTokenizer(Label2IDTokenizer, io.IOMixin):
     """Initializes the GeneTokenizer object."""
 
     cls_token: str = "[CLS]"

--- a/sub-packages/bionemo-llm/src/bionemo/llm/model/biobert/model.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/model/biobert/model.py
@@ -32,7 +32,7 @@ from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.utils import get_linear_layer
 from nemo.collections.common.tokenizers.huggingface.auto_tokenizer import AutoTokenizer
-from nemo.lightning import get_vocab_size
+from nemo.lightning import get_vocab_size, io
 from nemo.lightning.megatron_parallel import MegatronLossReduction
 from torch import Tensor
 from torch.optim import Optimizer
@@ -337,7 +337,14 @@ class MegatronBioBertModel(LanguageModule):
 
 
 @dataclass
-class BioBertConfig(BionemoTrainableModelConfig[MegatronBioBertModel, MegatronLossReduction], TransformerConfig):  # noqa: D101
+class BioBertConfig(
+    BionemoTrainableModelConfig[MegatronBioBertModel, MegatronLossReduction], TransformerConfig, io.IOMixin
+):
+    """Config class for BioBert model, responsible for the partial configuration of Transformer models.
+
+    `configure_model()` is ultimately called by the LightningModule using PTL lightning module hooks.
+    """
+
     # From megatron.core.models.gpt.bert_model.GPTModel
     fp16_lm_cross_entropy: bool = False
     parallel_output: bool = True

--- a/sub-packages/bionemo-llm/src/bionemo/llm/utils/logger_utils.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/utils/logger_utils.py
@@ -16,6 +16,7 @@ import pathlib
 from typing import Any, Dict, Optional, Sequence, TypedDict
 
 from nemo.lightning.nemo_logger import NeMoLogger
+from nemo.lightning.pytorch import callbacks as nemo_callbacks
 from nemo.utils import logging
 from pytorch_lightning.loggers import TensorBoardLogger, WandbLogger
 
@@ -41,9 +42,10 @@ class WandbLoggerOptions(TypedDict):
 
 def setup_nemo_lightning_logger(
     name: str = "default-name",
-    root_dir: str = "./results",
+    root_dir: str | pathlib.Path = "./results",
     initialize_tensorboard_logger: bool = False,
     wandb_kwargs: Optional[WandbLoggerOptions] = None,
+    ckpt_callback: Optional[nemo_callbacks.ModelCheckpoint] = None,
     **kwargs: Dict[str, Any],
 ) -> NeMoLogger:
     """Setup the logger for the experiment.
@@ -53,6 +55,8 @@ def setup_nemo_lightning_logger(
         root_dir: The root directory to create the `name` directory in for saving run results.
         initialize_tensorboard_logger: Whether to initialize the tensorboard logger.
         wandb_kwargs: The kwargs for the wandb logger.
+        ckpt_callback: The checkpoint callback to use, must be a child of the pytorch lightning ModelCheckpoint callback.
+            NOTE the type annotation in the underlying NeMoCheckpoint constructor is incorrect.
         **kwargs: The kwargs for the NeMoLogger.
 
     Returns:
@@ -71,10 +75,11 @@ def setup_nemo_lightning_logger(
         tb_logger = None
         logging.warning("User-set tensorboard is currently turned off. Internally one may still be set by NeMo2.")
     logger: NeMoLogger = NeMoLogger(
-        dir=root_dir,
+        dir=str(root_dir),
         name=name,
         tensorboard=tb_logger,
         wandb=wandb_logger,
+        ckpt=ckpt_callback,
         **kwargs,
     )
     # Needed so that the trainer can find an output directory for the profiler


### PR DESCRIPTION
# Checkpointing

This PR brings over lessons from experimenting with the GPT example on bringing checkpointing into our geneformer exmaple. Setups AutoResume and checkpointing with io nemo files.

## How to enable auto resume
`--resume-if-exists`

## Tests?
Tests will be added to a separate PR to avoid falling behind on structural changes:

- Stop and go tests on model loss
- Stop and go tests with/without nemo_ckpt_io
- Stop and go tests with nemo_ckpt_io and a changing configuration of parallelism and precision


# The key changes to our configuration are as follows (and in the diff):

## MegatronStrategy:

 - ckpt_include_optimizer=True, Includes the optimizer state in the state_dict and restores it on restoration. This is needed for any jobs that expect interruptions (any large jobs, jobs on clusters with time limits, etc)
 - ckpt_parallel_load=True, loads checkpoints in parallel, useful for very large model restoration
 
 ## ModelCheckpoint
This is a callback class included from NeMo that must be hooked into the logger to function correctly. This overrides the default pytorch lightning `ModelCheckpoint` class and adds NeMo-specific filename structures to support things like finding the last checkpoint, best-k checkpoints, etc.

Importantly, it also includes `enable_nemo_ckpt_io`, which is our 'replacement' for `.nemo` files previously. This is includes all the state registered with the model in the form of either IOMixins, or from `nemo.lightning.io.mixin.track_io`. 

## Restoring a model
To restore a model from a 'nemo file' (actually the `enable_nemo_ckpt_io` code path, you want something like follows:

```python
from nemo.lightning.io.api import load_context, load

# Useful stuff for understanding wtf is going on.
# ctx = load_context('test_logdir_gpt/default/checkpoints/default--reduced_train_loss=0.0303-epoch=0-last')
# ctx = load('test_logdir_gpt/default/checkpoints/default--reduced_train_loss=0.0303-epoch=0-last', [])
# print(list(ctx.model.module.parameters()))

# NOTE: the meat:

ckpt_dir = 'test_logdir_gpt/default/checkpoints/default--reduced_train_loss=0.0303-epoch=0-last'
from nemo import lightning as nl

trainer = nl.Trainer(
    devices=1,
    strategy=nl.MegatronStrategy(tensor_model_parallel_size=1),
    plugins=nl.MegatronMixedPrecision(precision='16-mixed')
)

fabric = trainer.to_fabric()
distributed_model = fabric.load_model(ckpt_dir)

actual_model = distributed_model.module.module.module.module

first = next(actual_model.parameters())
print(first)
``` 

