### PR TITLE
add pyright checks to github workflows

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,6 +37,7 @@
 					"./sub-packages/bionemo-geneformer/src",
 					"./sub-packages/bionemo-llm/src",
 					"./sub-packages/bionemo-testing/src",
+					"./sub-packages/bionemo-scdl/src",
 					"./sub-packages/bionemo-example_model/src",
 					"./3rdparty/NeMo",
 					"./3rdparty/Megatron-LM"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,6 +14,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        submodules: 'recursive'
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,6 +21,7 @@ jobs:
     - run: pip install -r requirements-dev.txt
     - run: ruff check scripts/ sub-packages/ docs/
     - run: tach check
+    - run: pyright sub-packages/ scripts/
     - uses: trufflesecurity/trufflehog@main
       with:
         extra_args: --only-verified

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,11 +18,11 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
+        cache: 'pip'
     - uses: pre-commit/action@v3.0.1
     - run: pip install -r requirements-dev.txt
     - run: ruff check scripts/ sub-packages/ docs/
     - run: tach check
-    - run: pyright sub-packages/ scripts/
     - uses: trufflesecurity/trufflehog@main
       with:
         extra_args: --only-verified

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ addopts = ["--ignore=3rdparty"]
 license = { file = "LICENSE/license.txt" }
 
 [tool.pyright]
-include = ["./sub-packages/bionemo-*/src"]
+include = ["./sub-packages/", "./scripts/"]
 exclude = ["*/tests/"]
 executionEnvironments = [
     { "root" = ".", pythonVersion = "3.10", extraPaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,22 +7,22 @@ skip-string-normalization = true
 line-length = 119
 
 [tool.ruff.lint]
-ignore = ["C901", "E741", "E501", "D100", "RUF005", "RUF010"]
+ignore = ["C901", "D100", "E501", "E741", "RUF005", "RUF010"]
 select = [
-    "C",    # Pylint conventions
-    "E",    # style stuff, whitespaces
-    "F",    # important pyflakes lints
-    "I",    # import sorting
-    "W",    # Pylint warnings
-    "D",    # Documentation formatting
-    "RUF",  # Some Ruff-specific lints, unused noqas, etc.
+    "C",   # Pylint conventions
+    "D",   # Documentation formatting
+    "E",   # style stuff, whitespaces
+    "F",   # important pyflakes lints
+    "I",   # import sorting
+    "RUF", # Some Ruff-specific lints, unused noqas, etc.
+    "W",   # Pylint warnings
 ]
 
 # Ignore import violations in all `__init__.py` files.
 [tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["D104", "E402", "F401", "F403", "F811",]
-"test_*.py" = ["D",]
-"scripts/*.py" = ["D",]
+"__init__.py" = ["D104", "E402", "F401", "F403", "F811"]
+"test_*.py" = ["D"]
+"scripts/*.py" = ["D"]
 
 [tool.ruff.lint.isort]
 lines-after-imports = 2
@@ -36,4 +36,22 @@ norecursedirs = ["3rdparty"]
 addopts = ["--ignore=3rdparty"]
 
 [project]
-license = {file = "LICENSE/license.txt"}
+license = { file = "LICENSE/license.txt" }
+
+[tool.pyright]
+include = ["./sub-packages/bionemo-*/src"]
+exclude = ["*/tests/"]
+executionEnvironments = [
+    { "root" = ".", pythonVersion = "3.10", extraPaths = [
+        "./3rdparty/Megatron-LM",
+        "./3rdparty/NeMo",
+        "./sub-packages/bionemo-core/src",
+        "./sub-packages/bionemo-esm2/src",
+        "./sub-packages/bionemo-example_model/src",
+        "./sub-packages/bionemo-fw/src",
+        "./sub-packages/bionemo-geneformer/src",
+        "./sub-packages/bionemo-llm/src",
+        "./sub-packages/bionemo-scdl/src",
+        "./sub-packages/bionemo-testing/src",
+    ] },
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ ipdb==0.13.11
 click==8.1.7
 tenacity==8.5.0
 tach>=0.9.0
+pyright


### PR DESCRIPTION
This is going to be fun.

Hmm, ok, this is going to harder than I expected. We're really going to want a working python environment when we run this, but that's only currently available in our 20Gb docker image. We could run this command as part of the blossom workflow in the meantime, but having a way to install our dependencies in a small CPU runner would be a nice QOL improvement.