### PR TITLE
re-enable merge groups to trigger blossom-ci

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -17,6 +17,7 @@ name: Blossom-CI
 on:
   issue_comment:
     types: [created]
+  merge_group:
   workflow_dispatch:
       inputs:
           platform:
@@ -34,30 +35,37 @@ jobs:
 
     # This job only runs for pull request comments
     if: |
-         github.event.comment.body == '/build-ci' &&
-         (github.actor == 'ohadmo' ||
-          github.actor == 'trvachov' ||
-          github.actor == 'jstjohn' ||
-          github.actor == 'pstjohn' ||
-          github.actor == 'malcolmgreaves' ||
-          github.actor == 'gwarmstrong' ||
-          github.actor == 'farhadrgh' ||
-          github.actor == 'dorotat-nv' ||
-          github.actor == 'jomitchellnv' ||
-          github.actor == 'skothenhill-nv' ||
-          github.actor == 'yzhang123' ||
-          github.actor == 'ntadimeti' ||
-          github.actor == 'broland-hat' ||
-          github.actor == 'polinabinder1' ||
-          github.actor == 'camirr-nv' ||
-          github.actor == 'sichu2023' ||
-          github.actor == 'jwilber' ||
-          github.actor == 'DejunL'||
-          github.actor == 'mengliu-nvidia' ||
-          github.actor == 'gagank1' ||
-          github.actor == 'guoqing-zhou' ||
-          github.actor == 'savitha-eng' ||
-          github.actor == 'tshimko-nv')
+         (
+            github.event.comment.body == '/build-ci' &&
+            (
+              github.actor == 'ohadmo' ||
+              github.actor == 'trvachov' ||
+              github.actor == 'jstjohn' ||
+              github.actor == 'pstjohn' ||
+              github.actor == 'malcolmgreaves' ||
+              github.actor == 'gwarmstrong' ||
+              github.actor == 'farhadrgh' ||
+              github.actor == 'dorotat-nv' ||
+              github.actor == 'jomitchellnv' ||
+              github.actor == 'skothenhill-nv' ||
+              github.actor == 'yzhang123' ||
+              github.actor == 'ntadimeti' ||
+              github.actor == 'broland-hat' ||
+              github.actor == 'polinabinder1' ||
+              github.actor == 'camirr-nv' ||
+              github.actor == 'sichu2023' ||
+              github.actor == 'jwilber' ||
+              github.actor == 'DejunL'||
+              github.actor == 'mengliu-nvidia' ||
+              github.actor == 'gagank1' ||
+              github.actor == 'guoqing-zhou' ||
+              github.actor == 'savitha-eng' ||
+              github.actor == 'tshimko-nv'
+            )
+          ) || (
+           github.event_name == 'merge_group'
+          )
+
     steps:
       - name: Check if comment is issued by authorized person
         run: blossom-ci


### PR DESCRIPTION
I'm hoping this doesn't brick our existing blossom workflow, but we'll need to quickly revert if it does. If we can get this merged to `main`, I'm hoping we can do the rest of our testing with merge groups with PRs to a seperate `main-merge-group` branch