### PR TITLE
Fix typos in geneformer benchmark description

### DIFF
--- a/docs/docs/user-guide/examples/bionemo-geneformer/geneformer-celltype-classification.ipynb
+++ b/docs/docs/user-guide/examples/bionemo-geneformer/geneformer-celltype-classification.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "source": [
     "# Geneformer Cell Type Classification Benchmark\n",
-    "Here we benchmark four models, with two baselines. These models are tasked with cell type classification, using the Chron’s disease small intestine dataset from Elmentaite et al. (2020), Developmental Cell. This dataset contains approximately 22,500 single cells from both healthy children aged 4-13 and chidlren with Chron’s disease. This dataset contains 31 unique cell types which we assume to be annotated accurately. This dataset was held out of our pre-training dataset as all diseased samples were removed.\n",
+    "Here we benchmark four models, with two baselines. These models are tasked with cell type classification, using the Crohn's disease small intestine dataset from Elmentaite et al. (2020), Developmental Cell. This dataset contains approximately 22,500 single cells from both healthy children aged 4-13 and children with Crohn's disease. This dataset contains 31 unique cell types which we assume to be annotated accurately. This dataset was held out of our pre-training dataset as all diseased samples were removed.\n",
     "\n",
     "* Baseline (1) scRNA workflow: this model uses PCA with 10 components and random forest on normalized and log transformed expression counts to produce a result.\n",
     "* Baseline (2) geneformer with random weight initialization. Some performance can come from large random projections, but we want to do better than that.\n",


### PR DESCRIPTION
Marking this as skip because it's a change to a markdown cell.