### PR TITLE
Add --all flag for bionemo_data_download

### DIFF
--- a/sub-packages/bionemo-testing/pyproject.toml
+++ b/sub-packages/bionemo-testing/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 [project.scripts]
-download_bionemo_data = "bionemo.testing.data.load:main_cli"
+download_bionemo_data = "bionemo.testing.data.load:entrypoint"
 
 # Make sure that the resource yaml files are being packaged alongside the python files.
 [tool.setuptools.package-data]


### PR DESCRIPTION
Adds a new flag, --all, to bionemo_data_download. This will override the other flags and download every possible resource, data and model, using the user-supplied --source.

This PR also refactors the script so that the variables are referenced to explicitly, rather than using the opaque argument parsed result object (args), aiding in readability & maintainability.