### PR TITLE
Establish CODEOWNERS for bionemo2

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@
 #
 # @DejunL - Dejun Lin
 # @broland-hat - Brian Roland
-# @cye-nvidia - Cory Ye
+# @cspades - Cory Ye
 # @dorotat-nv - Dorota
 # @farhadrgh - Farhad Ramezanghorbani
 # @guoqing-zhou - Guoqing Zhou


### PR DESCRIPTION
Populates the `CODEOWNERS` file, setting proper code owners for all areas of the bionemo2 codebase.