### PR TITLE
Add pstjohn as authorized user for pull request CI

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -38,6 +38,7 @@ jobs:
          (github.actor == 'ohadmo' ||
           github.actor == 'trvachov' ||
           github.actor == 'jstjohn' ||
+          github.actor == 'pstjohn' ||
           github.actor == 'malcolmgreaves' ||
           github.actor == 'gwarmstrong' ||
           github.actor == 'farhadrgh' ||


### PR DESCRIPTION
Adds pstjohn to the list of users able to trigger CI with /build-ci