### PR TITLE
Update NeMo and Megatron to TOT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN git clone https://github.com/NVIDIA/apex.git && \
   --config-settings "--build-option=--cpp_ext --cuda_ext --fast_layer_norm --distributed_adam --deprecated_fused_adam --group_norm"
 
 # Transformer Engine pre-1.7.0. 1.7 standardizes the meaning of bits in the attention mask to match
-ARG TE_COMMIT=7d576ed25266a17a7b651f2c12e8498f67e0baea
+ARG TE_COMMIT=c27ee60ec746210bcea4ec33958dbbff06706506
 RUN git clone https://github.com/NVIDIA/TransformerEngine.git && \
   cd TransformerEngine && \
   git fetch origin ${TE_COMMIT} && \

--- a/docs/docs/user-guide/examples/bionemo-esm2/pretrain.md
+++ b/docs/docs/user-guide/examples/bionemo-esm2/pretrain.md
@@ -253,7 +253,6 @@ checkpoint_callback = nl_callbacks.ModelCheckpoint(
     save_last=True,
     monitor="val_loss",
     save_top_k=1,
-    every_n_train_steps=100,
     always_save_context=True,
 )
 

--- a/scripts/gpt-pretrain.py
+++ b/scripts/gpt-pretrain.py
@@ -187,7 +187,10 @@ def main() -> None:
     devices, seq_length = 1, 2048
 
     strategy = nl.MegatronStrategy(
-        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, pipeline_dtype=torch.float32
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        pipeline_dtype=torch.float32,
+        ckpt_async_save=False,
     )
     trainer = nl.Trainer(
         devices=devices,

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/model/finetune/train.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/model/finetune/train.py
@@ -50,6 +50,7 @@ def train_model(
     metric_tracker: Callback | None = None,
     tokenizer: BioNeMoESMTokenizer = get_tokenizer(),
     peft: PEFT | None = None,
+    _use_rich_model_summary: bool = True,
 ) -> Tuple[Path, Callback | None, nl.Trainer]:
     """Trains a BioNeMo ESM2 model using PyTorch Lightning.
 
@@ -62,6 +63,8 @@ def train_model(
         metric_tracker: Optional callback to track metrics
         tokenizer: The tokenizer to use. Defaults to `get_tokenizer()`.
         peft: The PEFT (Parameter-Efficient Fine-Tuning) module. Defaults to None.
+        _use_rich_model_summary: Whether to use the RichModelSummary callback, omitted in our test suite until
+            https://nvbugspro.nvidia.com/bug/4959776 is resolved. Defaults to True.
 
     Returns:
         A tuple containing the path to the saved checkpoint, a MetricTracker
@@ -103,7 +106,13 @@ def train_model(
         enable_nemo_ckpt_io=True,
     )
 
-    callbacks: list[Callback] = [RichModelSummary(max_depth=4)]
+    if _use_rich_model_summary:
+        # RichModelSummary is not used in the test suite until https://nvbugspro.nvidia.com/bug/4959776 is resolved due
+        # to errors with serialization / deserialization.
+        callbacks: list[Callback] = [RichModelSummary(max_depth=4)]
+    else:
+        callbacks = []
+
     if metric_tracker is not None:
         callbacks.append(metric_tracker)
     if peft is not None:

--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/data/test_tokenizer.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/data/test_tokenizer.py
@@ -98,7 +98,7 @@ def test_tokenize_with_empty_string(tokenizer):
 
 
 def test_tokenizer_serialization(tokenizer, tmp_path):
-    tokenizer.io_dump(tmp_path / "tokenizer")
+    tokenizer.io_dump(tmp_path / "tokenizer", yaml_attrs=[])  # BioNeMoESMTokenizer takes no __init__ arguments
     deserialized_tokenizer = io.load(tmp_path / "tokenizer", tokenizer.__class__)
 
     our_tokens = deserialized_tokenizer.encode("K A <mask> I S Q", add_special_tokens=False)

--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/finetune/test_finetune.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/finetune/test_finetune.py
@@ -61,7 +61,7 @@ def pretrain_data_module(dummy_protein_dataset, dummy_parquet_train_val_inputs):
 @pytest.mark.needs_gpu
 @pytest.mark.parametrize("with_peft", [True, False])
 def test_esm2_finetune_token_classifier(
-    tmpdir,
+    tmp_path,
     esm2_2layer_config,
     tokenizer,
     pretrain_data_module,
@@ -75,12 +75,13 @@ def test_esm2_finetune_token_classifier(
     with megatron_parallel_state_utils.distributed_model_parallel_state(seed):
         ckpt_path, initial_metrics, trainer = train_model(
             experiment_name="test_experiment",
-            experiment_dir=tmpdir / "pretrain",
+            experiment_dir=tmp_path / "pretrain",
             config=esm2_2layer_config,
             data_module=pretrain_data_module,
             n_steps_train=n_steps_train,
             metric_tracker=MetricTracker(metrics_to_track_val=["loss"], metrics_to_track_train=["loss"]),
             tokenizer=tokenizer,
+            _use_rich_model_summary=False,
         )
         pretrain_requires_grad = [p.requires_grad for _, p in trainer.model.named_parameters()]
         assert all(pretrain_requires_grad), "Frozen parameters in pretraining"
@@ -101,13 +102,14 @@ def test_esm2_finetune_token_classifier(
         finetune_data_module = ESM2FineTuneDataModule(dataset, dataset)
         simple_ft_checkpoint, simple_ft_metrics, trainer = train_model(
             experiment_name="finetune_new_head",
-            experiment_dir=tmpdir / "finetune_new_head",  # new checkpoint will land in a subdir of this
+            experiment_dir=tmp_path / "finetune_new_head",  # new checkpoint will land in a subdir of this
             config=esm2_finetune_config,  # same config as before since we are just continuing training
             data_module=finetune_data_module,
             n_steps_train=n_steps_train,
             metric_tracker=MetricTracker(metrics_to_track_val=["loss"], metrics_to_track_train=["loss"]),
             tokenizer=tokenizer,
             peft=peft,
+            _use_rich_model_summary=False,
         )
 
         weights_ckpt = simple_ft_checkpoint / "weights"
@@ -133,7 +135,7 @@ def test_esm2_finetune_token_classifier(
 @pytest.mark.needs_gpu
 @pytest.mark.parametrize("with_peft", [True, False])
 def test_esm2_finetune_regressor(
-    tmpdir,
+    tmp_path,
     esm2_2layer_config,
     tokenizer,
     pretrain_data_module,
@@ -147,12 +149,13 @@ def test_esm2_finetune_regressor(
     with megatron_parallel_state_utils.distributed_model_parallel_state(seed):
         ckpt_path, initial_metrics, trainer = train_model(
             experiment_name="test_experiment",
-            experiment_dir=tmpdir / "pretrain",
+            experiment_dir=tmp_path / "pretrain",
             config=esm2_2layer_config,
             data_module=pretrain_data_module,
             n_steps_train=n_steps_train,
             metric_tracker=MetricTracker(metrics_to_track_val=["loss"], metrics_to_track_train=["loss"]),
             tokenizer=tokenizer,
+            _use_rich_model_summary=False,
         )
         pretrain_requires_grad = [p.requires_grad for _, p in trainer.model.named_parameters()]
         assert all(pretrain_requires_grad), "Frozen parameters in pretraining"
@@ -173,13 +176,14 @@ def test_esm2_finetune_regressor(
         finetune_data_module = ESM2FineTuneDataModule(dataset, dataset)
         simple_ft_checkpoint, simple_ft_metrics, trainer = train_model(
             experiment_name="finetune_new_head_regression",
-            experiment_dir=tmpdir / "finetune_new_head_regression",  # new checkpoint will land in a subdir of this
+            experiment_dir=tmp_path / "finetune_new_head_regression",  # new checkpoint will land in a subdir of this
             config=esm2_regression_finetune_config,  # same config as before since we are just continuing training
             data_module=finetune_data_module,
             n_steps_train=n_steps_train,
             metric_tracker=MetricTracker(metrics_to_track_val=["loss"], metrics_to_track_train=["loss"]),
             tokenizer=tokenizer,
             peft=peft,
+            _use_rich_model_summary=False,
         )
 
         weights_ckpt = simple_ft_checkpoint / "weights"

--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_stop_and_go.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_stop_and_go.py
@@ -92,7 +92,7 @@ class TestESM2StopAndGo(stop_and_go.StopAndGoHarness):
                 adam_beta2=0.98,
             ),
             lr_scheduler=WarmupAnnealDecayHoldScheduler(
-                warmup_steps=50, max_steps=cls.num_steps, max_lr=cls.lr, min_lr=cls.lr / 10.0, anneal_percentage=0.10
+                warmup_steps=50, max_steps=cls.num_steps, max_lr=cls.lr, min_lr=0.0, anneal_percentage=0.10
             ),
         )
 

--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/scripts/test_train_esm2.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/scripts/test_train_esm2.py
@@ -30,7 +30,6 @@ from bionemo.llm.utils.datamodule_utils import parse_kwargs_to_arglist
 from bionemo.testing import megatron_parallel_state_utils
 
 
-@pytest.mark.skip("duplicate unittest")
 @pytest.fixture
 def dummy_protein_dataset(tmp_path):
     """Create a mock protein dataset."""
@@ -62,7 +61,6 @@ def dummy_protein_dataset(tmp_path):
     return db_file
 
 
-@pytest.mark.skip("duplicate unittest")
 @pytest.fixture
 def dummy_parquet_train_val_inputs(tmp_path):
     """Create a mock protein train and val cluster parquet."""
@@ -102,7 +100,7 @@ def test_main_runs(monkeypatch, tmpdir, dummy_protein_dataset, dummy_parquet_tra
             result_dir=result_dir,
             wandb_project=None,
             wandb_offline=True,
-            num_steps=55,
+            num_steps=10,
             warmup_steps=5,
             limit_val_batches=1,
             val_check_interval=1,

--- a/sub-packages/bionemo-example_model/src/bionemo/example_model/lightning/lightning_basic.py
+++ b/sub-packages/bionemo-example_model/src/bionemo/example_model/lightning/lightning_basic.py
@@ -649,8 +649,7 @@ class BionemoLightningModule(pl.LightningModule, io.IOMixin, LightningPassthroug
 checkpoint_callback = nl_callbacks.ModelCheckpoint(
     save_last=True,
     save_on_train_epoch_end=True,
-    monitor="reduced_train_loss",
-    every_n_train_steps=25,
+    monitor="val_loss",
     always_save_context=True,  # Enables the .nemo file-like checkpointing where all IOMixins are under SerDe
 )
 

--- a/sub-packages/bionemo-example_model/src/bionemo/example_model/training_scripts/finetune_mnist.py
+++ b/sub-packages/bionemo-example_model/src/bionemo/example_model/training_scripts/finetune_mnist.py
@@ -44,8 +44,7 @@ def run_finetune(checkpoint_dir: str, name: str, directory_name: str):
     checkpoint_callback = nl_callbacks.ModelCheckpoint(
         save_last=True,
         save_on_train_epoch_end=True,
-        monitor="reduced_train_loss",
-        every_n_train_steps=25,
+        monitor="val_loss",
         always_save_context=True,  # Enables the .nemo file-like checkpointing where all IOMixins are under SerDe
     )
 

--- a/sub-packages/bionemo-example_model/tests/bionemo/example_model/lightning/test_lightning_basic.py
+++ b/sub-packages/bionemo-example_model/tests/bionemo/example_model/lightning/test_lightning_basic.py
@@ -52,10 +52,10 @@ def _train_model_get_ckpt(
     checkpoint_callback = nl_callbacks.ModelCheckpoint(
         save_last=True,
         save_on_train_epoch_end=True,
-        monitor="reduced_train_loss",  # TODO find out how to get val_loss logged and use "val_loss",
-        every_n_train_steps=5,
+        monitor="val_loss",
         always_save_context=True,  # Enables the .nemo file-like checkpointing where all IOMixins are under SerDe
         # async_save=False,  # Tries to save asynchronously, previously led to race conditions.
+        filename="{epoch}-{step}-{val_loss:.2f}",
     )
     save_dir = root_dir / name
     tb_logger = TensorBoardLogger(save_dir=save_dir, name=name)

--- a/sub-packages/bionemo-geneformer/src/bionemo/geneformer/scripts/train_geneformer.py
+++ b/sub-packages/bionemo-geneformer/src/bionemo/geneformer/scripts/train_geneformer.py
@@ -320,7 +320,7 @@ def main(
     # Configure our custom Checkpointer
     checkpoint_callback = nl_callbacks.ModelCheckpoint(
         save_last=save_last_checkpoint,
-        monitor=metric_to_monitor_for_checkpoints,  # "val_loss",
+        monitor=metric_to_monitor_for_checkpoints,
         save_top_k=save_top_k,
         every_n_train_steps=val_check_interval,
         always_save_context=True,  # Enables the .nemo file-like checkpointing where all IOMixins are under SerDe

--- a/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/scripts/test_train_geneformer.py
+++ b/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/scripts/test_train_geneformer.py
@@ -37,7 +37,6 @@ def test_bionemo2_rootdir():
     assert data_path.is_dir(), "Test data directory is supposed to be a directory."
 
 
-@pytest.mark.skip("duplicate unittest")
 def test_main_runs(tmpdir):
     result_dir = Path(tmpdir.mkdir("results"))
 

--- a/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_model.py
+++ b/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_model.py
@@ -821,8 +821,7 @@ def _train_model_get_ckpt(
     checkpoint_callback = nl_callbacks.ModelCheckpoint(
         save_last=True,
         save_on_train_epoch_end=True,
-        monitor="reduced_train_loss",  # TODO find out how to get val_loss logged and use "val_loss",
-        every_n_train_steps=n_steps_train // 2,
+        monitor="val_loss",
         always_save_context=True,  # Enables the .nemo file-like checkpointing where all IOMixins are under SerDe
     )
     save_dir = root_dir / name

--- a/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_stop_and_go.py
+++ b/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_stop_and_go.py
@@ -97,7 +97,7 @@ class TestGeneformerStopAndGo(stop_and_go.StopAndGoHarness):
     limit_val_batches: int = 2
     lr: float = 1e-4
     precision: Literal["16-mixed", "bf16-mixed", "32"] = MODEL_PRECISION
-    train_val_output_atol: float = 2e-2
+    output_tensor_atol: float = 3e-2
 
     @override
     @classmethod

--- a/sub-packages/bionemo-llm/src/bionemo/llm/model/biobert/model.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/model/biobert/model.py
@@ -397,7 +397,11 @@ class MegatronBioBertModel(LanguageModule):
         rotary_pos_emb = None
         if self.position_embedding_type == "rope":
             rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
-                inference_params, self.encoder, encoder_input, self.config
+                inference_params,
+                self.encoder,
+                encoder_input,
+                self.config,
+                packed_seq_params=None,  # TODO @sichu: upstream to Megatron-LM
             )
             rotary_pos_emb = self.rotary_pos_emb(rotary_seq_len)
 

--- a/sub-packages/bionemo-llm/src/bionemo/llm/utils/weight_utils.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/utils/weight_utils.py
@@ -145,7 +145,7 @@ def load_weights_sharded_inplace_nemo2_to_mcore(
     sharded_state_dict = {
         _munge_key_megatron_to_nemo2(k): _munge_sharded_tensor_key_megatron_to_nemo2(v)
         for k, v in model.sharded_state_dict().items()
-        if not _key_in_filter(k, skip_keys_with_these_prefixes)
+        if not _key_in_filter(k, skip_keys_with_these_prefixes) and "_extra_state" not in k
     }
     dist_checkpointing.load(
         sharded_state_dict=sharded_state_dict,

--- a/sub-packages/bionemo-llm/tests/bionemo/llm/test_lightning.py
+++ b/sub-packages/bionemo-llm/tests/bionemo/llm/test_lightning.py
@@ -169,6 +169,8 @@ class NestedModule(nn.Module):
         return self.other(x)
 
 
+# TODO rewrite unittest and potentially LightningPassthroughPredictionMixin
+@pytest.mark.xfail(reason="MegatronStrategy no longer has '_get_loss_reduction' attribute")
 def test_mixin_strategy_contract_get_loss_reduction():
     with megatron_parallel_state_utils.clean_parallel_state_context():
         strategy = nl.MegatronStrategy(

--- a/sub-packages/bionemo-llm/tests/bionemo/llm/utils/test_iomixin_utils.py
+++ b/sub-packages/bionemo-llm/tests/bionemo/llm/utils/test_iomixin_utils.py
@@ -45,6 +45,12 @@ class OverrideModelDataClass2(BaseDataClass, iom.IOMixinWithGettersSetters):
 
 
 class TestIOMixin:
+    """TestCase on IOMixin.
+
+    Notes:
+        IOMixin only captures non-default __init__ arguments into self.__io__ to ensure no compatibility in loading older mcore config in newer versions.
+    """
+
     def test_dataclasses_two_versions(self):
         _ = OverrideModelDataClass1(b=2)
         v1 = OverrideModelDataClass2(b=4)
@@ -80,10 +86,10 @@ class TestIOMixin:
         with pytest.raises(KeyError):
             v1.get_hparam("q")
 
-        # Make sure we can get all hyper-parameters that are not defaultfactory objects
-        assert v1.get_hparams() == {"b": 7, "c": 3}
+        # Make sure we can get all hyper-parameters that are **non-default** non-defaultfactory objects
+        assert v1.get_hparams() == {"b": 7}
 
-        # Make sure by default we can change botht he hyper-parameter and the attribute.
+        # Make sure by default we can change both the hyper-parameter and the attribute.
         v1_copy.set_hparam("b", 8)
         assert v1_copy.b == 8
         assert v1_copy.get_hparam("b") == 8
@@ -92,8 +98,8 @@ class TestIOMixin:
         v1 = OverrideModelDataClass1()
         v1.set_hparam("a", 7)
         assert v1.a == 7
-        # Make sure we can get all hyper-parameters
-        assert v1.get_hparams() == {"a": 7, "b": 3, "c": 3}
+        # Make sure we can get all **non-default** **non-defaultfactory** hyper-parameters
+        assert v1.get_hparams() == {"a": 7}
 
         v1_copy = io.reinit(v1)
         assert v1_copy.a == 7, "V1 should re-initialize with the updated hyper-parameter."

--- a/sub-packages/bionemo-testing/src/bionemo/testing/harnesses/stop_and_go.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/harnesses/stop_and_go.py
@@ -106,8 +106,8 @@ class StopAndGoHarness(ABC):
     limit_val_batches: int
     lr: float = 1e-4
     precision: Literal["16-mixed", "bf16-mixed", "32"]
-    train_val_output_atol: float = 1e-3
-    other_output_atol: float = 1e-4
+    output_tensor_atol: float = 1e-3  # Absolute tolerance for model precision between output tensors.
+    output_tensor_rtol: float = 1e-4  # Relative tolerance for model precision between output tensors.
 
     # class variables that will be setup in setUpClass
     tempdir: tempfile.TemporaryDirectory
@@ -173,6 +173,7 @@ class StopAndGoHarness(ABC):
             ddp="megatron",
             find_unused_parameters=True,
             ckpt_include_optimizer=True,
+            ckpt_async_save=False,
         )
 
         trainer = nl.Trainer(
@@ -233,13 +234,13 @@ class StopAndGoHarness(ABC):
 
         callbacks[Mode.STOP].update(
             {
-                testing_callbacks.RaiseAfterMetadataCallback: testing_callbacks.RaiseAfterMetadataCallback(),
+                testing_callbacks.StopAfterValidEpochEndCallback: testing_callbacks.StopAfterValidEpochEndCallback(),
                 nl_callbacks.ModelCheckpoint: nl_callbacks.ModelCheckpoint(
                     save_last=True,
-                    monitor="reduced_train_loss",
+                    monitor="val_loss",
                     save_top_k=2,
-                    every_n_train_steps=cls.val_check_interval,
                     always_save_context=True,
+                    filename="{epoch}-{step}-{val_loss:.2f}",
                 ),
             }
         )
@@ -264,20 +265,17 @@ class StopAndGoHarness(ABC):
         model, data, opt = cls.setup_model(mode=Mode.STOP)
         trainer = cls.setup_trainer(Mode.STOP)
         with distributed_model_parallel_state():
-            try:
-                llm.train(
-                    model=model,
-                    data=data,
-                    trainer=trainer,
-                    log=cls.nemo_logger,
-                    optim=opt,
-                    resume=resume.AutoResume(
-                        resume_if_exists=False,  # Looks for the -last checkpoint to continue training.
-                        resume_ignore_no_checkpoint=True,  # When false this will throw an error with no existing checkpoint.
-                    ),
-                )
-            except testing_callbacks.StopAndGoException:
-                return
+            llm.train(
+                model=model,
+                data=data,
+                trainer=trainer,
+                log=cls.nemo_logger,
+                optim=opt,
+                resume=resume.AutoResume(
+                    resume_if_exists=False,  # Looks for the -last checkpoint to continue training.
+                    resume_ignore_no_checkpoint=True,  # When false this will throw an error with no existing checkpoint.
+                ),
+            )
 
     @classmethod
     def resume(cls) -> None:
@@ -329,6 +327,9 @@ class StopAndGoHarness(ABC):
             testing_callbacks.TrainInputCallback,
             testing_callbacks.TrainOutputCallback,
             testing_callbacks.TrainLossCallback,
+            testing_callbacks.ValidInputCallback,
+            testing_callbacks.ValidOutputCallback,
+            testing_callbacks.ValidLossCallback,
         ],
     )
     def test_stop_and_go_consistency(self, callback_type):
@@ -337,12 +338,17 @@ class StopAndGoHarness(ABC):
         continuous_callback = get_callback(self.callbacks, Mode.CONTINUOUS, callback_type)
         assert interrupted_callback.data, f"No data found for {callback_type}"
 
-        if callback_type == testing_callbacks.TrainOutputCallback:
-            atol = self.train_val_output_atol
+        if callback_type in {testing_callbacks.TrainOutputCallback, testing_callbacks.ValidOutputCallback}:
+            atol, rtol = self.output_tensor_atol, self.output_tensor_rtol
         else:
-            atol = self.other_output_atol
+            atol, rtol = 1e-4, 1e-4
 
-        recursive_assert_approx_equal(interrupted_callback.data, continuous_callback.data, atol=atol)
+        recursive_assert_approx_equal(
+            interrupted_callback.data,
+            continuous_callback.data,
+            atol=atol,
+            rtol=rtol,
+        )
 
     def test_train_val_init_consumed_samples(self):
         """Tests the initial consumed samples in stop-and-go scenario."""
@@ -358,40 +364,10 @@ class StopAndGoHarness(ABC):
         assert train_consumed_stop == 0
         assert train_consumed_go > 0
 
-    # TODO: For some reason, validation in NeMo runs an extra batch in the case when the training is stopped and
-    # resumed. Hopefully we can fix this upstream and remove the indexing based on the length of the continuous
-    # validation batches.
-    @pytest.mark.xfail(reason="Validation runs an extra batch in the case when training is stopped and resumed.")
     def test_identical_number_of_validation_batches(self):
         """Ensures that the input tensors for training are identical for the interrupted and continuous tests."""
-        callback_type = testing_callbacks.ValidInputCallback
+        callback_type = testing_callbacks.ValidLossCallback
         interrupted_callback = get_callback(self.callbacks, Mode.RESUME, callback_type)
         continuous_callback = get_callback(self.callbacks, Mode.CONTINUOUS, callback_type)
         assert interrupted_callback.data, f"No data found for {callback_type}"
-        recursive_assert_approx_equal(interrupted_callback.data, continuous_callback.data)
         assert len(interrupted_callback.data) == len(continuous_callback.data)
-
-    @pytest.mark.parametrize(
-        "callback_type",
-        [
-            testing_callbacks.ValidInputCallback,
-            testing_callbacks.ValidOutputCallback,
-            testing_callbacks.ValidLossCallback,
-        ],
-    )
-    def test_stop_and_go_consistency_with_uneven_validation_sizes(self, callback_type):
-        """Ensures that the input tensors for training are identical for the interrupted and continuous tests."""
-        interrupted_callback = get_callback(self.callbacks, Mode.RESUME, callback_type)
-        continuous_callback = get_callback(self.callbacks, Mode.CONTINUOUS, callback_type)
-        assert interrupted_callback.data, f"No data found for {callback_type}"
-
-        # Hack: Validation seems to run an extra batch in the case when training is stopped and resumed, but we can
-        # still test the rest of the data to ensure consistency.
-        interrupted_data = interrupted_callback.data[-len(continuous_callback.data) :]
-
-        if callback_type == testing_callbacks.ValidOutputCallback:
-            atol = self.train_val_output_atol
-        else:
-            atol = self.other_output_atol
-
-        recursive_assert_approx_equal(interrupted_data, continuous_callback.data, atol=atol)

--- a/sub-packages/bionemo-testing/src/bionemo/testing/testing_callbacks.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/testing_callbacks.py
@@ -29,11 +29,7 @@ from bionemo.testing.harnesses.mode import Mode
 from bionemo.testing.torch import recursive_detach
 
 
-class StopAndGoException(Exception):  # noqa: D101
-    pass
-
-
-class RaiseAfterMetadataCallback(Callback):
+class StopAfterValidEpochEndCallback(Callback):
     """A callback that raises a StopAndGoException after the validation epoch.
 
     Use this callback for pytest based Stop and go tests.
@@ -42,7 +38,7 @@ class RaiseAfterMetadataCallback(Callback):
     def on_validation_epoch_end(self, trainer: Trainer, pl_module: LightningModule):  # noqa: D102
         if trainer.sanity_checking:
             return
-        raise StopAndGoException()
+        trainer.should_stop = True
 
 
 class BaseInterruptedVsContinuousCallback(Callback, CallbackMethods, io.IOMixin):


### PR DESCRIPTION
Updates us to TOT NeMo and Megatron, and bumps the transformer engine version to 1.11.

Includes a number of fixes we need to make to be compatible with these newer versions, including changes to IOMixin


Branches off of #302.

Includes the fix from NeMo for validation batches after restart NVIDIA/NeMo#11029

