### PR TITLE
use torchmetrics ppl logging

### DIFF
--- a/sub-packages/bionemo-llm/src/bionemo/llm/data/collate.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/data/collate.py
@@ -101,7 +101,7 @@ def bert_padding_collate_fn(
         "text": padding_value,
         "types": 0,
         "attention_mask": False,
-        "labels": -1,
+        "labels": -100,
         "loss_mask": False,
         "is_random": 0,
     }


### PR DESCRIPTION
Some experiments using torchmetrics for perplexity logging.

Example wandb chart for single-GPU training: https://wandb.ai/clara-discovery/bionemo-hf-pretraining/runs/fgn32r4p?nw=nwuserpstjohn