### PR TITLE
change source for coverage report

### DIFF
--- a/ci/scripts/run_pytest.sh
+++ b/ci/scripts/run_pytest.sh
@@ -33,4 +33,4 @@ for dir in docs/ ./sub-packages/bionemo-*/; do
 done
 
 python -m coverage combine
-python -m coverage report -m
+python -m coverage report --show-missing

--- a/ci/scripts/run_pytest.sh
+++ b/ci/scripts/run_pytest.sh
@@ -29,8 +29,8 @@ python -m coverage erase
 
 for dir in docs/ ./sub-packages/bionemo-*/; do
     echo "Running pytest in $dir"
-    python -m coverage run --parallel-mode --source sub-packages/ -m pytest -v --nbval-lax $dir
+    python -m coverage run --parallel-mode --source bionemo -m pytest -v --nbval-lax $dir
 done
 
 python -m coverage combine
-python -m coverage report
+python -m coverage report -m


### PR DESCRIPTION
Corrects the `source` field for the coverage report, prints out which lines are missed.