### PR TITLE
bugfix - wrong variable referenced

### DIFF
--- a/internal/scripts/setup_env_file.sh
+++ b/internal/scripts/setup_env_file.sh
@@ -24,7 +24,7 @@ DOCKER_REPO_PATH='/workspace/bionemo2'
 LOCAL_REPO_PATH=$(realpath $(pwd))
 if [[ $(basename "${LOCAL_REPO_PATH}") != "bionemo-framework" ]]; then
   echo "ERROR: must run from the root of the bionemo repository!"
-  echo "ERROR: invalid path: ${LOCAL_DATA_PATH}"
+  echo "ERROR: invalid path: ${LOCAL_REPO_PATH}"
   exit 1
 fi
 # NOTE: do allow IMAGE_TAG to be overridden by env var, but DO NOT set this in the .env file!


### PR DESCRIPTION
Fixes a bug in that references the wrong variable in `setup_env_file.sh`. It's `LOCAL_REPO_PATH` not `LOCAL_DATA_PATH`.