### PR TITLE
debugging checkpoint resumption

### DIFF
--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -436,3 +436,12 @@ class PerplexityLoggingCallback(pl.Callback, CallbackMethods):
             step.pl_module.log("val_ppl", ppl, prog_bar=True, on_epoch=True)
         elif self.log_train and step.trainer.training:
             step.pl_module.log("train_ppl", ppl, prog_bar=True, batch_size=1, sync_dist=False)
+
+
+class StopAfterStepCallback(pl.Callback, CallbackMethods):
+    def __init__(self, stop_after_steps: int):
+        self.stop_after_steps = stop_after_steps
+
+    def on_megatron_step_end(self, step, microbatch_outputs, reduced=None) -> None:
+        if step.trainer.global_step >= self.stop_after_steps:
+            raise RuntimeError(f"Stopping after {self.stop_after_steps} steps")


### PR DESCRIPTION
Currently running the following pre-training command:

```
DATA_DIR=$(download_bionemo_data esm2/testdata_esm2_pretrain:2.0 --source ngc)

train_esm2 \
    --train-cluster-path ${DATA_DIR}/2024_03_sanity/train_clusters_sanity.parquet \
    --train-database-path ${DATA_DIR}/2024_03_sanity/train_sanity.db \
    --valid-cluster-path ${DATA_DIR}/2024_03_sanity/valid_clusters.parquet \
    --valid-database-path ${DATA_DIR}/2024_03_sanity/validation.db \
    --resume-if-exists \
    --precision="bf16-mixed" \
    --num-gpus 1 \
    --num-nodes 1 \
    --num-steps 10_000 \
    --val-check-interval 1_000 \
    --stop-after-steps 1_500 \
    --max-seq-length 1024 \
    --limit-val-batches 2 \
    --micro-batch-size 16 \
    --num-layers=6 \
    --hidden-size=320 \
    --num-attention-heads=20 \
    --ffn-hidden-size=1280 \
    --tensor-model-parallel-size 1 \
    --create-tensorboard-logger \
    --wandb-project=esm2_checkpoint_resumption \
    --experiment-name=8m_pretraining_local
```

Runs resumed from a checkpoint are reproducible, but different from the model that continued without stopping

![Screenshot 2024-11-22 at 9 57 02 AM](https://github.com/user-attachments/assets/e96c86a7-10f2-460d-9320-52e8f21cd698)
