### PR TITLE
Pstjohn/stop and go test non validation

### DIFF
--- a/ci/scripts/run_pytest.sh
+++ b/ci/scripts/run_pytest.sh
@@ -29,7 +29,8 @@ python -m coverage erase
 
 for dir in docs/ ./sub-packages/bionemo-*/; do
     echo "Running pytest in $dir"
-    python -m coverage run --parallel-mode --source bionemo -m pytest -v --nbval-lax $dir
+    python -m coverage run --parallel-mode --source bionemo \
+        -m pytest -v --nbval-lax --durations=0 --durations-min=60.0 $dir
 done
 
 python -m coverage combine

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-ruff==0.0.292
+ruff==0.5.1  # Needs to match the version of ruff used in .pre-commit-config.yaml.
 black==23.1.0
 pre-commit==3.4.0
 virtualenv==20.26.3

--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_stop_and_go.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_stop_and_go.py
@@ -18,8 +18,8 @@ import signal
 from pathlib import Path
 from typing import Literal
 
-import pytest
 import lightning.pytorch as pl
+import pytest
 from megatron.core.optimizer import OptimizerConfig
 from nemo import lightning as nl
 from nemo.lightning.pytorch import callbacks as nl_callbacks
@@ -121,9 +121,9 @@ class TestESM2StopAndGoCheckpointNotAtValidation(TestESM2StopAndGo):
     def get_default_callbacks(cls):
         callbacks = super().get_default_callbacks()
         callbacks[Mode.STOP][nl_callbacks.PreemptionCallback] = nl_callbacks.PreemptionCallback(sig=signal.SIGUSR2)
-        callbacks[Mode.STOP][
-            testing_callbacks.SignalAfterGivenStepCallback
-        ] = testing_callbacks.SignalAfterGivenStepCallback(stop_step=2, signal_=signal.SIGUSR2)
+        callbacks[Mode.STOP][testing_callbacks.SignalAfterGivenStepCallback] = (
+            testing_callbacks.SignalAfterGivenStepCallback(stop_step=2, signal_=signal.SIGUSR2)
+        )
 
         return callbacks
 
@@ -162,7 +162,10 @@ class TestESM2StopAndGoCheckpointNotAtValidation(TestESM2StopAndGo):
             # On resumption from a checkpoint that wasn't created at the end of validation, the validation interval is
             # shifted in the subsequent training jobs. See this slack thread for more details:
             # https://nvidia.slack.com/archives/C074Z808N05/p1733171223813409
-            pytest.xfail(reason="Currently seeing issues in validation timing with PreemptionCallback")
+            pytest.xfail(
+                reason="Currently seeing issues in validation timing with PreemptionCallback. "
+                "See https://nvbugspro.nvidia.com/bug/4994415F."
+            )
         super().test_stop_and_go_consistency(callback_type)
 
     @pytest.mark.skip(reason="We don't expect the STOP variant to hit on_valid_epoch_end before stopping.")

--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_stop_and_go.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_stop_and_go.py
@@ -158,6 +158,9 @@ class TestESM2StopAndGoCheckpointNotAtValidation(TestESM2StopAndGo):
             testing_callbacks.ValidLossCallback,
             testing_callbacks.ValidOutputCallback,
         ]:
+            # On resumption from a checkpoint that wasn't created at the end of validation, the validation interval is
+            # shifted in the subsequent training jobs. See this slack thread for more details:
+            # https://nvidia.slack.com/archives/C074Z808N05/p1733171223813409
             pytest.xfail(reason="Currently seeing issues in validation timing with PreemptionCallback")
         super().test_stop_and_go_consistency(callback_type)
 

--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_stop_and_go.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_stop_and_go.py
@@ -80,7 +80,7 @@ class TestESM2StopAndGo(stop_and_go.StopAndGoHarness):
             micro_batch_size=2,
             min_seq_length=None,
             max_seq_length=1024,
-            num_workers=0,
+            num_workers=1,
             persistent_workers=False,
             random_mask_strategy=RandomMaskStrategy.ALL_TOKENS,
         )

--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_stop_and_go.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_stop_and_go.py
@@ -137,6 +137,30 @@ class TestESM2StopAndGoCheckpointNotAtValidation(TestESM2StopAndGo):
         assert pytest_wrapped_e.type is SystemExit
         assert pytest_wrapped_e.value.code == 0
 
-    @pytest.mark.skip()
+    @pytest.mark.parametrize(
+        "callback_type",
+        [
+            testing_callbacks.LearningRateCallback,
+            testing_callbacks.GlobalStepStateCallback,
+            testing_callbacks.ConsumedSamplesCallback,
+            testing_callbacks.OptimizerStateCallback,
+            testing_callbacks.TrainInputCallback,
+            testing_callbacks.TrainOutputCallback,
+            testing_callbacks.TrainLossCallback,
+            testing_callbacks.ValidInputCallback,
+            testing_callbacks.ValidOutputCallback,
+            testing_callbacks.ValidLossCallback,
+        ],
+    )
+    def test_stop_and_go_consistency(self, callback_type):
+        if callback_type in [
+            testing_callbacks.ValidInputCallback,
+            testing_callbacks.ValidLossCallback,
+            testing_callbacks.ValidOutputCallback,
+        ]:
+            pytest.xfail(reason="Currently seeing issues in validation timing with PreemptionCallback")
+        super().test_stop_and_go_consistency(callback_type)
+
+    @pytest.mark.skip(reason="We don't expect the STOP variant to hit on_valid_epoch_end before stopping.")
     def test_train_val_init_consumed_samples(self):
         pass

--- a/sub-packages/bionemo-testing/src/bionemo/testing/harnesses/stop_and_go.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/harnesses/stop_and_go.py
@@ -359,6 +359,7 @@ class StopAndGoHarness(ABC):
         stop_callback = get_callback(
             self.callbacks, Mode.STOP, testing_callbacks.TrainValInitConsumedSamplesStopAndGoCallback
         )
+        print(stop_callback.data)
         train_consumed_stop, val_consumed_stop = stop_callback.data
 
         resume_callback = get_callback(

--- a/sub-packages/bionemo-testing/src/bionemo/testing/harnesses/stop_and_go.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/harnesses/stop_and_go.py
@@ -356,18 +356,14 @@ class StopAndGoHarness(ABC):
 
     def test_train_val_init_consumed_samples(self):
         """Tests the initial consumed samples in stop-and-go scenario."""
-        stop_callback = get_callback(
+        train_consumed_stop, val_consumed_stop = get_callback(
             self.callbacks, Mode.STOP, testing_callbacks.TrainValInitConsumedSamplesStopAndGoCallback
-        )
-        print(stop_callback.data)
-        train_consumed_stop, val_consumed_stop = stop_callback.data
-
-        resume_callback = get_callback(
+        ).data
+        train_consumed_go, val_consumed_go = get_callback(
             self.callbacks, Mode.RESUME, testing_callbacks.TrainValInitConsumedSamplesStopAndGoCallback
-        )
-        train_consumed_resume, val_consumed_resume = resume_callback.data
+        ).data
 
         assert val_consumed_stop == 0
-        assert val_consumed_resume == 0
+        assert val_consumed_go == 0
         assert train_consumed_stop == 0
-        assert train_consumed_resume > 0
+        assert train_consumed_go > 0

--- a/sub-packages/bionemo-testing/src/bionemo/testing/harnesses/stop_and_go.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/harnesses/stop_and_go.py
@@ -356,22 +356,17 @@ class StopAndGoHarness(ABC):
 
     def test_train_val_init_consumed_samples(self):
         """Tests the initial consumed samples in stop-and-go scenario."""
-        train_consumed_stop, val_consumed_stop = get_callback(
+        stop_callback = get_callback(
             self.callbacks, Mode.STOP, testing_callbacks.TrainValInitConsumedSamplesStopAndGoCallback
-        ).data
-        train_consumed_go, val_consumed_go = get_callback(
+        )
+        train_consumed_stop, val_consumed_stop = stop_callback.data
+
+        resume_callback = get_callback(
             self.callbacks, Mode.RESUME, testing_callbacks.TrainValInitConsumedSamplesStopAndGoCallback
-        ).data
+        )
+        train_consumed_resume, val_consumed_resume = resume_callback.data
 
         assert val_consumed_stop == 0
-        assert val_consumed_go == 0
+        assert val_consumed_resume == 0
         assert train_consumed_stop == 0
-        assert train_consumed_go > 0
-
-    def test_identical_number_of_validation_batches(self):
-        """Ensures that the input tensors for training are identical for the interrupted and continuous tests."""
-        callback_type = testing_callbacks.ValidLossCallback
-        interrupted_callback = get_callback(self.callbacks, Mode.RESUME, callback_type)
-        continuous_callback = get_callback(self.callbacks, Mode.CONTINUOUS, callback_type)
-        assert interrupted_callback.data, f"No data found for {callback_type}"
-        assert len(interrupted_callback.data) == len(continuous_callback.data)
+        assert train_consumed_resume > 0

--- a/sub-packages/bionemo-testing/src/bionemo/testing/testing_callbacks.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/testing_callbacks.py
@@ -202,7 +202,6 @@ class ValidLossCallback(BaseInterruptedVsContinuousCallback):
     ) -> None:
         """Get consumed samples as metadata."""
         if step.trainer.validating:
-            print("In ValidLossCallback")
             self.data.append(recursive_detach(reduced))
 
 

--- a/sub-packages/bionemo-testing/src/bionemo/testing/testing_callbacks.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/testing_callbacks.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 
+import os
+import signal
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Union
 
@@ -29,8 +31,8 @@ from bionemo.testing.harnesses.mode import Mode
 from bionemo.testing.torch import recursive_detach
 
 
-class StopAfterValidEpochEndCallback(Callback):
-    """A callback that raises a StopAndGoException after the validation epoch.
+class StopAfterValidEpochEndCallback(Callback, CallbackMethods):
+    """A callback that stops training after the validation epoch.
 
     Use this callback for pytest based Stop and go tests.
     """
@@ -39,6 +41,28 @@ class StopAfterValidEpochEndCallback(Callback):
         if trainer.sanity_checking:
             return
         trainer.should_stop = True
+
+
+class SignalAfterGivenStepCallback(Callback, CallbackMethods):
+    """A callback that emits a given signal to the current process at the defined step.
+
+    Use this callback for pytest based Stop and go tests.
+    """
+
+    def __init__(self, stop_step: int, signal_: signal.Signals = signal.SIGUSR2):
+        """Initializes the callback with the given stop_step."""
+        self.stop_step = stop_step
+        self.signal = signal_
+
+    def on_megatron_step_end(
+        self,
+        step: MegatronStep,
+        microbatch_outputs: List[Any],
+        reduced: Optional[Union[torch.Tensor, Dict[str, torch.Tensor]]] = None,
+    ) -> None:
+        """Stop training if the global step is greater than or equal to the stop_step."""
+        if step.trainer.global_step >= self.stop_step:
+            os.kill(os.getpid(), self.signal)
 
 
 class BaseInterruptedVsContinuousCallback(Callback, CallbackMethods, io.IOMixin):
@@ -178,6 +202,7 @@ class ValidLossCallback(BaseInterruptedVsContinuousCallback):
     ) -> None:
         """Get consumed samples as metadata."""
         if step.trainer.validating:
+            print("In ValidLossCallback")
             self.data.append(recursive_detach(reduced))
 
 

--- a/sub-packages/bionemo-testing/src/bionemo/testing/testing_callbacks.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/testing_callbacks.py
@@ -54,15 +54,11 @@ class SignalAfterGivenStepCallback(Callback, CallbackMethods):
         self.stop_step = stop_step
         self.signal = signal_
 
-    def on_megatron_step_end(
-        self,
-        step: MegatronStep,
-        microbatch_outputs: List[Any],
-        reduced: Optional[Union[torch.Tensor, Dict[str, torch.Tensor]]] = None,
-    ) -> None:
+    def on_megatron_step_start(self, step: MegatronStep) -> MegatronStep:
         """Stop training if the global step is greater than or equal to the stop_step."""
         if step.trainer.global_step >= self.stop_step:
             os.kill(os.getpid(), self.signal)
+        return step
 
 
 class BaseInterruptedVsContinuousCallback(Callback, CallbackMethods, io.IOMixin):


### PR DESCRIPTION
Explicitly test that train inputs and outputs are consistent when we use PreemptionCallback to handle a training interrupt.
Currently it seems that doing this changes the validation step schedule, but otherwise training should be identical.


STOP OUTPUT:
```
Sanity checking Validation: iteration 1/2
Sanity checking Validation: iteration 2/2
Training epoch 0, iteration 0/9 | lr: 0 | global_batch_size: 2 | global_step: 0 | reduced_train_loss: 4.87
Training epoch 0, iteration 1/9 | lr: 2e-06 | global_batch_size: 2 | global_step: 1 | reduced_train_loss: 4.771 | consumed_samples: 4
[NeMo I 2024-12-02 19:12:44 preemption:87] Received signal 12, initiating graceful stop
[NeMo I 2024-12-02 19:12:44 preemption:67] Preemption detected, saving checkpoint and exiting
2024-12-02 19:12:44,487 _dedup_tensors.py:46 INFO p:MainProcess t:MainThread: Duplicate keys to remove: {}
```

RESUME OUTPUT:
```
Restored all states from the checkpoint at /tmp/tmpn8luhenb/TestESM2StopAndGoCheckpointNotAtValidation/checkpoints/epoch=0-step=2-val_loss=0.00-last/weights
Training epoch 0, iteration 3/9 | lr: 6e-06 | consumed_samples: 8 | global_batch_size: 2 | global_step: 3 | reduced_train_loss: 4.783
Training epoch 0, iteration 4/9 | lr: 8e-06 | consumed_samples: 10 | global_batch_size: 2 | global_step: 4 | reduced_train_loss: 4.785
Validation: iteration 1/2
Validation: iteration 2/2
2024-12-02 19:12:50,690 _dedup_tensors.py:46 INFO p:MainProcess t:MainThread: Duplicate keys to remove: {}
Training epoch 0, iteration 5/9 | lr: 1e-05 | consumed_samples: 12 | global_batch_size: 2 | global_step: 5 | reduced_train_loss: 4.672 | val_loss: 4.711
Training epoch 0, iteration 6/9 | lr: 1.2e-05 | consumed_samples: 14 | global_batch_size: 2 | global_step: 6 | reduced_train_loss: 4.7 | val_loss: 4.711
Training epoch 0, iteration 7/9 | lr: 1.4e-05 | consumed_samples: 16 | global_batch_size: 2 | global_step: 7 | reduced_train_loss: 4.621 | val_loss: 4.711
Training epoch 0, iteration 8/9 | lr: 1.6e-05 | consumed_samples: 18 | global_batch_size: 2 | global_step: 8 | reduced_train_loss: 4.532 | val_loss: 4.711
Validation: iteration 1/2
Validation: iteration 2/2
Training epoch 0, iteration 9/9 | lr: 1.8e-05 | consumed_samples: 20 | global_batch_size: 2 | global_step: 9 | reduced_train_loss: 4.497 | val_loss: 4.544
`Trainer.fit` stopped: `max_steps=10` reached.
```

CONTINUOUS OUTPUT:
```
Sanity checking Validation: iteration 1/2
Sanity checking Validation: iteration 2/2
Training epoch 0, iteration 0/9 | lr: 0 | global_batch_size: 2 | global_step: 0 | reduced_train_loss: 4.87
Training epoch 0, iteration 1/9 | lr: 2e-06 | global_batch_size: 2 | global_step: 1 | reduced_train_loss: 4.771 | consumed_samples: 4
Training epoch 0, iteration 2/9 | lr: 4e-06 | global_batch_size: 2 | global_step: 2 | reduced_train_loss: 4.87 | consumed_samples: 6
Training epoch 0, iteration 3/9 | lr: 6e-06 | global_batch_size: 2 | global_step: 3 | reduced_train_loss: 4.783 | consumed_samples: 8
Validation: iteration 1/2
Validation: iteration 2/2
Training epoch 0, iteration 4/9 | lr: 8e-06 | global_batch_size: 2 | global_step: 4 | reduced_train_loss: 4.785 | consumed_samples: 10 | val_loss: 4.758
Training epoch 0, iteration 5/9 | lr: 1e-05 | global_batch_size: 2 | global_step: 5 | reduced_train_loss: 4.672 | consumed_samples: 12 | val_loss: 4.758
Training epoch 0, iteration 6/9 | lr: 1.2e-05 | global_batch_size: 2 | global_step: 6 | reduced_train_loss: 4.7 | consumed_samples: 14 | val_loss: 4.758
Training epoch 0, iteration 7/9 | lr: 1.4e-05 | global_batch_size: 2 | global_step: 7 | reduced_train_loss: 4.621 | consumed_samples: 16 | val_loss: 4.758
Validation: iteration 1/2
Validation: iteration 2/2
Training epoch 0, iteration 8/9 | lr: 1.6e-05 | global_batch_size: 2 | global_step: 8 | reduced_train_loss: 4.532 | consumed_samples: 18 | val_loss: 4.573
Training epoch 0, iteration 9/9 | lr: 1.8e-05 | global_batch_size: 2 | global_step: 9 | reduced_train_loss: 4.497 | consumed_samples: 20 | val_loss: 4.573
Validation: iteration 1/2
Validation: iteration 2/2
`Trainer.fit` stopped: `max_steps=10` reached.


```