### PR TITLE
fix post-create command

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -2,7 +2,8 @@
 
 pip install --disable-pip-version-check --no-cache-dir -e 3rdparty/Megatron-LM
 pip install --disable-pip-version-check --no-cache-dir -e 3rdparty/NeMo[all]
+
 for SUB_PKG in sub-packages/bionemo-*;
 do
-    pip install --disable-pip-version-check --no-cache-dir -e $SUB_PKG
+    pip install --disable-pip-version-check --no-cache-dir --no-deps -e $SUB_PKG
 done


### PR DESCRIPTION
Because we're now installing all the sub-package requirements.txt files in the base image, we can install these with `--no-deps` in the devcontainer postCreateCommand. We in fact need to switch over to this since we're now explicitly listing internal packages as dependencies, which can cause some conflicts with the existing script