### PR TITLE
[QA Bug] Remove NGC dependency 

### DIFF
--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/model/finetune/train.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/model/finetune/train.py
@@ -175,7 +175,7 @@ if __name__ == "__main__":
     seed = 42
 
     # To download a 650M pre-trained ESM2 model
-    pretrain_ckpt_path = load("esm2/650m:2.0", source="ngc")
+    pretrain_ckpt_path = load("esm2/650m:2.0")
 
     config = ESM2FineTuneSeqConfig(initial_ckpt_path=str(pretrain_ckpt_path))
 


### PR DESCRIPTION
This allows the checkpoint to be optionally downloaded from PBSS for QA testing.

This is a temporary solution to unblock QA - this example will be deprecated in the next release