### PR TITLE
[cye/wandb-fix] Fix WandB issue.

### DIFF
--- a/requirements-cve.txt
+++ b/requirements-cve.txt
@@ -7,3 +7,4 @@ Werkzeug>=3.0.3
 nltk>=3.9.1
 pillow>=10.3.0
 tornado>=6.4.2
+wandb>=0.19.1 # Addresses CVE GHSA-v778-237x-gjrc

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,4 +8,4 @@ awscli==1.33.33
 nbval==0.11.0
 # For NvFaidx equivalence tests
 pyfaidx==0.8.1.3
-wandb<0.19.0 # temporary pin: https://nvidia.slack.com/archives/C074Z808N05/p1733418209959769
+wandb>=0.19.1 # Addresses CVE GHSA-v778-237x-gjrc

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,4 +8,3 @@ awscli==1.33.33
 nbval==0.11.0
 # For NvFaidx equivalence tests
 pyfaidx==0.8.1.3
-wandb>=0.19.1 # Addresses CVE GHSA-v778-237x-gjrc


### PR DESCRIPTION
## Summary

- `wandb>=0.19.1`: `wandb` Path validation bug has been fixed [between 0.19.0 and 0.19.1](https://github.com/wandb/wandb/compare/v0.19.0...v0.19.1).
  - Specifically, this commit / PR: [chore: allow pathlib.Path's for path-related Settings](https://github.com/wandb/wandb/commit/2f11cc702f80f42411b81b41f5d898ffbc00200a)
- CVE "Misuse of ServerConfig.PublicKeyCallback may cause authorization bypass in golang.org/x/crypto" is fixed in `0.19.1` as well. Two birds, one stone. (Was never a "true" vuln.)

## Details

- Resolves this NVBug for [CVE GHSA-v778-237x-gjrc](https://github.com/advisories/GHSA-v778-237x-gjrc): https://nvbugspro.nvidia.com/bug/5010582
  - WandB PR: https://github.com/wandb/wandb/pull/9069#issuecomment-2540317234
- Slack Threads
  - `Path` Validation Issue: https://nvidia.slack.com/archives/C074Z808N05/p1733418209959769 and https://nvidia-external.slack.com/archives/C016YA15HB3/p1733439699068689
  - WandB CVE: https://nvidia.slack.com/archives/C074Z808N05/p1734047115497109

## Usage

- N/A

## Testing

- CI Pipelines
  - https://prod.blsm.nvidia.com/bionemo-external-bionemo-fw/job/branch_pipeline/533/
  - https://prod.blsm.nvidia.com/bionemo-external-bionemo-fw/job/pr_pipeline/1220/
