### PR TITLE
Implement megatron-aware perplexity in torchmetrics

### DIFF
--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -30,7 +30,6 @@ from bionemo.esm2.api import ESM2Config
 from bionemo.esm2.data.datamodule import ESMDataModule
 from bionemo.esm2.data.dataset import RandomMaskStrategy
 from bionemo.esm2.data.tokenizer import get_tokenizer
-from bionemo.llm.lightning import PerplexityLoggingCallback
 from bionemo.llm.model.biobert.lightning import biobert_lightning_module
 from bionemo.llm.model.biobert.model import BiobertSpecOption
 from bionemo.llm.model.lr_scheduler import WarmupAnnealDecayHoldScheduler

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -221,7 +221,12 @@ def main(
         log_every_n_steps=log_every_n_steps,
         num_nodes=num_nodes,
         callbacks=callbacks,
-        plugins=nl.MegatronMixedPrecision(precision=precision),
+        plugins=nl.MegatronMixedPrecision(
+            precision=precision,
+            params_dtype=get_autocast_dtype(precision),
+            pipeline_dtype=get_autocast_dtype(precision),
+            autocast_enabled=False,
+        ),
     )
 
     tokenizer = get_tokenizer()

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -179,7 +179,7 @@ def main(
         find_unused_parameters=True,
         gradient_as_bucket_view=True,
         ckpt_include_optimizer=True,
-        ckpt_async_save=True,
+        ckpt_async_save=False,  # TODO turn off due to error: Invalid access pattern: 1 ShardedObject are missing.
         ckpt_parallel_load=True,
     )
 

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -217,13 +217,7 @@ def main(
         log_every_n_steps=log_every_n_steps,
         num_nodes=num_nodes,
         callbacks=callbacks,
-        plugins=nl.MegatronMixedPrecision(
-            precision=precision,
-            params_dtype=get_autocast_dtype(precision),
-            pipeline_dtype=get_autocast_dtype(precision),
-            grad_reduce_in_fp32=False,
-            autocast_enabled=False,
-        ),
+        plugins=nl.MegatronMixedPrecision(precision=precision),
     )
 
     tokenizer = get_tokenizer()

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -225,6 +225,7 @@ def main(
             precision=precision,
             params_dtype=get_autocast_dtype(precision),
             pipeline_dtype=get_autocast_dtype(precision),
+            grad_reduce_in_fp32=False,
             autocast_enabled=False,
         ),
     )

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -286,6 +286,9 @@ def main(
                 anneal_percentage=0.10,
             ),
         ),
+        # perplexity logging
+        log_train_ppl=False,
+        log_val_ppl=True,
     )
 
     # Configure our custom Checkpointer

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -598,7 +598,7 @@ def get_parser():
     parser.add_argument(
         "--log-train-ppl",
         action="store_true",
-        default=True,
+        default=False,
         help="Log perplexity during training.",
     )
     parser.add_argument(

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -82,6 +82,8 @@ def main(
     save_best_checkpoint: bool = True,
     save_last_checkpoint: bool = True,
     metric_to_monitor_for_checkpoints: str = "val_loss",
+    log_train_ppl: bool = False,
+    log_val_ppl: bool = True,
     save_top_k: int = 2,
     nsys_profiling: bool = False,
     nsys_start_step: int = 0,
@@ -137,6 +139,8 @@ def main(
         save_best_checkpoint (bool): whether to save the best checkpoint
         save_last_checkpoint (bool): whether to save the last checkpoint
         metric_to_monitor_for_checkpoints (str): metric to monitor for checkpoints
+        log_train_ppl (bool): log training perplexity
+        log_val_ppl (bool): log validation perplexity
         save_top_k (int): number of top checkpoints to save
         nsys_profiling (bool): whether to enable nsys profiling
         nsys_start_step (int): start step for nsys profiling
@@ -287,8 +291,8 @@ def main(
             ),
         ),
         # perplexity logging
-        log_train_ppl=False,
-        log_val_ppl=True,
+        log_train_ppl=log_train_ppl,
+        log_val_ppl=log_val_ppl,
     )
 
     # Configure our custom Checkpointer
@@ -367,6 +371,8 @@ def train_esm2_entrypoint():
         save_best_checkpoint=args.save_best_checkpoint,
         save_last_checkpoint=args.save_last_checkpoint,
         metric_to_monitor_for_checkpoints=args.metric_to_monitor_for_checkpoints,
+        log_train_ppl=args.log_train_ppl,
+        log_val_ppl=args.log_val_ppl,
         save_top_k=args.save_top_k,
         nsys_profiling=args.nsys_profiling,
         nsys_start_step=args.nsys_start_step,
@@ -602,6 +608,25 @@ def get_parser():
         required=False,
         default="val_loss",
         help="The metric to monitor for checkpointing.",
+    )
+    parser.add_argument(
+        "--log-train-ppl",
+        action="store_true",
+        default=True,
+        help="Log perplexity during training.",
+    )
+    parser.add_argument(
+        "--log-val-ppl",
+        action="store_true",
+        default=False,
+        help="Log perplexity during validation.",
+    )
+    parser.add_argument(
+        "--no-log-val-ppl",
+        action="store_false",
+        dest="log_val_ppl",
+        default=True,
+        help="Disable logging perplexity during validation.",
     )
     parser.add_argument(
         "--save-top-k",

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from typing import List, Optional, Sequence, get_args
 
 from lightning.pytorch.callbacks import LearningRateMonitor, RichModelSummary
-from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.optimizer import OptimizerConfig
 from nemo import lightning as nl
 from nemo.collections import llm
@@ -168,18 +167,11 @@ def main(
     strategy = nl.MegatronStrategy(
         tensor_model_parallel_size=tensor_model_parallel_size,
         pipeline_model_parallel_size=pipeline_model_parallel_size,
-        pipeline_dtype=get_autocast_dtype(precision),
-        ddp=DistributedDataParallelConfig(
-            check_for_nan_in_grad=True,
-            overlap_grad_reduce=True,
-            overlap_param_gather=True,
-            average_in_collective=True,
-            use_distributed_optimizer=True,
-        ),
+        ddp="megatron",
         find_unused_parameters=True,
-        gradient_as_bucket_view=True,
         ckpt_include_optimizer=True,
-        ckpt_async_save=False,  # TODO turn off due to error: Invalid access pattern: 1 ShardedObject are missing.
+        # NOTE: there are issues related to async that may occur, most recently observed due to duplicate filenames.
+        ckpt_async_save=True,
         ckpt_parallel_load=True,
     )
 

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -255,6 +255,9 @@ def main(
     if scheduler_num_steps is None:
         scheduler_num_steps = num_steps
 
+    if (log_train_ppl or log_val_ppl) and pipeline_model_parallel_size > 1:
+        raise NotImplementedError("Perplexity logging does not support pipeline parallelism yet.")
+
     model = biobert_lightning_module(
         esm2_config,
         tokenizer=tokenizer,

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import List, Optional, Sequence, get_args
 
 from lightning.pytorch.callbacks import LearningRateMonitor, RichModelSummary
+from megatron.core.distributed.distributed_data_parallel_config import DistributedDataParallelConfig
 from megatron.core.optimizer import OptimizerConfig
 from nemo import lightning as nl
 from nemo.collections import llm
@@ -163,10 +164,17 @@ def main(
     strategy = nl.MegatronStrategy(
         tensor_model_parallel_size=tensor_model_parallel_size,
         pipeline_model_parallel_size=pipeline_model_parallel_size,
-        ddp="megatron",
+        pipeline_dtype=get_autocast_dtype(precision),
+        ddp=DistributedDataParallelConfig(
+            check_for_nan_in_grad=True,
+            overlap_grad_reduce=True,
+            overlap_param_gather=True,
+            average_in_collective=True,
+            use_distributed_optimizer=True,
+        ),
         find_unused_parameters=True,
+        gradient_as_bucket_view=True,
         ckpt_include_optimizer=True,
-        # NOTE: there are issues related to async that may occur, most recently observed due to duplicate filenames.
         ckpt_async_save=True,
         ckpt_parallel_load=True,
     )

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -193,7 +193,6 @@ def main(
     )
 
     callbacks = [
-        PerplexityLoggingCallback(log_train=False, log_val=True),
         RichModelSummary(max_depth=4),
         LearningRateMonitor(),
         nl_callbacks.PreemptionCallback(),

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import List, Optional, Sequence, get_args
 
 from lightning.pytorch.callbacks import LearningRateMonitor, RichModelSummary
-from megatron.core.distributed.distributed_data_parallel_config import DistributedDataParallelConfig
+from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.optimizer import OptimizerConfig
 from nemo import lightning as nl
 from nemo.collections import llm

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -293,9 +293,6 @@ class BionemoLightningModule(
         # all scaling on the internal states are cancelled out in the formula "exp(total_log_probs / count)" so we can safely sum across all devices
         self.log_train_ppl = log_train_ppl
         self.log_val_ppl = log_val_ppl
-        if (log_train_ppl or log_val_ppl) and self.trainer.strategy.pipeline_model_parallel_size > 1:
-            raise NotImplementedError("Perplexity logging does not support pipeline parallelism yet.")
-
         if log_train_ppl:
             self.train_ppl = MegatronPerplexityMetric(ignore_index=-100)
         if log_val_ppl:

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -351,6 +351,8 @@ class BionemoLightningModule(
             self.train_ppl(logits, batch["labels"])
             self.log("train_ppl", self.train_ppl, on_step=True, on_epoch=False)
 
+        return outputs
+
     def validation_step(self, batch, batch_idx: Optional[int] = None) -> Tensor:
         """In mcore the loss-function is part of the forward-pass when labels are provided."""
         outputs = self.forward_step(batch)
@@ -359,6 +361,8 @@ class BionemoLightningModule(
         if self.log_val_ppl and parallel_state.is_pipeline_last_stage():
             self.valid_ppl(logits, batch["labels"])
             self.log("valid_ppl", self.valid_ppl, on_step=False, on_epoch=True)
+
+        return outputs
 
     def predict_step(self, batch, batch_idx: Optional[int] = None) -> Tensor:
         """Alias for forward_step."""

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -291,6 +291,8 @@ class BionemoLightningModule(
         self.model_transform = model_transform
 
         # all scaling on the internal states are cancelled out in the formula "exp(total_log_probs / count)" so we can safely sum across all devices
+        self.log_train_ppl = log_train_ppl
+        self.log_val_ppl = log_val_ppl
         if log_train_ppl:
             self.train_ppl = MegatronPerplexityMetric(ignore_index=-100)
         if log_val_ppl:

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -292,7 +292,7 @@ class BionemoLightningModule(
         self._forward_step = forward_step
         self.model_transform = model_transform
 
-        process_group = parallel_state.get_data_parallel_group()  # TODO how to select only the last pp stage?
+        process_group = parallel_state.get_data_parallel_group()  # TODO only as a placeholder: how to select only the last pp stage?
         if log_train_ppl:
             self.train_ppl = MegatronPerplexityMetric(
                 ignore_index=-100,

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -214,7 +214,7 @@ of the examples in the iterator.
 class MegatronPerplexityMetric(torchmetrics.text.Perplexity):
     def __init__(self, *args, **kwargs):
         if parallel_state.get_context_parallel_world_size() > 1:
-            raise NotImplementedError(f"{__class__} does not support context parallelism yet.")
+            raise NotImplementedError(f"{self.__class__} does not support context parallelism yet.")
 
         self.cross_entropy_loss_fusion = kwargs.pop("cross_entropy_loss_fusion", False)
         super().__init__(*args, **kwargs)

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -237,6 +237,7 @@ class MegatronPerplexityMetric(torchmetrics.text.Perplexity):
 
         self.total_log_probs += unreduced_token_loss.sum()
         self.count += mask.sum()
+        # the numerator and denominator cancels tp out in the formulae "exp(total_log_probs / count)"
 
 
 class BionemoLightningModule(
@@ -291,7 +292,6 @@ class BionemoLightningModule(
         self._forward_step = forward_step
         self.model_transform = model_transform
 
-        # TODO normalize sum aggregation with TP
         process_group = parallel_state.get_data_parallel_group()  # TODO how to select only the last pp stage?
         if log_train_ppl:
             self.train_ppl = MegatronPerplexityMetric(

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -293,6 +293,9 @@ class BionemoLightningModule(
         # all scaling on the internal states are cancelled out in the formula "exp(total_log_probs / count)" so we can safely sum across all devices
         self.log_train_ppl = log_train_ppl
         self.log_val_ppl = log_val_ppl
+        if (log_train_ppl or log_val_ppl) and self.trainer.strategy.pipeline_model_parallel_size > 1:
+            raise NotImplementedError("Perplexity logging does not support pipeline parallelism yet.")
+
         if log_train_ppl:
             self.train_ppl = MegatronPerplexityMetric(ignore_index=-100)
         if log_val_ppl:

--- a/sub-packages/bionemo-llm/tests/bionemo/llm/test_lightning.py
+++ b/sub-packages/bionemo-llm/tests/bionemo/llm/test_lightning.py
@@ -24,7 +24,7 @@ from torch import nn
 from torchmetrics.text import Perplexity
 
 from bionemo.llm import lightning as bnptl
-from bionemo.llm.lightning import PerplexityLoggingCallback, batch_collator, get_dtype_device
+from bionemo.llm.lightning import PerplexityLoggingCallback, batch_collator, get_dtype_device, MegatronPerplexityMetric
 from bionemo.testing import megatron_parallel_state_utils
 from bionemo.testing.lightning import get_random_microbatch
 
@@ -185,6 +185,43 @@ def test_mixin_strategy_contract_get_loss_reduction():
         strategy_reduction_function = strategy._get_loss_reduction("predict")
         assert isinstance(strategy_reduction_function(mixin), bnptl.PassthroughLossReduction)
 
+
+def test_megatron_perplexity_metric_with_single_microbatch_golden_value_without_parallelism(seed: int = 42):
+    """Test PerplexityLoggingCallback with a single microbatch without parallelism"""
+    with megatron_parallel_state_utils.distributed_model_parallel_state(seed=seed):
+        # setup test input
+        microbatch_size, max_sequence_length, vocab_size = 1, 1024, 2
+        microbatch_outputs = [get_random_microbatch(microbatch_size, max_sequence_length, vocab_size, seed)]
+        num_microbatches = len(microbatch_outputs)
+
+        # setup mock objects
+        mock_megatron_step = mock.MagicMock()
+        mock_megatron_step.pl_module.log.return_value = None
+        mock_megatron_step.trainer.training = False
+        mock_megatron_step.trainer.sanity_checking = False
+        mock_megatron_step.num_microbatches = num_microbatches
+
+        # setup metric
+        megatron_ppl_metric = MegatronPerplexityMetric(ignore_index=-100)
+
+        # compare to torchmetric
+        metric = Perplexity(ignore_index=-100).to(torch.cuda.current_device())
+        for microbatch_output in microbatch_outputs:
+            megatron_ppl_metric.update(
+                microbatch_output["forward_out"]["token_logits"].transpose(0, 1).contiguous(),
+                microbatch_output["batch"]["labels"],
+            )
+            metric.update(
+                microbatch_output["forward_out"]["token_logits"].transpose(0, 1).contiguous(),
+                microbatch_output["batch"]["labels"],
+            )
+        ppl_value = megatron_ppl_metric.compute()
+        ppl_golden_value = metric.compute()
+
+        torch.testing.assert_close(
+            ppl_value,
+            ppl_golden_value,
+        )
 
 def test_perplexity_logging_callback_with_single_microbatch_golden_value_without_parallelism(seed: int = 42):
     """Test PerplexityLoggingCallback with a single microbatch without parallelism"""

--- a/sub-packages/bionemo-llm/tests/bionemo/llm/test_lightning.py
+++ b/sub-packages/bionemo-llm/tests/bionemo/llm/test_lightning.py
@@ -202,10 +202,10 @@ def test_megatron_perplexity_metric_with_single_microbatch_golden_value_without_
         mock_megatron_step.num_microbatches = num_microbatches
 
         # setup metric
-        megatron_ppl_metric = MegatronPerplexityMetric(ignore_index=-100)
-
-        # compare to torchmetric
+        megatron_ppl_metric = MegatronPerplexityMetric(ignore_index=-100).to(torch.cuda.current_device())
         metric = Perplexity(ignore_index=-100).to(torch.cuda.current_device())
+
+        # compute values
         for microbatch_output in microbatch_outputs:
             megatron_ppl_metric.update(
                 microbatch_output["forward_out"]["token_logits"].transpose(0, 1).contiguous(),

--- a/sub-packages/bionemo-testing/src/bionemo/testing/lightning.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/lightning.py
@@ -20,7 +20,11 @@ import torch
 
 
 def get_random_microbatch(
-    microbatch_size: int, max_sequence_length: int, vocab_size: int, seed: int
+    microbatch_size: int,
+    max_sequence_length: int,
+    vocab_size: int,
+    seed: int,
+    mask_index: int = -100,
 ) -> Dict[str, Dict[str, torch.Tensor]]:
     """Generate random microbatches for testing.
 
@@ -35,8 +39,8 @@ def get_random_microbatch(
         device=torch.cuda.current_device(),
     )  # [b s]
     loss_mask = torch.randint(
-        low=1,
-        high=1 + 1,
+        low=0,
+        high=1+1,
         size=(microbatch_size, max_sequence_length),
         dtype=torch.long,
         device=torch.cuda.current_device(),
@@ -45,7 +49,7 @@ def get_random_microbatch(
     token_logits = torch.rand(
         max_sequence_length, microbatch_size, vocab_size, device=torch.cuda.current_device(), generator=generator
     )  # [s b v]
-    labels[loss_mask == 0] = -100  # propagate masking to labels
+    labels[loss_mask == 0] = mask_index  # propagate masking to labels
     microbatch_output = {
         "batch": {"labels": labels, "loss_mask": loss_mask},
         "forward_out": {"token_logits": token_logits},

--- a/sub-packages/bionemo-testing/src/bionemo/testing/lightning.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/lightning.py
@@ -40,7 +40,7 @@ def get_random_microbatch(
     )  # [b s]
     loss_mask = torch.randint(
         low=0,
-        high=1+1,
+        high=1 + 1,
         size=(microbatch_size, max_sequence_length),
         dtype=torch.long,
         device=torch.cuda.current_device(),


### PR DESCRIPTION
## Summary
Replace `PerplexityLoggingCallback` with parallelism-aware `MegatronPerplexityMetric`. Pipeline parallel is not supported yet.

## Usage
Added perplexity logging in argparse.
```python
python sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py --log-train-ppl --log-val-ppl
```

## Testing
Added under `sub-packages/bionemo-llm/tests/bionemo/llm/test_lightning.py`

Tests for these changes can be run via:
```shell
pytest -v sub-packages/bionemo-llm/tests/bionemo/llm/test_lightning.py
```
