### PR TITLE
change ESM2 to ESM-2 in written docs

### DIFF
--- a/docs/docs/datasets/uniprot.md
+++ b/docs/docs/datasets/uniprot.md
@@ -8,10 +8,10 @@ UniProt Archive (UniParc). UniRef90 clusters these unique sequences into buckets
 a single sequence from within each cluster as the representative sequence. UniRef50 is then built by clustering these
 UniRef90 representative sequences into groups with 50% sequence similarity.
 
-## Data Used for ESM2 Pre-training
+## Data Used for ESM-2 Pre-training
 
-Since the original train/test splits from ESM2 were not available [3], we replicated the ESM2 pre-training experiments
-with UniProt's 2024_03 release. Following the approach described by the ESM2 authors, we removed artificial sequences
+Since the original train/test splits from ESM-2 were not available [3], we replicated the ESM-2 pre-training experiments
+with UniProt's 2024_03 release. Following the approach described by the ESM-2 authors, we removed artificial sequences
 and reserved 0.5% of UniRef50 clusters for validation. From the 65,672,139 UniRef50 clusters, this resulted in 328,360
 validation sequences. We then ran MMSeqs to further ensure no contamination of the training set with sequences similar
 to the validation set. This resulted in 65,182,365 training UniRef50 clusters comprising 187,382,018 UniRef90 sequences.

--- a/docs/docs/models/esm2.md
+++ b/docs/docs/models/esm2.md
@@ -123,7 +123,7 @@ checkpoints is consistent with their outputs when evaluated with the HuggingFace
 #### Single-node Training Performance
 
 <figure markdown="span">
-  ![ESM2 Single-Device Training Performance](site:assets/images/esm2/esm2_single_node_training_perf.svg){ width="350" }
+  ![ESM-2 Single-Device Training Performance](site:assets/images/esm2/esm2_single_node_training_perf.svg){ width="350" }
 </figure>
 
 The pure-pytorch baseline (compiled with `torch.compile()`) raised an out-of-memory error for batch sizes larger than 16
@@ -133,7 +133,7 @@ at the ESM2-650M model size. The `bionemo2` model could handle batch sizes of 46
 #### Model Scaling
 
 <figure markdown="span">
-  ![ESM2 Model Scaling](site:assets/images/esm2/esm2_model_scaling.svg)
+  ![ESM-2 Model Scaling](site:assets/images/esm2/esm2_model_scaling.svg)
 </figure>
 
 Training ESM-2 at the 650M, 3B, and 15B model variants show improved performance with the BioNeMo2 framework over the
@@ -143,7 +143,7 @@ nodes.
 #### Device Scaling
 
 <figure markdown="span">
-  ![ESM2 Device Scaling](site:assets/images/esm2/esm2_device_scaling.svg){ width="400" }
+  ![ESM-2 Device Scaling](site:assets/images/esm2/esm2_device_scaling.svg){ width="400" }
 </figure>
 
 Training ESM-3B on 256 NVIDIA A100s on 32 nodes achieved 96.85% of the theoretical linear throughput expected from

--- a/docs/docs/user-guide/appendix/releasenotes-fw.md
+++ b/docs/docs/user-guide/appendix/releasenotes-fw.md
@@ -4,7 +4,7 @@
 ## BioNeMo Framework v2.0
 
 ### New Features:
-* ESM2 implementation
+* ESM-2 implementation
   * State of the art training performance and equivalent accuracy to the reference implementation
   * 650M, and 3B scale checkpoints available which mirror the reference model
   * Flexible fine-tuning examples that can be copied and modified to accomplish a wide variety of downstream tasks
@@ -62,7 +62,7 @@
 ## BioNeMo Framework v1.6
 ### New Features
 * [Model Fine-tuning] `model.freeze_layers` fine-tuning config parameter added to freeze a specified number of layers. Thank you to github user [@nehap25](https://github.com/nehap25)!
-* [ESM2]  Loading pre-trained ESM2 weights and continue pre-training on the MLM objective on a custom FASTA dataset is now supported.
+* [ESM2]  Loading pre-trained ESM-2 weights and continue pre-training on the MLM objective on a custom FASTA dataset is now supported.
 * [OpenFold] MLPerf feature 3.2 bug (mha_fused_gemm) fix has merged.
 * [OpenFold] MLPerf feature 3.10 integrated into bionemo framework.
 * [DiffDock] Updated data loading module for DiffDock model training, changing from sqlite3 backend to webdataset.
@@ -125,7 +125,7 @@
 * Wrapper scripts for DNABERT and OpenFold to launch jobs on BCP.
 
 ### Bug fixes and Improvements
-* Interface improvements for ESM2 data ingestion and pre-processing. The interface allows for explicit specification of training, validation, and test sets. The user may set `config.model.data.default_dataset_path` to maintain prior behavior, or set `config.model.data.train.dataset_path`, `config.model.data.val.dataset_path`, `config.model.data.test.dataset_path` which may all be unique.
+* Interface improvements for ESM-2 data ingestion and pre-processing. The interface allows for explicit specification of training, validation, and test sets. The user may set `config.model.data.default_dataset_path` to maintain prior behavior, or set `config.model.data.train.dataset_path`, `config.model.data.val.dataset_path`, `config.model.data.test.dataset_path` which may all be unique.
 
 ### Known Issues
 * OpenFold training speed does not yet include [MLPerf optimizations](https://blogs.nvidia.com/blog/scaling-ai-training-mlperf/), and these will be released in the subsequent release.

--- a/docs/docs/user-guide/examples/bionemo-esm2/finetune.md
+++ b/docs/docs/user-guide/examples/bionemo-esm2/finetune.md
@@ -1,21 +1,21 @@
-# ESM2 Fine-Tuning
+# ESM-2 Fine-Tuning
 
-This readme serves as a demo for implementing ESM2 Fine-tuning module, running a regression example and using the model for inference.
+This readme serves as a demo for implementing ESM-2 Fine-tuning module, running a regression example and using the model for inference.
 
-The ESM2 model is a transformer-based protein language model that has achieved state-of-the-art results in various protein-related tasks. When fine-tuning ESM2, the task head plays a crucial role. A task head refers to the additional layer or set of layers added on top of a pre-trained model, like the ESM2 transformer-based protein language model, to adapt it for a specific downstream task. As a part of transfer learning, a pre-trained model is often utilized to learn generic features from a large-scale dataset. However, these features might not be directly applicable to the specific task at hand. By incorporating a task head, which consists of learnable parameters, the model can adapt and specialize to the target task. The task head serves as a flexible and adaptable component that learns task-specific representations by leveraging the pre-trained features as a foundation. Through fine-tuning, the task head enables the model to learn and extract task-specific patterns, improving performance and addressing the nuances of the downstream task. It acts as a critical bridge between the pre-trained model and the specific task, enabling efficient and effective transfer of knowledge.
+The ESM-2 model is a transformer-based protein language model that has achieved state-of-the-art results in various protein-related tasks. When fine-tuning ESM2, the task head plays a crucial role. A task head refers to the additional layer or set of layers added on top of a pre-trained model, like the ESM-2 transformer-based protein language model, to adapt it for a specific downstream task. As a part of transfer learning, a pre-trained model is often utilized to learn generic features from a large-scale dataset. However, these features might not be directly applicable to the specific task at hand. By incorporating a task head, which consists of learnable parameters, the model can adapt and specialize to the target task. The task head serves as a flexible and adaptable component that learns task-specific representations by leveraging the pre-trained features as a foundation. Through fine-tuning, the task head enables the model to learn and extract task-specific patterns, improving performance and addressing the nuances of the downstream task. It acts as a critical bridge between the pre-trained model and the specific task, enabling efficient and effective transfer of knowledge.
 
 
 # Setup and Assumptions
 
 In this tutorial, we will demonstrate how to create a fine-tune module, train a regression task head, and use the fine-tuned model for inference.
 
-All commands should be executed inside the BioNeMo docker container, which has all ESM2 dependencies pre-installed. This tutorial assumes that a copy of the BioNeMo framework repo exists on workstation or server and has been mounted inside the container at `/workspace/bionemo2`. (**Note**: This `WORKDIR` may be `/workspaces/bionemo-framework` if you are using the VSCode Dev Container.) For more information on how to build or pull the BioNeMo2 container, refer to the [Access and Startup](../../getting-started/access-startup.md).
+All commands should be executed inside the BioNeMo docker container, which has all ESM-2 dependencies pre-installed. This tutorial assumes that a copy of the BioNeMo framework repo exists on workstation or server and has been mounted inside the container at `/workspace/bionemo2`. (**Note**: This `WORKDIR` may be `/workspaces/bionemo-framework` if you are using the VSCode Dev Container.) For more information on how to build or pull the BioNeMo2 container, refer to the [Access and Startup](../../getting-started/access-startup.md).
 
 To successfully accomplish this we need to define some key classes:
 
 1. Loss Reduction Method - To compute the supervised fine-tuning loss.
 2. Fine-Tuned Model Head - Downstream task head model.
-3. Fine-Tuned Model - Model that combines ESM2 with the task head model.
+3. Fine-Tuned Model - Model that combines ESM-2 with the task head model.
 4. Fine-Tuning Config - Configures the fine-tuning model and loss to use in the training and inference framework.
 5. Dataset - Training and inference datasets for ESM2.
 
@@ -41,7 +41,7 @@ class RegressorLossReduction(BERTMLMLossWithReduction):
 
 ## 2 - Fine-Tuned Model Head
 
-An MLP class for sequence-level regression. This class inherits `MegatronModule` and uses the fine-tune config (`TransformerConfig`) to configure the regression head for the fine-tuned ESM2 model.
+An MLP class for sequence-level regression. This class inherits `MegatronModule` and uses the fine-tune config (`TransformerConfig`) to configure the regression head for the fine-tuned ESM-2 model.
 
 ```python
 class MegatronMLPHead(MegatronModule):
@@ -60,7 +60,7 @@ class MegatronMLPHead(MegatronModule):
 
 ## 3 - Fine-Tuned Model
 
-A fine-tuned ESM2 model class for token classification tasks. This class inherits from the `ESM2Model` class and adds the custom regression head `MegatronMLPHead` the we created in the previous step. Optionally one can freeze all or parts of the encoder by parsing through the model parameters in the model constructor.
+A fine-tuned ESM-2 model class for token classification tasks. This class inherits from the `ESM2Model` class and adds the custom regression head `MegatronMLPHead` the we created in the previous step. Optionally one can freeze all or parts of the encoder by parsing through the model parameters in the model constructor.
 
 ```python
 class ESM2FineTuneSeqModel(ESM2Model):
@@ -84,12 +84,12 @@ class ESM2FineTuneSeqModel(ESM2Model):
 
 ## 4 - Fine-Tuning Config
 
-A `dataclass` that configures the fine-tuned ESM2 model. In this example `ESM2FineTuneSeqConfig` inherits from `ESM2GenericConfig` and adds custom arguments to setup the fine-tuned model. The `configure_model()` method of this `dataclass` is called within the `Lightning` module to call the model constructor with the `dataclass` arguments.
+A `dataclass` that configures the fine-tuned ESM-2 model. In this example `ESM2FineTuneSeqConfig` inherits from `ESM2GenericConfig` and adds custom arguments to setup the fine-tuned model. The `configure_model()` method of this `dataclass` is called within the `Lightning` module to call the model constructor with the `dataclass` arguments.
 
 The common arguments among different fine-tuning tasks are
 
 - `model_cls`: The fine-tune model class (`ESM2FineTuneSeqModel`)
-- `initial_ckpt_path`: BioNeMo 2.0 ESM2 pre-trained checkpoint
+- `initial_ckpt_path`: BioNeMo 2.0 ESM-2 pre-trained checkpoint
 - `initial_ckpt_skip_keys_with_these_prefixes`: skip keys when loading parameters from a checkpoint. Here we should not look for `regression_head` in the pre-trained checkpoint.
 - `get_loss_reduction_class()`: Implements selection of the appropriate `MegatronLossReduction` class, e.g. `bionemo.esm2.model.finetune.finetune_regressor.RegressorLossReduction`.
 
@@ -151,7 +151,7 @@ data_module = ESM2FineTuneDataModule(
 
 # Fine-Tuning the Regressor Task Head for ESM2
 
-Now we can put these five requirements together to fine-tune a regressor task head starting from a pre-trained ESM2 model (`pretrain_ckpt_path`). We can take advantage of a simple training loop in ```bionemo.esm2.model.fnetune.train``` and use the ```train_model()`` function to start the fine-tuning process in the following.
+Now we can put these five requirements together to fine-tune a regressor task head starting from a pre-trained ESM-2 model (`pretrain_ckpt_path`). We can take advantage of a simple training loop in ```bionemo.esm2.model.fnetune.train``` and use the ```train_model()`` function to start the fine-tuning process in the following.
 
 ```python
 # create a List[Tuple] with (sequence, target) values
@@ -198,7 +198,7 @@ This example is fully implemented in ```bionemo.esm2.model.finetune.train``` and
 python /workspace/bionemo2/sub-packages/bionemo-esm2/src/bionemo/esm2/model/finetune/train.py
 ```
 ## Notes
-1. The above example is fine-tuning a randomly initialized ESM2 model for demonstration purposes. In order to fine-tune a pre-trained ESM2 model, please download the ESM2 650M checkpoint from NGC resources using the following bash command
+1. The above example is fine-tuning a randomly initialized ESM-2 model for demonstration purposes. In order to fine-tune a pre-trained ESM-2 model, please download the ESM-2 650M checkpoint from NGC resources using the following bash command
     ```bash
     download_bionemo_data esm2/650m:2.0 --source ngc
     ```
@@ -218,7 +218,7 @@ python /workspace/bionemo2/sub-packages/bionemo-esm2/src/bionemo/esm2/model/fine
     ```
 3. We are using a small dataset of artificial sequences as our fine-tuning data in this example. You may experience over-fitting and observe no change in the validation metrics.
 
-# Fine-Tuned ESM2 Model Inference
+# Fine-Tuned ESM-2 Model Inference
 Once we have a checkpoint we can create a config object by pointing the path in `initial_ckpt_path` and use that for inference. Since we need to load all the parameters from this checkpoint (and don't skip the head) we reset the `nitial_ckpt_skip_keys_with_these_prefixes` in this config. Now we can use the ```bionemo.esm2.model.fnetune.train.infer``` to run inference on prediction dataset.
 
 ```python

--- a/docs/docs/user-guide/examples/bionemo-esm2/pretrain.md
+++ b/docs/docs/user-guide/examples/bionemo-esm2/pretrain.md
@@ -1,14 +1,14 @@
-# ESM2 Pretraining
+# ESM-2 Pretraining
 
 This tutorial serves as a demo for pretraining [ESM2](https://www.science.org/doi/abs/10.1126/science.ade2574) from scratch with [UniProt](https://www.uniprot.org/) sequences.
 
-The ESM2 model is a transformer-based protein language model that was pretrained on masked language model (MLM) task. The objective is to recover the original amino acid types of the perturbed locations from the rest of the protein sequences. Through pretraining, ESM2 learns the evolutionary information in protein sequences similar to conservation analysis and Pott's model, and predicts the optimal mutations on any given protein sequence.
+The ESM-2 model is a transformer-based protein language model that was pretrained on masked language model (MLM) task. The objective is to recover the original amino acid types of the perturbed locations from the rest of the protein sequences. Through pretraining, ESM-2 learns the evolutionary information in protein sequences similar to conservation analysis and Pott's model, and predicts the optimal mutations on any given protein sequence.
 
 # Setup and Assumptions
 
-In this tutorial, we will demonstrate how to create an ESM2 pretraining data module, and create and train a ESM2 model.
+In this tutorial, we will demonstrate how to create an ESM-2 pretraining data module, and create and train a ESM-2 model.
 
-All commands should be executed inside the BioNeMo docker container, which has all ESM2 dependencies pre-installed. This tutorial assumes that a copy of the BioNeMo framework repo exists on workstation or server and has been mounted inside the container at `/workspace/bionemo2`.  For more information on how to build or pull the BioNeMo2 container, refer to the [Initialization Guide](../../getting-started/initialization-guide.md).
+All commands should be executed inside the BioNeMo docker container, which has all ESM-2 dependencies pre-installed. This tutorial assumes that a copy of the BioNeMo framework repo exists on workstation or server and has been mounted inside the container at `/workspace/bionemo2`.  For more information on how to build or pull the BioNeMo2 container, refer to the [Initialization Guide](../../getting-started/initialization-guide.md).
 
 !!! note
 
@@ -19,7 +19,7 @@ Similar to PyTorch Lightning, we have to define some key classes:
 1. `MegatronStrategy` - To launch and setup parallelism for [NeMo](https://github.com/NVIDIA/NeMo/tree/main) and [Megatron-LM](https://github.com/NVIDIA/Megatron-LM).
 2. `Trainer` - To configure training configurations and logging.
 3. `ESMDataModule` - To load pretraining training and validation data with mapped UniRef90 sequences to UniRef50 clusters.
-4. `ESM2Config` - To configure the ESM2 model as `BionemoLightningModule`.
+4. `ESM2Config` - To configure the ESM-2 model as `BionemoLightningModule`.
 
 ## 1 - MegatronStrategy
 BioNeMo2 supports data parallel (DP), tensor parallel (TP) and pipeline parallel (PP) for training large models. Instead of `DDPStrategy` in PyTorch Lightning, we use `MegatronStrategy` to launch and setup parallelism for NeMo and Megatron-LM.
@@ -94,7 +94,7 @@ print(PrecisionTypes)  # show all possible precision types
 ```
 
 ## 3 - ESMDataModule
-Before instantiating with data module, we can first download the testing ESM2 pretraining data with `download_bionemo_data`. The command line will download the data if we haven't yet, and will return the path to the testing data, which is needed to instantiate `ESMDataModule`.
+Before instantiating with data module, we can first download the testing ESM-2 pretraining data with `download_bionemo_data`. The command line will download the data if we haven't yet, and will return the path to the testing data, which is needed to instantiate `ESMDataModule`.
 
 ```bash
 download_bionemo_data esm2/testdata_esm2_pretrain:2.0 --source ngc  # test data
@@ -137,7 +137,7 @@ data = ESMDataModule(
 
 !!! note "`RandomMaskStrategy`"
 
-    When trained on MLM objective, the loss function randomly includes 15% of the tokens, within which 80% are masked, 10% are replaced with a random token, and 10% are kept unchanged. Since the vocabulary includes amino acids as well as special tokens, part of the protein sequence may be replaced by a special token. This is the default in both BioNeMo2 and HuggingFace ESM2 implementation.
+    When trained on MLM objective, the loss function randomly includes 15% of the tokens, within which 80% are masked, 10% are replaced with a random token, and 10% are kept unchanged. Since the vocabulary includes amino acids as well as special tokens, part of the protein sequence may be replaced by a special token. This is the default in both BioNeMo2 and HuggingFace ESM-2 implementation.
 
     To enforce amino-acid-only replacement, users can pass `random_mask_strategy=RandomMaskStrategy.AMINO_ACID_ONLY` to `ESMDataModule`.
 
@@ -156,7 +156,7 @@ from bionemo.llm.lightning import BionemoLightningModule
 from bionemo.llm.model.biobert.lightning import biobert_lightning_module
 from bionemo.llm.model.biobert.model import BiobertSpecOption
 
-# ESM2 650M config
+# ESM-2 650M config
 num_layers = 33
 hidden_size = 1280
 num_attention_heads = 20
@@ -212,7 +212,7 @@ model: BionemoLightningModule = biobert_lightning_module(
 
 !!! note "`ModuleSpec`"
 
-    `ModelSpec` decides what torch modules are used in the transformer layers. By default, BioNeMo2 accelerates ESM2 architecture with TransformerEngine layers. Users can define their own `ModelSpec` for customized transformer layers. See [`get_biobert_spec`](https://github.com/NVIDIA/bionemo-framework/blob/main/sub-packages/bionemo-llm/src/bionemo/llm/model/biobert/transformer_specs.py#L61).
+    `ModelSpec` decides what torch modules are used in the transformer layers. By default, BioNeMo2 accelerates ESM-2 architecture with TransformerEngine layers. Users can define their own `ModelSpec` for customized transformer layers. See [`get_biobert_spec`](https://github.com/NVIDIA/bionemo-framework/blob/main/sub-packages/bionemo-llm/src/bionemo/llm/model/biobert/transformer_specs.py#L61).
 
 
 !!! note "`BionemoLightningModule`"

--- a/docs/docs/user-guide/getting-started/development.md
+++ b/docs/docs/user-guide/getting-started/development.md
@@ -14,7 +14,7 @@ we ensure that BioNeMo developers follow similar patterns to those we expect of 
 
 Each model is stored in its own subdirectory of `sub-packages`. Some examples of models include:
 
-* `bionemo-esm2`: The ESM2 model
+* `bionemo-esm2`: The ESM-2 model
 * `bionemo-geneformer`: The Geneformer model
 * `bionemo-example_model`: A minimal example MNIST model that demonstrates how you can write a lightweight
     Megatron model that does not actually support any megatron parallelism, but should run fine as long as you only use
@@ -79,7 +79,7 @@ The scripts provide various options that can be customized for pretraining, such
 You can specify these options when running the script using command-line arguments. For each of the available scripts,
 you can use the `--help` option for an explanation of the available options for that model.
 
-For more information on pretraining a model, refer to the [ESM2 Pretraining Tutorial](../examples/bionemo-esm2/pretrain.md).
+For more information on pretraining a model, refer to the [ESM-2 Pretraining Tutorial](../examples/bionemo-esm2/pretrain.md).
 
 ## Fine-Tuning
 
@@ -133,7 +133,7 @@ of the model. The fine-tuning steps will be application-specific, but a general 
     model.
 6. **Run inference**: Once the model is fine-tuned, use it to make predictions on new, unseen data.
 
-For more information on fine-tuning a model, refer to the [ESM2 Fine-tuning
+For more information on fine-tuning a model, refer to the [ESM-2 Fine-tuning
 Tutorial](../examples/bionemo-esm2/finetune.md).
 
 ## Advanced Developer Documentation

--- a/sub-packages/bionemo-testing/src/bionemo/testing/data/README.md
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/data/README.md
@@ -32,7 +32,7 @@ example, in `esm2.yaml`:
   sha256: 1e38063cafa808306329428dd17ea6df78c9e5d6b3d2caf04237c555a1f131b7
   owner: Farhad Ramezanghorbani <farhadr@nvidia.com>
   description: >
-    A pretrained 650M parameter ESM2 model.
+    A pretrained 650M parameter ESM-2 model.
     See https://ngc.nvidia.com/catalog/models/nvidia:clara:esm2nv650m.
 ```
 


### PR DESCRIPTION
Changes "ESM2" to "ESM-2" in markdown files