### PR TITLE
Explore esm2 training instability 20241119

### DIFF
--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -264,6 +264,7 @@ def main(
                 weight_decay=0.01,
                 adam_beta1=0.9,
                 adam_beta2=0.98,
+                adam_eps=1e-5,  # default of 1e-8 creates instability
             ),
             lr_scheduler=WarmupAnnealDecayHoldScheduler(
                 warmup_steps=warmup_steps, max_steps=num_steps, max_lr=lr, min_lr=0.0, anneal_percentage=0.10

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -17,6 +17,7 @@ import argparse
 from pathlib import Path
 from typing import List, Optional, Sequence, get_args
 
+from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.optimizer import OptimizerConfig
 from nemo import lightning as nl
 from nemo.collections import llm
@@ -158,10 +159,15 @@ def main(
         pipeline_model_parallel_size=pipeline_model_parallel_size,
     )
 
+    # ddp = "megatron"  # this will launch DistributedDataParallelConfig(check_for_nan_in_grad=True).
+    ddp = DistributedDataParallelConfig(
+        grad_reduce_in_fp32=True,
+        check_for_nan_in_grad=True,
+    )
     strategy = nl.MegatronStrategy(
         tensor_model_parallel_size=tensor_model_parallel_size,
         pipeline_model_parallel_size=pipeline_model_parallel_size,
-        ddp="megatron",
+        ddp=ddp,
         find_unused_parameters=True,
         ckpt_include_optimizer=True,
         # NOTE: there are issues related to async that may occur, most recently observed due to duplicate filenames.

--- a/sub-packages/bionemo-geneformer/src/bionemo/geneformer/scripts/train_geneformer.py
+++ b/sub-packages/bionemo-geneformer/src/bionemo/geneformer/scripts/train_geneformer.py
@@ -602,28 +602,28 @@ def get_parser():
 
     parser.add_argument(
         "--num-layers",
-        dtype=int,
+        type=int,
         default=6,
         help="Number of layers in model",
     )
 
     parser.add_argument(
         "--hidden-size",
-        dtype=int,
+        type=int,
         default=256,
         help="Hidden layer size",
     )
 
     parser.add_argument(
         "--ffn-hidden-size",
-        dtype=int,
+        type=int,
         default=512,
         help="FFN hidden layer size",
     )
 
     parser.add_argument(
         "--num-attention-heads",
-        dtype=int,
+        type=int,
         default=4,
         help="Number of attention heads.",
     )
@@ -684,25 +684,25 @@ def get_parser():
     )
     parser.add_argument(
         "--layernorm-eps",
-        dtype=float,
+        type=float,
         default=1e-12,
         help="Use data precision to define the epsilon for layer norm. Default is 1e-12 if not defined.",
     )
     parser.add_argument(
         "--adam-eps",
-        dtype=float,
+        type=float,
         default=1e-8,
         help="Use data precision to define the epsilon for adam. Default is 1e-5 if not defined.",
     )
     parser.add_argument(
         "--adam-w",
-        dtype=float,
+        type=float,
         default=0.01,
         help="Use data precision to define the epsilon for adam. Default is 0.1 if not defined.",
     )
     parser.add_argument(
         "--adam-beta2",
-        dtype=float,
+        type=float,
         default=0.999,
         help="Use data precision to define the epsilon for adam. Default is 0.999 if not defined.",
     )


### PR DESCRIPTION
Dependent on https://github.com/NVIDIA/bionemo-framework/pull/448

WAND comparison on full pretraining runs
* grad norm https://wandb.ai/clara-discovery/bionemo-hf-pretraining/reports/grad_norm-24-11-19-16-32-45---VmlldzoxMDI0MjUxNA
* reduced train loss https://wandb.ai/clara-discovery/bionemo-hf-pretraining/reports/reduced_train_loss-24-11-19-16-33-13---VmlldzoxMDI0MjUyMA

WAND comparison on local test runs
* grad norm https://wandb.ai/clara-discovery/bionemo2-esm2-instability/reports/grad_norm-24-11-19-17-31-38---VmlldzoxMDI0MzQzNg
* reduced train loss https://wandb.ai/clara-discovery/bionemo2-esm2-instability/reports/reduced_train_loss-24-11-19-17-32-18---VmlldzoxMDI0MzQ0OA