### PR TITLE
add fname parameter for pooch downloads

### DIFF
--- a/sub-packages/bionemo-core/src/bionemo/core/data/load.py
+++ b/sub-packages/bionemo-core/src/bionemo/core/data/load.py
@@ -165,6 +165,7 @@ def load(
 
     download = pooch.retrieve(
         url=str(url),
+        fname=f"{resource.sha256}-{filename}",
         known_hash=resource.sha256,
         path=cache_dir,
         downloader=download_fn,


### PR DESCRIPTION
Pooch automatically calculates a filename for downloads that is a function of the hash and the URL, but we want to ensure that downloads from NGC and PBSS have identical local filenames so that their cache is shared, and the URLs for both resources don't typically match.

Here we set the fname parameter manually so that we don't download duplicate objects from ngc and pbss