### PR TITLE
package resource files with installed package

### DIFF
--- a/sub-packages/bionemo-testing/pyproject.toml
+++ b/sub-packages/bionemo-testing/pyproject.toml
@@ -2,6 +2,10 @@
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[options]
+zip_safe = true
+include_package_data = true
+
 [project]
 name = "bionemo-testing"
 version = "2.0.0"

--- a/sub-packages/bionemo-testing/src/bionemo/testing/data/load.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/data/load.py
@@ -41,7 +41,7 @@ def _get_cache_dir() -> Path:
 
 
 BIONEMO_CACHE_DIR = _get_cache_dir()
-BIONEMO_CACHE_DIR.mkdir(exist_ok=True)
+BIONEMO_CACHE_DIR.mkdir(exist_ok=True, parents=True)
 
 
 def default_pbss_client():


### PR DESCRIPTION
Just another reason we should be testing against our installed packages, not a locally-editable version 😢 . These resource files weren't being packaged