### PR TITLE
convert root_directory to a field with default_factory

### DIFF
--- a/sub-packages/bionemo-geneformer/src/bionemo/geneformer/data/preprocess.py
+++ b/sub-packages/bionemo-geneformer/src/bionemo/geneformer/data/preprocess.py
@@ -15,7 +15,7 @@
 
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional, Sequence
 
 from bionemo.llm.utils.remote import RemoteResource
@@ -32,7 +32,7 @@ class ResourcePreprocessor(ABC):
         remote -> prepare -> prepared data.
     """  # noqa: D205
 
-    root_directory: Optional[str] = RemoteResource.get_env_tmpdir()  # noqa: RUF009
+    root_directory: Optional[str] = field(default_factory=RemoteResource.get_env_tmpdir)
     dest_directory: str = "data"
 
     def get_checksums(self) -> List[str]:  # noqa: D102


### PR DESCRIPTION
Fixes this bug where we're not creating a new temporary directory whenever we instantiate this class.

Closes #57 