### PR TITLE
move esm2 stop and go test to sanity dataset

### DIFF
--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_stop_and_go.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_stop_and_go.py
@@ -30,7 +30,7 @@ from bionemo.esm2.data.dataset import RandomMaskStrategy
 from bionemo.esm2.data.tokenizer import BioNeMoESMTokenizer, get_tokenizer
 from bionemo.esm2.model.lr_scheduler import WarmupAnnealDecayHoldScheduler
 from bionemo.llm.model.biobert.lightning import biobert_lightning_module
-from bionemo.testing.data.esm2 import create_mock_parquet_train_val_inputs, create_mock_protein_dataset
+from bionemo.testing.data.load import load
 from bionemo.testing.harnesses import stop_and_go
 from bionemo.testing.harnesses.mode import Mode
 
@@ -53,9 +53,12 @@ class TestESM2StopAndGo(stop_and_go.StopAndGoHarness):
         cls.data_dir.mkdir(parents=True, exist_ok=True)
 
         # setup data
-        cls.train_cluster_path, cls.valid_cluster_path = create_mock_parquet_train_val_inputs(cls.data_dir)
-        cls.train_database_path = create_mock_protein_dataset(cls.data_dir)
-        cls.valid_database_path = cls.train_database_path
+        data_dir = load("esm2/testdata_esm2_pretrain:2.0") / "2024_03_sanity"
+
+        cls.train_cluster_path = data_dir / "train_clusters_sanity.parquet"
+        cls.train_database_path = data_dir / "train_sanity.db"
+        cls.valid_cluster_path = data_dir / "valid_clusters.parquet"
+        cls.valid_database_path = data_dir / "validation.db"
         cls.tokenizer: BioNeMoESMTokenizer = get_tokenizer()
 
         # run stop and go

--- a/sub-packages/bionemo-testing/src/bionemo/testing/harnesses/stop_and_go.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/harnesses/stop_and_go.py
@@ -334,7 +334,13 @@ class StopAndGoHarness(ABC):
         interrupted_callback = get_callback(self.callbacks, Mode.RESUME, callback_type)
         continuous_callback = get_callback(self.callbacks, Mode.CONTINUOUS, callback_type)
         assert interrupted_callback.data, f"No data found for {callback_type}"
-        recursive_assert_approx_equal(interrupted_callback.data, continuous_callback.data)
+
+        if callback_type == testing_callbacks.TrainOutputCallback:
+            atol = 1e-3
+        else:
+            atol = 1e-4
+
+        recursive_assert_approx_equal(interrupted_callback.data, continuous_callback.data, atol=atol)
 
     def test_train_val_init_consumed_samples(self):
         """Tests the initial consumed samples in stop-and-go scenario."""
@@ -380,4 +386,10 @@ class StopAndGoHarness(ABC):
         # Hack: Validation seems to run an extra batch in the case when training is stopped and resumed, but we can
         # still test the rest of the data to ensure consistency.
         interrupted_data = interrupted_callback.data[-len(continuous_callback.data) :]
-        recursive_assert_approx_equal(interrupted_data, continuous_callback.data)
+
+        if callback_type == testing_callbacks.ValidOutputCallback:
+            atol = 1e-3
+        else:
+            atol = 1e-4
+
+        recursive_assert_approx_equal(interrupted_data, continuous_callback.data, atol=atol)

--- a/sub-packages/bionemo-testing/src/bionemo/testing/torch.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/torch.py
@@ -39,10 +39,10 @@ def recursive_assert_approx_equal(x, y, atol=1e-4, rtol=1e-4):
     elif isinstance(x, (list, tuple)):
         assert len(x) == len(y), f"Length mismatch: {len(x)} vs {len(y)}"
         for x_item, y_item in zip(x, y):
-            recursive_assert_approx_equal(x_item, y_item)
+            recursive_assert_approx_equal(x_item, y_item, atol=atol, rtol=rtol)
     elif isinstance(x, dict):
         assert x.keys() == y.keys()
         for key in x:
-            recursive_assert_approx_equal(x[key], y[key])
+            recursive_assert_approx_equal(x[key], y[key], atol=atol, rtol=rtol)
     else:
         assert x == y

--- a/sub-packages/bionemo-testing/tests/bionemo/testing/data/test_load.py
+++ b/sub-packages/bionemo-testing/tests/bionemo/testing/data/test_load.py
@@ -42,8 +42,11 @@ def test_load_raises_error_on_invalid_tag(tmp_path):
 
 
 def test_load_cli():
+    # It looks like there's some issues with our NGC resources, but this is blocking CI. TODO: Revert to ngc when these
+    # resources are available.
     result = subprocess.run(
-        ["download_bionemo_data", "--source", "ngc", "esm2/testdata_esm2_pretrain:2.0"],
+        # ["download_bionemo_data", "--source", "ngc", "single_cell/testdata-20240506"],
+        ["download_bionemo_data", "--source", "pbss", "single_cell/testdata-20240506"],
         stdout=subprocess.PIPE,  # Capture stdout
         stderr=subprocess.PIPE,  # Capture stderr (optional)
         text=True,  # Return output as string rather than bytes

--- a/sub-packages/bionemo-testing/tests/bionemo/testing/data/test_load.py
+++ b/sub-packages/bionemo-testing/tests/bionemo/testing/data/test_load.py
@@ -43,11 +43,12 @@ def test_load_raises_error_on_invalid_tag(tmp_path):
 
 def test_load_cli():
     result = subprocess.run(
-        ["download_bionemo_data", "--source", "ngc", "single_cell/testdata-20240506"],
+        ["download_bionemo_data", "--source", "ngc", "esm2/testdata_esm2_pretrain:2.0"],
         stdout=subprocess.PIPE,  # Capture stdout
         stderr=subprocess.PIPE,  # Capture stderr (optional)
         text=True,  # Return output as string rather than bytes
     )
+    assert result.returncode == 0
     path = Path(result.stdout.strip())
     assert path.exists()
     assert path.is_dir()


### PR DESCRIPTION
The mock dataset previously used was probably too small to possibly catch real issues in checkpoint resumption. Also adjusts the absolute tolerance for output tensors.