### PR TITLE
add dev tools to devcontainer build

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-sudo pip install --no-deps --editable ./3rdparty/* ./sub-packages/bionemo-*
+for sub in ./3rdparty/* ./sub-packages/*; do
+    uv pip install --no-deps --no-build-isolation --editable $sub
+done


### PR DESCRIPTION
Adds development tools from `requirements-dev.txt` to the devcontainer image.

This also reverts #123 since it seems to have introduced some import errors