### PR TITLE
remove esm2 min lr

### DIFF
--- a/scripts/protein/esm2/esm2_pretrain.py
+++ b/scripts/protein/esm2/esm2_pretrain.py
@@ -234,7 +234,7 @@ def main(
                 adam_beta2=0.98,
             ),
             lr_scheduler=WarmupAnnealDecayHoldScheduler(
-                warmup_steps=warmup_steps, max_steps=num_steps, max_lr=lr, min_lr=lr / 10.0, anneal_percentage=0.10
+                warmup_steps=warmup_steps, max_steps=num_steps, max_lr=lr, min_lr=0.0, anneal_percentage=0.10
             ),
         ),
     )


### PR DESCRIPTION
I don't think the original ESM2 authors set a starting learning rate for ESM2 training. The min_lr here should probably start from zero