### PR TITLE
Remove wget from image

### DIFF
--- a/setup/Dockerfile
+++ b/setup/Dockerfile
@@ -146,7 +146,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
         python3-setuptools python3-dev libboost-all-dev swig \
-        wget git unzip tmux vim emacs-nox tree xterm \
+        git unzip tmux vim emacs-nox tree xterm \
         liblmdb-dev libopenbabel-dev python3-openbabel openbabel libopenbabel7
 
 ## libboost-all-dev is required by vina==1.2.5 for its compilation


### PR DESCRIPTION
Removing wget from image for OSRB compliance. Context: internal [nvbug #4837137](https://nvbugspro.nvidia.com/bug/4837137)