### PR TITLE
Make example notebook runnable in bionemo-scdl

### DIFF
--- a/sub-packages/bionemo-scdl/examples/example_notebook.ipynb
+++ b/sub-packages/bionemo-scdl/examples/example_notebook.ipynb
@@ -6,6 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import tempfile\n",
+    "\n",
     "from torch.utils.data import DataLoader\n",
     "\n",
     "from bionemo.scdl.io.single_cell_memmap_dataset import SingleCellMemMapDataset\n",
@@ -26,8 +28,6 @@
    "outputs": [],
    "source": [
     "#Create a SingleCellMemMapDataset\n",
-    "from bionemo.scdl.io.single_cell_memmap_dataset import SingleCellMemMapDataset\n",
-    "\n",
     "data = SingleCellMemMapDataset(\"97e_scmm\", \"hdf5s/97e96fb1-8caf-4f08-9174-27308eabd4ea.h5ad\")\n"
    ]
   },
@@ -107,6 +107,19 @@
     "hdf5 directory has one or more AnnData files, the SingleCellCollection class crawls the filesystem to recursively find \n",
     "AnnData files (with the h5ad extension). The code below is in scripts/convert_h5ad_to_scdl.py. It will create a new\n",
     "dataset at example_dataset. This can also be called with the convert_h5ad_to_scdl command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# path to dir holding hdf5s data\n",
+    "hdf5s = \"./hdf5s\"\n",
+    "\n",
+    "# path to output dir where SCDataset will be stored\n",
+    "example_dataset = \"./scdataset_output\""
    ]
   },
   {


### PR DESCRIPTION
Previously, the example notebook wasn't runnable, as it was missing an import (`tempfile`) and the final cell expected two non-existent variables: `hdf5s` and `example_dataset`