### PR TITLE
Export FUSED_ATTN in release container and fix geneformer stop and go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -204,4 +204,5 @@ COPY ./docs ./docs
 RUN chmod 777 -R /workspace/bionemo2/
 
 # Transformer engine attention defaults
+# We have to declare this again because the devcontainer splits from the release image's base.
 ENV NVTE_FUSED_ATTN=1 NVTE_FLASH_ATTN=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -202,3 +202,6 @@ COPY ./ci/scripts ./ci/scripts
 COPY ./docs ./docs
 
 RUN chmod 777 -R /workspace/bionemo2/
+
+# Transformer engine attention defaults
+ENV NVTE_FUSED_ATTN=1 NVTE_FLASH_ATTN=0

--- a/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_stop_and_go.py
+++ b/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_stop_and_go.py
@@ -28,7 +28,6 @@ import math
 import pathlib
 from typing import Literal
 
-import pytest
 import pytorch_lightning as pl
 import torch
 from megatron.core.optimizer.optimizer_config import OptimizerConfig
@@ -164,35 +163,3 @@ class TestGeneformerStopAndGo(stop_and_go.StopAndGoHarness):
         assert val_consumed_go == 0
         assert train_consumed_stop == 0
         assert train_consumed_go > 0
-
-    # Delete the following lines once we've merged the rest of the geneformer fixes.
-
-    @pytest.mark.parametrize(
-        "callback_type",
-        [
-            testing_callbacks.ValidInputCallback,
-            testing_callbacks.ValidOutputCallback,
-            testing_callbacks.ValidLossCallback,
-        ],
-    )
-    def test_stop_and_go_consistency_with_uneven_validation_sizes(self, callback_type):
-        if callback_type == testing_callbacks.ValidOutputCallback:
-            pytest.xfail("Outputs are currently inconsistent in Geneformer.")
-        super().test_stop_and_go_consistency_with_uneven_validation_sizes(callback_type)
-
-    @pytest.mark.parametrize(
-        "callback_type",
-        [
-            testing_callbacks.LearningRateCallback,
-            testing_callbacks.GlobalStepStateCallback,
-            testing_callbacks.ConsumedSamplesCallback,
-            testing_callbacks.OptimizerStateCallback,
-            testing_callbacks.TrainInputCallback,
-            testing_callbacks.TrainOutputCallback,
-            testing_callbacks.TrainLossCallback,
-        ],
-    )
-    def test_stop_and_go_consistency(self, callback_type):
-        if callback_type == testing_callbacks.TrainOutputCallback:
-            pytest.xfail("Outputs are currently inconsistent in Geneformer.")
-        super().test_stop_and_go_consistency_with_uneven_validation_sizes(callback_type)


### PR DESCRIPTION
Looks like for some reason, the output tensors are not consistent between the interrupted and continuous training runs without `NVTE_FUSED_ATTN=1 NVTE_FLASH_ATTN=0` set in the release container. These are set in the development container though, so we should keep these consistent.

Possibly the model isn't as deterministic without these set?