### PR TITLE
Update error prone stop/go atol to more stable setting

### DIFF
--- a/sub-packages/bionemo-core/tests/bionemo/core/data/test_load.py
+++ b/sub-packages/bionemo-core/tests/bionemo/core/data/test_load.py
@@ -269,6 +269,7 @@ def test_default_pbss_client():
     assert client.meta.endpoint_url == "https://pbss.s8k.io"
 
 
+@pytest.mark.xfail(reason="Logging into NGC is not required to download artifacts in BioNeMo.")
 def test_default_ngc_client():
     clt = default_ngc_client()
     assert clt.api_key is not None

--- a/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_stop_and_go.py
+++ b/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_stop_and_go.py
@@ -97,7 +97,7 @@ class TestGeneformerStopAndGo(stop_and_go.StopAndGoHarness):
     limit_val_batches: int = 2
     lr: float = 1e-4
     precision: Literal["16-mixed", "bf16-mixed", "32"] = MODEL_PRECISION
-    train_val_output_atol: float = 2e-2
+    train_val_output_atol: float = 3e-2
 
     @override
     @classmethod


### PR DESCRIPTION
This addresses a rare, random failure in the geneformer stop/go test @polinabinder1 observed [here](https://prod.blsm.nvidia.com/bionemo-external-bionemo-fw/job/test_pytest/826/console). This mirrors the setting we have now in main: https://github.com/NVIDIA/bionemo-framework/blob/main/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_stop_and_go.py#L100
