### PR TITLE
set num_workers to 1 for esm2 tests

### DIFF
--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/finetune/test_finetune.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/finetune/test_finetune.py
@@ -54,6 +54,7 @@ def pretrain_data_module(dummy_protein_dataset, dummy_parquet_train_val_inputs):
         micro_batch_size=4,
         min_seq_length=None,
         max_seq_length=1024,
+        num_workers=1,
     )
     yield data_module
 

--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_model.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_model.py
@@ -249,6 +249,7 @@ def test_esm2_loss(esm2_650M_config_w_ckpt, dummy_protein_dataset, dummy_parquet
             min_seq_length=None,
             max_seq_length=1024,
             seed=seed,
+            num_workers=1,
         )
         assert data_module is not None
         data_module.trainer = mock.Mock()

--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_stop_and_go.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_stop_and_go.py
@@ -76,7 +76,7 @@ class TestESM2StopAndGo(stop_and_go.StopAndGoHarness):
             micro_batch_size=2,
             min_seq_length=None,
             max_seq_length=1024,
-            num_workers=0,
+            num_workers=1,
             persistent_workers=False,
             random_mask_strategy=RandomMaskStrategy.ALL_TOKENS,
         )


### PR DESCRIPTION
Should help to address errors like https://prod.blsm.nvidia.com/bionemo-external-bionemo-fw/job/test_pytest/838/console 
```14:14:12  E       RuntimeError: DataLoader worker (pid 8445) is killed by signal: Aborted.```
when we use too many resources on the CI machine