### PR TITLE
remove every_n_train_steps from ModelCheckpoint

### DIFF
--- a/docs/docs/user-guide/examples/bionemo-esm2/pretrain.md
+++ b/docs/docs/user-guide/examples/bionemo-esm2/pretrain.md
@@ -253,7 +253,6 @@ checkpoint_callback = nl_callbacks.ModelCheckpoint(
     save_last=True,
     monitor="val_loss",
     save_top_k=1,
-    every_n_train_steps=100,
     always_save_context=True,
 )
 

--- a/scripts/protein/esm2/esm2_pretrain.py
+++ b/scripts/protein/esm2/esm2_pretrain.py
@@ -245,7 +245,6 @@ def main(
         save_last=save_last_checkpoint,
         monitor=metric_to_monitor_for_checkpoints,  # "val_loss",
         save_top_k=save_top_k,
-        every_n_train_steps=val_check_interval,
         always_save_context=True,  # Enables the .nemo file-like checkpointing where all IOMixins are under SerDe
     )
 

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/model/finetune/train.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/model/finetune/train.py
@@ -70,8 +70,7 @@ def train_model(
     checkpoint_callback = nl_callbacks.ModelCheckpoint(
         save_last=True,
         save_on_train_epoch_end=True,
-        monitor="reduced_train_loss",  # TODO find out how to get val_loss logged and use "val_loss",
-        every_n_train_steps=n_steps_train // 2,
+        monitor="val_loss",
         always_save_context=True,  # Enables the .nemo file-like checkpointing where all IOMixins are under SerDe
     )
 

--- a/sub-packages/bionemo-example_model/src/bionemo/example_model/lightning/lightning_basic.py
+++ b/sub-packages/bionemo-example_model/src/bionemo/example_model/lightning/lightning_basic.py
@@ -650,7 +650,6 @@ checkpoint_callback = nl_callbacks.ModelCheckpoint(
     save_last=True,
     save_on_train_epoch_end=True,
     monitor="reduced_train_loss",
-    every_n_train_steps=25,
     always_save_context=True,  # Enables the .nemo file-like checkpointing where all IOMixins are under SerDe
 )
 

--- a/sub-packages/bionemo-example_model/src/bionemo/example_model/training_scripts/finetune_mnist.py
+++ b/sub-packages/bionemo-example_model/src/bionemo/example_model/training_scripts/finetune_mnist.py
@@ -44,8 +44,7 @@ def run_finetune(checkpoint_dir: str, name: str, directory_name: str):
     checkpoint_callback = nl_callbacks.ModelCheckpoint(
         save_last=True,
         save_on_train_epoch_end=True,
-        monitor="reduced_train_loss",
-        every_n_train_steps=25,
+        monitor="val_loss",
         always_save_context=True,  # Enables the .nemo file-like checkpointing where all IOMixins are under SerDe
     )
 

--- a/sub-packages/bionemo-example_model/tests/bionemo/example_model/lightning/test_lightning_basic.py
+++ b/sub-packages/bionemo-example_model/tests/bionemo/example_model/lightning/test_lightning_basic.py
@@ -52,8 +52,7 @@ def _train_model_get_ckpt(
     checkpoint_callback = nl_callbacks.ModelCheckpoint(
         save_last=True,
         save_on_train_epoch_end=True,
-        monitor="reduced_train_loss",  # TODO find out how to get val_loss logged and use "val_loss",
-        every_n_train_steps=5,
+        monitor="val_loss",
         always_save_context=True,  # Enables the .nemo file-like checkpointing where all IOMixins are under SerDe
         # async_save=False,  # Tries to save asynchronously, previously led to race conditions.
     )

--- a/sub-packages/bionemo-geneformer/src/bionemo/geneformer/scripts/train_geneformer.py
+++ b/sub-packages/bionemo-geneformer/src/bionemo/geneformer/scripts/train_geneformer.py
@@ -313,7 +313,6 @@ def main(
         save_last=save_last_checkpoint,
         monitor=metric_to_monitor_for_checkpoints,  # "val_loss",
         save_top_k=save_top_k,
-        every_n_train_steps=val_check_interval,
         always_save_context=True,  # Enables the .nemo file-like checkpointing where all IOMixins are under SerDe
     )
 

--- a/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_model.py
+++ b/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_model.py
@@ -821,8 +821,7 @@ def _train_model_get_ckpt(
     checkpoint_callback = nl_callbacks.ModelCheckpoint(
         save_last=True,
         save_on_train_epoch_end=True,
-        monitor="reduced_train_loss",  # TODO find out how to get val_loss logged and use "val_loss",
-        every_n_train_steps=n_steps_train // 2,
+        monitor="val_loss",
         always_save_context=True,  # Enables the .nemo file-like checkpointing where all IOMixins are under SerDe
     )
     save_dir = root_dir / name

--- a/sub-packages/bionemo-llm/src/bionemo/llm/train.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/train.py
@@ -69,7 +69,6 @@ def nemo_logger_factory(experiment_config: ExperimentConfig, wandb_config: Optio
         save_last=experiment_config.save_last_checkpoint,
         monitor=experiment_config.metric_to_monitor_for_checkpoints,
         save_top_k=experiment_config.save_top_k,
-        every_n_train_steps=experiment_config.save_every_n_steps,
         always_save_context=True,
     )
 

--- a/sub-packages/bionemo-testing/src/bionemo/testing/harnesses/stop_and_go.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/harnesses/stop_and_go.py
@@ -234,9 +234,8 @@ class StopAndGoHarness(ABC):
                 testing_callbacks.RaiseAfterMetadataCallback: testing_callbacks.RaiseAfterMetadataCallback(),
                 nl_callbacks.ModelCheckpoint: nl_callbacks.ModelCheckpoint(
                     save_last=True,
-                    monitor="reduced_train_loss",
+                    monitor="val_loss",
                     save_top_k=2,
-                    every_n_train_steps=cls.val_check_interval,
                     always_save_context=True,
                 ),
             }


### PR DESCRIPTION
## Summary
Drop all `val_check_interval` to `Trainer` in favor of `every_n_train_steps` to `ModelCheckpoint`.

## Details
In the current NeMo version, providing `every_n_train_steps` to `ModelCheckpoint` and `val_check_interval` to `Trainer` will save the first checkpoint before validation. This leads to incorrect `val_loss` logging in the first checkpoint name.

Also in favor of `val_loss` as monitored metric over `reduced_train_loss`.