### PR TITLE
Fix tach modules & unpin dev version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,6 @@ repos:
         # 1. Attempt to automatically fix any lint issues.
         args: ["--fix"]
       - id: ruff-format
-  - repo: https://github.com/gauge-sh/tach-pre-commit
-    rev: v0.13.1
-    hooks:
-      - id: tach
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:

--- a/ci/scripts/static_checks.sh
+++ b/ci/scripts/static_checks.sh
@@ -11,6 +11,12 @@ ruff check scripts/ sub-packages/ docs/
 E_RUFF_CHECK="$?"
 set -e
 
+echo "Running tach checks"
+set +e
+tach check
+E_TACH_CHECK="$?"
+set -e
+
 echo "Running pre-commit checks"
 set +e
 pre-commit run --all-files --show-diff-on-failure --color always
@@ -26,6 +32,10 @@ fi
 if [[ "${E_RUFF_CHECK}" != "0" ]]; then
   ANY_FAILURE=1
   echo "ERROR: ruff check failed! (exit: ${E_RUFF_CHECK})"
+fi
+if [[ "${E_TACH_CHECK}" != "0" ]]; then
+  ANY_FAILURE=1
+  echo "ERROR: tach check failed! (exit: ${E_TACH_CHECK})"
 fi
 if [[ "${ANY_FAILURE}" != "0" ]]; then
   exit 1


### PR DESCRIPTION
Updates the sub-package inter-dependencies specified for `tach`. Several new sub-packages were not included. Now, all `sub-packages/bionemo-*` are included and correctly specified. The `tach.toml` file has been reorganized to make it (1) easy to copy-and-paste updates from the top-level `pyproject.toml` file for bionemo sub-packages and (2) lists each tach module's section in alphabetical order. Also unpins the `tach` dependency from the `uv` dev-dependencies.