### PR TITLE
xFail known bad tests on H100 and fix CVEs

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -312,6 +312,7 @@ COPY --from=rust-env /usr/local/rustup /usr/local/rustup
 
 
 # RUN rm -rf /usr/local/cargo /usr/local/rustup
+RUN rm -rf /root/.cache/bazel
 RUN chmod 777 -R /workspace/bionemo2/
 
 # Transformer engine attention defaults

--- a/docs/docs/user-guide/appendix/releasenotes-fw.md
+++ b/docs/docs/user-guide/appendix/releasenotes-fw.md
@@ -21,6 +21,8 @@
   * Moved inference script to a new executable `infer_esm2`, and deprecated the inference example in the fine-tuning tutorial.
   * Added new Jupyter notebook tutorials for inference and zero-shot protein design. These notebooks can be deployed on the cloud resources as a [brev.dev](https://www.brev.dev/) launchable.
 
+###  Known Issues:
+* Loading a checkpoint for Geneformer inference on H100 has a known regression in accuracy. Work is in progress to resolve by next release.
 
 ## BioNeMo Framework v2.1
 

--- a/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_model.py
+++ b/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_model.py
@@ -260,6 +260,9 @@ class _DummyDataSet(torch.utils.data.Dataset):
         return {"text": self.input_ids[idx], "attention_mask": self.mask[idx]}
 
 
+@pytest.mark.xfail(
+    reason="Known issue on H100 GPUs"
+)
 def test_geneformer_nemo1_v_nemo2_inference_golden_values(
     geneformer_config: GeneformerConfig, cells: List[List[str]], seed: int = 42
 ):


### PR DESCRIPTION
Known issue on H100 (and GH200) with loading checkpoints. Also fixes CVE in ARM container by deleting bazel cache.

Carries the branch fix in https://github.com/NVIDIA/bionemo-framework/pull/547 into `main`.