### PR TITLE
Disable validation/test stages in ESM-2 and Geneformer

### DIFF
--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/data/datamodule.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/data/datamodule.py
@@ -158,7 +158,6 @@ class ESMDataModule(MegatronDataModule):
         val_clusters = dataset.create_valid_clusters(self._valid_cluster_path)
         if self.trainer.limit_val_batches == 0.0:  # disable validation
             logging.info("Skip creating validation dataset because trainer.limit_val_batches=0.")
-            self._valid_ds = None
         else:
             num_val_samples = infer_num_samples(
                 limit_batches=self.trainer.limit_val_batches,

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/data/datamodule.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/data/datamodule.py
@@ -156,24 +156,28 @@ class ESMDataModule(MegatronDataModule):
 
         # Create validation dataset
         val_clusters = dataset.create_valid_clusters(self._valid_cluster_path)
-        num_val_samples = infer_num_samples(
-            limit_batches=self.trainer.limit_val_batches,
-            num_samples_in_dataset=len(val_clusters),
-            global_batch_size=self.data_sampler.global_batch_size,
-            stage="val",
-        )
-        self._valid_ds = dataset.create_valid_dataset(
-            clusters=self._valid_cluster_path,
-            db_path=self._valid_database_path,
-            total_samples=num_val_samples,
-            seed=self._seed,
-            max_seq_length=self._max_seq_length,
-            mask_prob=self._mask_prob,
-            mask_token_prob=self._mask_token_prob,
-            mask_random_prob=self._mask_random_prob,
-            random_mask_strategy=self._random_mask_strategy,
-            tokenizer=self._tokenizer,
-        )
+        if self.trainer.limit_val_batches == 0.0:  # disable validation
+            logging.warning("Skip creating validation dataset because trainer.limit_val_batches=0.")
+            self._valid_ds = None
+        else:
+            num_val_samples = infer_num_samples(
+                limit_batches=self.trainer.limit_val_batches,
+                num_samples_in_dataset=len(val_clusters),
+                global_batch_size=self.data_sampler.global_batch_size,
+                stage="val",
+            )
+            self._valid_ds = dataset.create_valid_dataset(
+                clusters=self._valid_cluster_path,
+                db_path=self._valid_database_path,
+                total_samples=num_val_samples,
+                seed=self._seed,
+                max_seq_length=self._max_seq_length,
+                mask_prob=self._mask_prob,
+                mask_token_prob=self._mask_token_prob,
+                mask_random_prob=self._mask_random_prob,
+                random_mask_strategy=self._random_mask_strategy,
+                tokenizer=self._tokenizer,
+            )
 
         assert (
             hasattr(self, "trainer") and self.trainer is not None

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/data/datamodule.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/data/datamodule.py
@@ -156,7 +156,7 @@ class ESMDataModule(MegatronDataModule):
 
         # Create validation dataset
         val_clusters = dataset.create_valid_clusters(self._valid_cluster_path)
-        if self.trainer.limit_val_batches == 0.0:  # disable validation
+        if self.trainer.limit_val_batches == 0:  # disable validation
             logging.info("Skip creating validation dataset because trainer.limit_val_batches=0.")
         else:
             num_val_samples = infer_num_samples(

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/data/datamodule.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/data/datamodule.py
@@ -157,7 +157,7 @@ class ESMDataModule(MegatronDataModule):
         # Create validation dataset
         val_clusters = dataset.create_valid_clusters(self._valid_cluster_path)
         if self.trainer.limit_val_batches == 0.0:  # disable validation
-            logging.warning("Skip creating validation dataset because trainer.limit_val_batches=0.")
+            logging.info("Skip creating validation dataset because trainer.limit_val_batches=0.")
             self._valid_ds = None
         else:
             num_val_samples = infer_num_samples(

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/model/finetune/datamodule.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/model/finetune/datamodule.py
@@ -228,7 +228,7 @@ class ESM2FineTuneDataModule(MegatronDataModule):
             self._train_ds = self._create_epoch_based_dataset(self.train_dataset, num_train_samples)
 
         # Create validation dataset
-        if self.valid_dataset is not None and self.trainer.limit_val_batches > 0.0:
+        if self.valid_dataset is not None and self.trainer.limit_val_batches != 0.:
             num_val_samples = infer_num_samples(
                 limit_batches=self.trainer.limit_val_batches,
                 num_samples_in_dataset=len(self.valid_dataset),

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/model/finetune/datamodule.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/model/finetune/datamodule.py
@@ -228,7 +228,7 @@ class ESM2FineTuneDataModule(MegatronDataModule):
             self._train_ds = self._create_epoch_based_dataset(self.train_dataset, num_train_samples)
 
         # Create validation dataset
-        if self.valid_dataset is not None and self.trainer.limit_val_batches != 0.:
+        if self.valid_dataset is not None and self.trainer.limit_val_batches != 0:
             num_val_samples = infer_num_samples(
                 limit_batches=self.trainer.limit_val_batches,
                 num_samples_in_dataset=len(self.valid_dataset),

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/model/finetune/datamodule.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/model/finetune/datamodule.py
@@ -228,7 +228,7 @@ class ESM2FineTuneDataModule(MegatronDataModule):
             self._train_ds = self._create_epoch_based_dataset(self.train_dataset, num_train_samples)
 
         # Create validation dataset
-        if self.valid_dataset is not None and self.trainer.limit_val_batches > 0.:
+        if self.valid_dataset is not None and self.trainer.limit_val_batches > 0.0:
             num_val_samples = infer_num_samples(
                 limit_batches=self.trainer.limit_val_batches,
                 num_samples_in_dataset=len(self.valid_dataset),

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/model/finetune/datamodule.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/model/finetune/datamodule.py
@@ -228,7 +228,7 @@ class ESM2FineTuneDataModule(MegatronDataModule):
             self._train_ds = self._create_epoch_based_dataset(self.train_dataset, num_train_samples)
 
         # Create validation dataset
-        if self.valid_dataset is not None:
+        if self.valid_dataset is not None and self.trainer.limit_val_batches > 0.:
             num_val_samples = infer_num_samples(
                 limit_batches=self.trainer.limit_val_batches,
                 num_samples_in_dataset=len(self.valid_dataset),

--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/data/test_datamodule.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/data/test_datamodule.py
@@ -174,35 +174,6 @@ def test_create_esm_datamodule_creates_valid_dataloaders_fractional_limit_val_ba
         data_module.setup()
 
 
-@pytest.mark.parametrize("limit_val_batches", [0, 0.0])
-def test_create_esm_datamodule_creates_valid_dataloaders_fractional_limit_val_batches_0(
-    dummy_protein_dataset, dummy_parquet_train_val_inputs, limit_val_batches
-):
-    train_cluster_path, valid_cluster_path = dummy_parquet_train_val_inputs
-
-    # Initialize the data module.
-    data_module = ESMDataModule(
-        train_cluster_path=train_cluster_path,
-        train_database_path=dummy_protein_dataset,
-        valid_cluster_path=valid_cluster_path,
-        valid_database_path=dummy_protein_dataset,
-        global_batch_size=8,
-        micro_batch_size=4,
-        min_seq_length=36,
-        max_seq_length=36,
-    )
-    assert data_module is not None
-
-    data_module.trainer = mock.Mock()
-    data_module.trainer.max_epochs = 1
-    data_module.trainer.max_steps = 10
-    data_module.trainer.val_check_interval = 2
-    data_module.trainer.limit_val_batches = limit_val_batches
-
-    with pytest.raises(ValueError, match="Invalid choice of limit_val_batches size: %s" % limit_val_batches):
-        data_module.setup()
-
-
 def test_create_esm_datamodule_creates_valid_dataloaders_fractional_limit_val_batches_not_multiple_of_global_batch_size(
     dummy_protein_dataset, dummy_parquet_train_val_inputs
 ):

--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/scripts/test_train_esm2.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/scripts/test_train_esm2.py
@@ -137,7 +137,7 @@ def test_main_runs(monkeypatch, tmpdir, dummy_protein_dataset, dummy_parquet_tra
     ).is_file(), "Could not find experiment log."
 
 
-@pytest.mark.parametrize("limit_val_batches", [1.0, 4, None])
+@pytest.mark.parametrize("limit_val_batches", [0., 1.0, 4, None])
 def test_val_dataloader_in_main_runs_with_limit_val_batches(
     monkeypatch, tmpdir, dummy_protein_dataset, dummy_parquet_train_val_inputs, limit_val_batches
 ):

--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/scripts/test_train_esm2.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/scripts/test_train_esm2.py
@@ -137,7 +137,7 @@ def test_main_runs(monkeypatch, tmpdir, dummy_protein_dataset, dummy_parquet_tra
     ).is_file(), "Could not find experiment log."
 
 
-@pytest.mark.parametrize("limit_val_batches", [0., 1.0, 4, None])
+@pytest.mark.parametrize("limit_val_batches", [0.0, 1.0, 4, None])
 def test_val_dataloader_in_main_runs_with_limit_val_batches(
     monkeypatch, tmpdir, dummy_protein_dataset, dummy_parquet_train_val_inputs, limit_val_batches
 ):

--- a/sub-packages/bionemo-geneformer/src/bionemo/geneformer/data/singlecell/datamodule.py
+++ b/sub-packages/bionemo-geneformer/src/bionemo/geneformer/data/singlecell/datamodule.py
@@ -193,18 +193,6 @@ class SingleCellDataModule(MegatronDataModule):
             assert max_train_steps > 0, "Please specify trainer.max_steps"
 
             num_train_samples = int(max_train_steps * self.data_sampler.global_batch_size)
-            num_val_samples = infer_num_samples(
-                limit_batches=self.trainer.limit_val_batches,
-                num_samples_in_dataset=len(self._val_dataset_ori),
-                global_batch_size=self.data_sampler.global_batch_size,
-                stage="val",
-            )
-            num_test_samples = infer_num_samples(
-                limit_batches=self.trainer.limit_test_batches,
-                num_samples_in_dataset=len(self._test_dataset_ori),
-                global_batch_size=self.data_sampler.global_batch_size,
-                stage="test",
-            )
 
             # This happens exactly once during setup.
             self._train_ds = MultiEpochDatasetResampler(
@@ -213,18 +201,38 @@ class SingleCellDataModule(MegatronDataModule):
                 shuffle=True,
                 seed=self.seed,
             )
-            self._validation_ds = MultiEpochDatasetResampler(
-                self._val_dataset_ori,
-                num_samples=num_val_samples,
-                shuffle=False,
-                seed=self.seed,
-            )
-            self._test_ds = MultiEpochDatasetResampler(
-                self._test_dataset_ori,
-                num_samples=num_test_samples,
-                shuffle=False,
-                seed=self.seed,
-            )
+            if self.trainer.limit_val_batches == 0.0:  # disable validation
+                logging.warning("Skip creating validation dataset because trainer.limit_val_batches=0.")
+                self._validation_ds = None
+            else:
+                num_val_samples = infer_num_samples(
+                    limit_batches=self.trainer.limit_val_batches,
+                    num_samples_in_dataset=len(self._val_dataset_ori),
+                    global_batch_size=self.data_sampler.global_batch_size,
+                    stage="val",
+                )
+                self._validation_ds = MultiEpochDatasetResampler(
+                    self._val_dataset_ori,
+                    num_samples=num_val_samples,
+                    shuffle=False,
+                    seed=self.seed,
+                )
+            if self.trainer.limit_test_batches == 0.0:  # disable testing
+                logging.warning("Skip creating test dataset because trainer.limit_test_batches=0.")
+                self._test_ds = None
+            else:
+                num_test_samples = infer_num_samples(
+                    limit_batches=self.trainer.limit_test_batches,
+                    num_samples_in_dataset=len(self._test_dataset_ori),
+                    global_batch_size=self.data_sampler.global_batch_size,
+                    stage="test",
+                )
+                self._test_ds = MultiEpochDatasetResampler(
+                    self._test_dataset_ori,
+                    num_samples=num_test_samples,
+                    shuffle=False,
+                    seed=self.seed,
+                )
         else:
             assert self._predict_dataset_ori is not None
             self._predict_ds = MultiEpochDatasetResampler(

--- a/sub-packages/bionemo-geneformer/src/bionemo/geneformer/data/singlecell/datamodule.py
+++ b/sub-packages/bionemo-geneformer/src/bionemo/geneformer/data/singlecell/datamodule.py
@@ -201,7 +201,7 @@ class SingleCellDataModule(MegatronDataModule):
                 shuffle=True,
                 seed=self.seed,
             )
-            if self.trainer.limit_val_batches == 0.0:  # disable validation
+            if self.trainer.limit_val_batches == 0:  # disable validation
                 logging.info("Skip creating validation dataset because trainer.limit_val_batches=0.")
             else:
                 num_val_samples = infer_num_samples(
@@ -216,7 +216,7 @@ class SingleCellDataModule(MegatronDataModule):
                     shuffle=False,
                     seed=self.seed,
                 )
-            if self.trainer.limit_test_batches == 0.0:  # disable testing
+            if self.trainer.limit_test_batches == 0:  # disable testing
                 logging.info("Skip creating test dataset because trainer.limit_test_batches=0.")
 
             else:

--- a/sub-packages/bionemo-geneformer/src/bionemo/geneformer/data/singlecell/datamodule.py
+++ b/sub-packages/bionemo-geneformer/src/bionemo/geneformer/data/singlecell/datamodule.py
@@ -202,7 +202,7 @@ class SingleCellDataModule(MegatronDataModule):
                 seed=self.seed,
             )
             if self.trainer.limit_val_batches == 0.0:  # disable validation
-                logging.warning("Skip creating validation dataset because trainer.limit_val_batches=0.")
+                logging.info("Skip creating validation dataset because trainer.limit_val_batches=0.")
                 self._validation_ds = None
             else:
                 num_val_samples = infer_num_samples(
@@ -218,8 +218,8 @@ class SingleCellDataModule(MegatronDataModule):
                     seed=self.seed,
                 )
             if self.trainer.limit_test_batches == 0.0:  # disable testing
-                logging.warning("Skip creating test dataset because trainer.limit_test_batches=0.")
-                self._test_ds = None
+                logging.info("Skip creating test dataset because trainer.limit_test_batches=0.")
+
             else:
                 num_test_samples = infer_num_samples(
                     limit_batches=self.trainer.limit_test_batches,

--- a/sub-packages/bionemo-geneformer/src/bionemo/geneformer/data/singlecell/datamodule.py
+++ b/sub-packages/bionemo-geneformer/src/bionemo/geneformer/data/singlecell/datamodule.py
@@ -203,7 +203,6 @@ class SingleCellDataModule(MegatronDataModule):
             )
             if self.trainer.limit_val_batches == 0.0:  # disable validation
                 logging.info("Skip creating validation dataset because trainer.limit_val_batches=0.")
-                self._validation_ds = None
             else:
                 num_val_samples = infer_num_samples(
                     limit_batches=self.trainer.limit_val_batches,

--- a/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/scripts/test_train_geneformer.py
+++ b/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/scripts/test_train_geneformer.py
@@ -46,12 +46,16 @@ def test_val_dataloader_in_main_runs_with_limit_val_batches(tmpdir, limit_val_ba
             data_dir=data_path,
             num_nodes=1,
             devices=1,
-            seq_length=128,
+            seq_length=8,
             result_dir=result_dir,
             wandb_project=None,
             wandb_offline=True,
             num_steps=5,
+<<<<<<< HEAD
             limit_val_batches=1,
+=======
+            limit_val_batches=limit_val_batches,
+>>>>>>> c7291696a (reduce geneformer e2e test burden)
             val_check_interval=2,
             num_dataset_workers=0,
             biobert_spec_option=BiobertSpecOption.bert_layer_local_spec,

--- a/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/scripts/test_train_geneformer.py
+++ b/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/scripts/test_train_geneformer.py
@@ -46,7 +46,7 @@ def test_val_dataloader_in_main_runs_with_limit_val_batches(tmpdir, limit_val_ba
             data_dir=data_path,
             num_nodes=1,
             devices=1,
-            seq_length=8,
+            seq_length=128,
             result_dir=result_dir,
             wandb_project=None,
             wandb_offline=True,

--- a/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/scripts/test_train_geneformer.py
+++ b/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/scripts/test_train_geneformer.py
@@ -51,11 +51,7 @@ def test_val_dataloader_in_main_runs_with_limit_val_batches(tmpdir, limit_val_ba
             wandb_project=None,
             wandb_offline=True,
             num_steps=5,
-<<<<<<< HEAD
-            limit_val_batches=1,
-=======
             limit_val_batches=limit_val_batches,
->>>>>>> c7291696a (reduce geneformer e2e test burden)
             val_check_interval=2,
             num_dataset_workers=0,
             biobert_spec_option=BiobertSpecOption.bert_layer_local_spec,

--- a/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/scripts/test_train_geneformer.py
+++ b/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/scripts/test_train_geneformer.py
@@ -37,7 +37,8 @@ def test_bionemo2_rootdir():
     assert data_path.is_dir(), "Test data directory is supposed to be a directory."
 
 
-def test_main_runs(tmpdir):
+@pytest.mark.parametrize("limit_val_batches", [0.0, 1])
+def test_val_dataloader_in_main_runs_with_limit_val_batches(tmpdir, limit_val_batches: float):
     result_dir = Path(tmpdir.mkdir("results"))
 
     with megatron_parallel_state_utils.distributed_model_parallel_state():

--- a/sub-packages/bionemo-llm/src/bionemo/llm/utils/datamodule_utils.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/utils/datamodule_utils.py
@@ -137,7 +137,7 @@ def infer_num_samples(
 
     If limit_batches is a float between 0 and 1, the number of samples is inferred as a fraction of the number of samples
     in the dataset. If limit_batches is an integer greater than or equal to 1, the number of limited samples is inferred
-    as the product of limit_batches and global batch size. If limit_batches is None, it defaultsto 1.0, indicating that
+    as the product of limit_batches and global batch size. If limit_batches is None, it defaults to 1.0, indicating that
     all dataset samples should be used.
     """
     limit_batches = 1.0 if limit_batches is None else limit_batches  # validation data does not require upsampling


### PR DESCRIPTION
## Summary
Allow `--limit-val-batches=0.` to disable validation. Same applies for testing in geneformer.

## Details
Previously validation dataset cannot be created when `limit_val_batches = 0.`. Now this is caught and the validation dataset is set to `None`. Same applies to test dataset.

## Tests
Implemented in `sub-packages/bionemo-geneformer/tests/bionemo/esm2/scripts/test_train_esm2.py::test_val_dataloader_in_main_runs_with_limit_val_batches` and that in geneformer.

## Out of scope
- The e2e test function only test whether it runs. It does not test whether validation is actually skipped.
- Currently there is no testing on finetuning.