### PR TITLE
Update command to pull latest BioNeMo1 tag

### DIFF
--- a/docs/bionemo/access-startup.md
+++ b/docs/bionemo/access-startup.md
@@ -44,7 +44,7 @@ docker pull $BIONEMO_IMAGE_PATH
 To automatically retrieve the latest container, you can use the following commands:
 
 ```bash
-LATEST_TAG=$(ngc registry image list --format_type=csv --column=tag nvidia/clara/bionemo-framework | tail +2 | head -1 | cut -f 2 -d',')
+LATEST_TAG=$(ngc registry image list --format_type=csv --column=tag nvidia/clara/bionemo-framework | grep "1\." | head -1 | cut -f 2 -d',')
 
 BIONEMO_IMAGE_PATH=nvcr.io/nvidia/clara/bionemo-framework:${LATEST_TAG}
 


### PR DESCRIPTION
This command updates the command to automatically pull the latest BioNeMo1 tag. Addresses internal bug 4943423.