### PR TITLE
Add trufflehog as a github action check

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,11 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - uses: actions/setup-python@v3
     - uses: pre-commit/action@v3.0.1
+    - uses: trufflesecurity/trufflehog@main
+      with:
+        extra_args: --only-verified


### PR DESCRIPTION
The trufflehog pre-commit hook is actually quite expensive to run, and may not be something we want to burden folks with on every commit. Adding it as a github action step should give us protection from any secrets getting into protected branches.