### PR TITLE
add internal link for devcontainer cache

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 		"context": "${localWorkspaceFolder}",
 		"dockerfile": "${localWorkspaceFolder}/Dockerfile",
 		"cacheFrom": "nvcr.io/nvidian/cvai_bnmo_trng/bionemo:bionemo2-latest",
+		"cacheFrom": "gitlab-master.nvidia.com:5005/clara-discovery/bionemo/bionemo-inter:bionemo2-latest-cache",
 		"target": "dev"
 	},
 	"mounts": [


### PR DESCRIPTION
Lets the devcontainer build pull from our internal nightly build's docker cache for NV developers