### PR TITLE
add search highlight + code copy capabilities

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -11,6 +11,9 @@ theme:
     - navigation.sections
     - navigation.instant
     - navigation.instant.prefetch
+    - search.suggest
+    - search.highlight
+    - content.code.copy
   font:
     text: NVIDIA Sans
     code: Roboto Mono


### PR DESCRIPTION
Very small PR to add some UX quality-of-life improvements:
-  search results will highlight on page
-  code snippets are copy & pastable.

(really just using this small PR as an opportunity to test the blossom `/build-ci` commands from my end, since I'm debugging this access with Ohad atm)


Example of added functionality:
<img width="783" alt="Screenshot 2024-08-16 at 1 36 22 PM" src="https://github.com/user-attachments/assets/e01276fc-a77a-4da7-b1d1-868b1704fbea">
