### PR TITLE
add generic torchmetric ppl logging on esm2

### DIFF
--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -30,7 +30,6 @@ from bionemo.esm2.api import ESM2Config
 from bionemo.esm2.data.datamodule import ESMDataModule
 from bionemo.esm2.data.dataset import RandomMaskStrategy
 from bionemo.esm2.data.tokenizer import get_tokenizer
-from bionemo.llm.lightning import PerplexityLoggingCallback
 from bionemo.llm.model.biobert.lightning import biobert_lightning_module
 from bionemo.llm.model.biobert.model import BiobertSpecOption
 from bionemo.llm.model.lr_scheduler import WarmupAnnealDecayHoldScheduler

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -301,6 +301,9 @@ def main(
                 anneal_percentage=0.10,
             ),
         ),
+        # perplexity logging
+        log_train_ppl=False,
+        log_val_ppl=True,
     )
 
     # Configure our custom Checkpointer

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from typing import List, Optional, Sequence, get_args
 
 from lightning.pytorch.callbacks import LearningRateMonitor, RichModelSummary
-from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.optimizer import OptimizerConfig
 from nemo import lightning as nl
 from nemo.collections import llm
@@ -190,9 +189,9 @@ def main(
             use_distributed_optimizer=True,
         ),
         find_unused_parameters=True,
-        gradient_as_bucket_view=True,
         ckpt_include_optimizer=True,
-        ckpt_async_save=False,  # TODO turn off due to error: Invalid access pattern: 1 ShardedObject are missing.
+        # NOTE: there are issues related to async that may occur, most recently observed due to duplicate filenames.
+        ckpt_async_save=True,
         ckpt_parallel_load=True,
     )
 

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -648,7 +648,7 @@ def get_parser():
     parser.add_argument(
         "--log-train-ppl",
         action="store_true",
-        default=True,
+        default=False,
         help="Log perplexity during training.",
     )
     parser.add_argument(

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -283,6 +283,9 @@ def main(
     if scheduler_num_steps is None:
         scheduler_num_steps = num_steps
 
+    if (log_train_ppl or log_val_ppl) and pipeline_model_parallel_size > 1:
+        raise NotImplementedError("Perplexity logging does not support pipeline parallelism yet.")
+
     model = biobert_lightning_module(
         esm2_config,
         tokenizer=tokenizer,

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -192,7 +192,7 @@ def main(
         find_unused_parameters=True,
         gradient_as_bucket_view=True,
         ckpt_include_optimizer=True,
-        ckpt_async_save=True,
+        ckpt_async_save=False,  # TODO turn off due to error: Invalid access pattern: 1 ShardedObject are missing.
         ckpt_parallel_load=True,
     )
 

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -84,6 +84,8 @@ def main(
     save_best_checkpoint: bool = True,
     save_last_checkpoint: bool = True,
     metric_to_monitor_for_checkpoints: str = "val_loss",
+    log_train_ppl: bool = False,
+    log_val_ppl: bool = True,
     save_top_k: int = 2,
     nsys_profiling: bool = False,
     nsys_start_step: int = 0,
@@ -145,6 +147,8 @@ def main(
         save_best_checkpoint (bool): whether to save the best checkpoint
         save_last_checkpoint (bool): whether to save the last checkpoint
         metric_to_monitor_for_checkpoints (str): metric to monitor for checkpoints
+        log_train_ppl (bool): log training perplexity
+        log_val_ppl (bool): log validation perplexity
         save_top_k (int): number of top checkpoints to save
         nsys_profiling (bool): whether to enable nsys profiling
         nsys_start_step (int): start step for nsys profiling
@@ -302,8 +306,8 @@ def main(
             ),
         ),
         # perplexity logging
-        log_train_ppl=False,
-        log_val_ppl=True,
+        log_train_ppl=log_train_ppl,
+        log_val_ppl=log_val_ppl,
     )
 
     # Configure our custom Checkpointer
@@ -387,6 +391,8 @@ def train_esm2_entrypoint():
         save_best_checkpoint=args.save_best_checkpoint,
         save_last_checkpoint=args.save_last_checkpoint,
         metric_to_monitor_for_checkpoints=args.metric_to_monitor_for_checkpoints,
+        log_train_ppl=args.log_train_ppl,
+        log_val_ppl=args.log_val_ppl,
         save_top_k=args.save_top_k,
         nsys_profiling=args.nsys_profiling,
         nsys_start_step=args.nsys_start_step,
@@ -639,6 +645,25 @@ def get_parser():
         required=False,
         default="val_loss",
         help="The metric to monitor for checkpointing.",
+    )
+    parser.add_argument(
+        "--log-train-ppl",
+        action="store_true",
+        default=True,
+        help="Log perplexity during training.",
+    )
+    parser.add_argument(
+        "--log-val-ppl",
+        action="store_true",
+        default=False,
+        help="Log perplexity during validation.",
+    )
+    parser.add_argument(
+        "--no-log-val-ppl",
+        action="store_false",
+        dest="log_val_ppl",
+        default=True,
+        help="Disable logging perplexity during validation.",
     )
     parser.add_argument(
         "--save-top-k",

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -214,7 +214,6 @@ def main(
     )
 
     callbacks = [
-        PerplexityLoggingCallback(log_train=False, log_val=True),
         RichModelSummary(max_depth=4),
         LearningRateMonitor(),
         nl_callbacks.PreemptionCallback(),

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -651,7 +651,7 @@ def get_parser():
         "--log-train-ppl",
         action="store_true",
         default=False,
-        help="Log perplexity during training.",
+        help="Log perplexity during training. Requires synchronization every training step and hurts performance. Enable only when necessary.",
     )
     parser.add_argument(
         "--log-val-ppl",

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -19,6 +19,7 @@ from typing import List, Optional, Sequence, get_args
 
 from lightning.pytorch.callbacks import LearningRateMonitor, RichModelSummary
 from megatron.core.optimizer import OptimizerConfig
+from megatron.core.distributed.distributed_data_parallel_config import DistributedDataParallelConfig
 from nemo import lightning as nl
 from nemo.collections import llm
 from nemo.lightning import resume
@@ -189,7 +190,6 @@ def main(
         ),
         find_unused_parameters=True,
         ckpt_include_optimizer=True,
-        # NOTE: there are issues related to async that may occur, most recently observed due to duplicate filenames.
         ckpt_async_save=True,
         ckpt_parallel_load=True,
     )
@@ -244,6 +244,7 @@ def main(
             autocast_enabled=False,
         ),
         enable_checkpointing=create_checkpoint_callback,
+        num_sanity_val_steps=0,
     )
 
     tokenizer = get_tokenizer()

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -293,9 +293,6 @@ class BionemoLightningModule(
         # all scaling on the internal states are cancelled out in the formula "exp(total_log_probs / count)" so we can safely sum across all devices
         self.log_train_ppl = log_train_ppl
         self.log_val_ppl = log_val_ppl
-        if (log_train_ppl or log_val_ppl) and self.trainer.strategy.pipeline_model_parallel_size > 1:
-            raise NotImplementedError("Perplexity logging does not support pipeline parallelism yet.")
-
         if log_train_ppl:
             self.train_ppl = MegatronPerplexityMetric(ignore_index=-100)
         if log_val_ppl:

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -351,6 +351,8 @@ class BionemoLightningModule(
             self.train_ppl(logits, batch["labels"])
             self.log("train_ppl", self.train_ppl, on_step=True, on_epoch=False)
 
+        return outputs
+
     def validation_step(self, batch, batch_idx: Optional[int] = None) -> Tensor:
         """In mcore the loss-function is part of the forward-pass when labels are provided."""
         outputs = self.forward_step(batch)
@@ -359,6 +361,8 @@ class BionemoLightningModule(
         if self.log_val_ppl and parallel_state.is_pipeline_last_stage():
             self.valid_ppl(logits, batch["labels"])
             self.log("valid_ppl", self.valid_ppl, on_step=False, on_epoch=True)
+
+        return outputs
 
     def predict_step(self, batch, batch_idx: Optional[int] = None) -> Tensor:
         """Alias for forward_step."""

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -291,6 +291,8 @@ class BionemoLightningModule(
         self.model_transform = model_transform
 
         # all scaling on the internal states are cancelled out in the formula "exp(total_log_probs / count)" so we can safely sum across all devices
+        self.log_train_ppl = log_train_ppl
+        self.log_val_ppl = log_val_ppl
         if log_train_ppl:
             self.train_ppl = MegatronPerplexityMetric(ignore_index=-100)
         if log_val_ppl:

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -292,7 +292,7 @@ class BionemoLightningModule(
         self._forward_step = forward_step
         self.model_transform = model_transform
 
-        process_group = parallel_state.get_data_parallel_group()  # TODO how to select only the last pp stage?
+        process_group = parallel_state.get_data_parallel_group()  # TODO only as a placeholder: how to select only the last pp stage?
         if log_train_ppl:
             self.train_ppl = MegatronPerplexityMetric(
                 ignore_index=-100,

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -214,7 +214,7 @@ of the examples in the iterator.
 class MegatronPerplexityMetric(torchmetrics.text.Perplexity):
     def __init__(self, *args, **kwargs):
         if parallel_state.get_context_parallel_world_size() > 1:
-            raise NotImplementedError(f"{__class__} does not support context parallelism yet.")
+            raise NotImplementedError(f"{self.__class__} does not support context parallelism yet.")
 
         self.cross_entropy_loss_fusion = kwargs.pop("cross_entropy_loss_fusion", False)
         super().__init__(*args, **kwargs)

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -237,6 +237,7 @@ class MegatronPerplexityMetric(torchmetrics.text.Perplexity):
 
         self.total_log_probs += unreduced_token_loss.sum()
         self.count += mask.sum()
+        # the numerator and denominator cancels tp out in the formulae "exp(total_log_probs / count)"
 
 
 class BionemoLightningModule(
@@ -291,7 +292,6 @@ class BionemoLightningModule(
         self._forward_step = forward_step
         self.model_transform = model_transform
 
-        # TODO normalize sum aggregation with TP
         process_group = parallel_state.get_data_parallel_group()  # TODO how to select only the last pp stage?
         if log_train_ppl:
             self.train_ppl = MegatronPerplexityMetric(

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -294,9 +294,11 @@ class BionemoLightningModule(
         self.log_train_ppl = log_train_ppl
         self.log_val_ppl = log_val_ppl
         if log_train_ppl:
-            self.train_ppl = MegatronPerplexityMetric(ignore_index=-100)
+            # self.train_ppl = MegatronPerplexityMetric(ignore_index=-100)
+            self.train_ppl = torchmetrics.text.Perplexity(ignore_index=-100)
         if log_val_ppl:
-            self.valid_ppl = MegatronPerplexityMetric(ignore_index=-100)
+            # self.valid_ppl = MegatronPerplexityMetric(ignore_index=-100)
+            self.valid_ppl = torchmetrics.text.Perplexity(ignore_index=-100)
 
     def configure_model(self) -> None:
         """Updates internal state: instantiates the model from the object's config, assigns to `model` attribute.

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -294,10 +294,8 @@ class BionemoLightningModule(
         self.log_train_ppl = log_train_ppl
         self.log_val_ppl = log_val_ppl
         if log_train_ppl:
-            # self.train_ppl = MegatronPerplexityMetric(ignore_index=-100)
             self.train_ppl = torchmetrics.text.Perplexity(ignore_index=-100)
         if log_val_ppl:
-            # self.valid_ppl = MegatronPerplexityMetric(ignore_index=-100)
             self.valid_ppl = torchmetrics.text.Perplexity(ignore_index=-100)
 
     def configure_model(self) -> None:

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -293,6 +293,9 @@ class BionemoLightningModule(
         # all scaling on the internal states are cancelled out in the formula "exp(total_log_probs / count)" so we can safely sum across all devices
         self.log_train_ppl = log_train_ppl
         self.log_val_ppl = log_val_ppl
+        if (log_train_ppl or log_val_ppl) and self.trainer.strategy.pipeline_model_parallel_size > 1:
+            raise NotImplementedError("Perplexity logging does not support pipeline parallelism yet.")
+
         if log_train_ppl:
             self.train_ppl = MegatronPerplexityMetric(ignore_index=-100)
         if log_val_ppl:

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -370,11 +370,11 @@ class BionemoLightningModule(
         if self.train_ppl is not None:
             if self.is_on_logging_device():
                 self.train_ppl.update(logits, batch["labels"])
-                train_metric_value = self.train_ppl.compute()
-                self.train_ppl.reset()
+            train_metric_value = self.train_ppl.compute()
+            self.train_ppl.reset()
 
-                if self.trainer.is_global_zero:
-                    self.log("train_ppl", train_metric_value, on_step=True, on_epoch=False, prog_bar=True)
+            if self.trainer.is_global_zero:
+                self.log("train_ppl", train_metric_value, on_step=True, on_epoch=False, prog_bar=True)
 
         return outputs
 
@@ -412,9 +412,10 @@ class BionemoLightningModule(
             self.valid_ppl.reset()  # clean up sanity runs
             return
 
+        valid_metric_value = self.valid_ppl.compute()
+        self.valid_ppl.reset()
+
         if self.is_on_logging_device():
-            valid_metric_value = self.valid_ppl.compute()
-            self.valid_ppl.reset()
             self.log("valid_ppl", valid_metric_value, on_step=False, on_epoch=True, prog_bar=True)
 
 

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -370,11 +370,11 @@ class BionemoLightningModule(
         if self.train_ppl is not None:
             if self.is_on_logging_device():
                 self.train_ppl.update(logits, batch["labels"])
-            train_metric_value = self.train_ppl.compute()
-            self.train_ppl.reset()
+                train_metric_value = self.train_ppl.compute()
+                self.train_ppl.reset()
 
-            if self.trainer.is_global_zero:
-                self.log("train_ppl", train_metric_value, on_step=True, on_epoch=False, prog_bar=True)
+                if self.trainer.is_global_zero:
+                    self.log("train_ppl", train_metric_value, on_step=True, on_epoch=False, prog_bar=True)
 
         return outputs
 
@@ -412,10 +412,9 @@ class BionemoLightningModule(
             self.valid_ppl.reset()  # clean up sanity runs
             return
 
-        valid_metric_value = self.valid_ppl.compute()
-        self.valid_ppl.reset()
-
         if self.is_on_logging_device():
+            valid_metric_value = self.valid_ppl.compute()
+            self.valid_ppl.reset()
             self.log("valid_ppl", valid_metric_value, on_step=False, on_epoch=True, prog_bar=True)
 
 

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -348,12 +348,10 @@ class BionemoLightningModule(
 
         if self.train_metric is not None:
             if self.is_on_logging_device():
-                self.train_metric.update(logits, batch["labels"])
-            train_metric_value = self.train_metric.compute()
-            self.train_metric.reset()
+                self.train_metric(logits, batch["labels"])  # TODO call the same as forward?
 
-            if self.trainer.is_global_zero:
-                self.log("train_ppl", train_metric_value, on_step=True, on_epoch=False, prog_bar=True)
+            self.log("train_ppl", self.train_metric, on_step=True, on_epoch=False, prog_bar=True, rank_zero_only=True)  # TODO rank_zero_only necessary
+            # self.train_metric.reset()
 
         return outputs
 
@@ -391,11 +389,8 @@ class BionemoLightningModule(
             self.valid_metric.reset()  # clean up sanity runs
             return
 
-        valid_metric_value = self.valid_metric.compute()
-        self.valid_metric.reset()
-
-        if self.is_on_logging_device():
-            self.log("valid_ppl", valid_metric_value, on_step=False, on_epoch=True, prog_bar=True)
+        self.log("valid_ppl", self.valid_metric, on_step=False, on_epoch=True, prog_bar=True, rank_zero_only=True)
+        # self.valid_metric.reset()
 
 
 def default_megatron_optimizer() -> MegatronOptimizerModule:

--- a/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/lightning.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Dict, Generic, Iterable, Iterator, List, Optio
 import lightning.pytorch as pl
 import torch.distributed
 import torchmetrics.text
+from torchmetrics.functional.text.perplexity import _perplexity_update
 from megatron.core import parallel_state
 from megatron.core.optimizer.optimizer_config import OptimizerConfig
 from nemo.lightning import io as nlio
@@ -255,8 +256,8 @@ class BionemoLightningModule(
         # TODO: Add transformer_layer_spec when we update mcore
         optimizer: MegatronOptimizerModule,
         model_transform: Optional[Callable[[MegatronModelType], MegatronModelType]] = None,
-        train_metric: Optional[torchmetrics.Metric] = None,
-        valid_metric: Optional[torchmetrics.Metric] = None,
+        log_train_ppl: bool = False,
+        log_val_ppl: bool = False,
         **model_construct_args,
     ) -> None:
         """Constructor.
@@ -290,8 +291,9 @@ class BionemoLightningModule(
         self._forward_step = forward_step
         self.model_transform = model_transform
 
-        self.train_metric = train_metric
-        self.valid_metric = valid_metric
+        # torchmetrics must init here for fiddle serialization
+        self.train_ppl = torchmetrics.text.Perplexity(ignore_index=-100) if log_train_ppl else None
+        self.valid_ppl = torchmetrics.text.Perplexity(ignore_index=-100) if log_val_ppl else None
 
     def configure_model(self) -> None:
         """Updates internal state: instantiates the model from the object's config, assigns to `model` attribute.
@@ -346,12 +348,11 @@ class BionemoLightningModule(
         outputs = self.forward_step(batch)
         logits = outputs["token_logits"].transpose(0, 1).clone().detach()  #  [s, b, v] -> [b, s, v]
 
-        if self.train_metric is not None:
+        if self.train_ppl is not None:
             if self.is_on_logging_device():
-                self.train_metric(logits, batch["labels"])  # TODO call the same as forward?
+                self.train_ppl(logits, batch["labels"])
 
-            self.log("train_ppl", self.train_metric, on_step=True, on_epoch=False, prog_bar=True, rank_zero_only=True)  # TODO rank_zero_only necessary
-            # self.train_metric.reset()
+            self.log("train_ppl", self.train_ppl, on_step=True, on_epoch=False, prog_bar=True)
 
         return outputs
 
@@ -360,8 +361,8 @@ class BionemoLightningModule(
         outputs = self.forward_step(batch)
         logits = outputs["token_logits"].transpose(0, 1).clone().detach()  #  [s, b, v] -> [b, s, v]
 
-        if self.valid_metric is not None and self.is_on_logging_device():
-            self.valid_metric.update(logits, batch["labels"])
+        if self.valid_ppl is not None and self.is_on_logging_device():
+            self.valid_ppl.update(logits, batch["labels"])
 
         return outputs
 
@@ -382,15 +383,14 @@ class BionemoLightningModule(
         return self.loss_reduction_class(validation_step=True)
 
     def on_validation_epoch_end(self):  # noqa: D102
-        if self.valid_metric is None:
+        if self.valid_ppl is None:
             return
 
         if self.trainer.sanity_checking:
-            self.valid_metric.reset()  # clean up sanity runs
+            self.valid_ppl.reset()  # clean up sanity runs
             return
 
-        self.log("valid_ppl", self.valid_metric, on_step=False, on_epoch=True, prog_bar=True, rank_zero_only=True)
-        # self.valid_metric.reset()
+        self.log("valid_ppl", self.valid_ppl, on_step=False, on_epoch=True, prog_bar=True)
 
 
 def default_megatron_optimizer() -> MegatronOptimizerModule:

--- a/sub-packages/bionemo-llm/tests/bionemo/llm/test_lightning.py
+++ b/sub-packages/bionemo-llm/tests/bionemo/llm/test_lightning.py
@@ -24,7 +24,7 @@ from torch import nn
 from torchmetrics.text import Perplexity
 
 from bionemo.llm import lightning as bnptl
-from bionemo.llm.lightning import PerplexityLoggingCallback, batch_collator, get_dtype_device
+from bionemo.llm.lightning import PerplexityLoggingCallback, batch_collator, get_dtype_device, MegatronPerplexityMetric
 from bionemo.testing import megatron_parallel_state_utils
 from bionemo.testing.lightning import get_random_microbatch
 
@@ -185,6 +185,43 @@ def test_mixin_strategy_contract_get_loss_reduction():
         strategy_reduction_function = strategy._get_loss_reduction("predict")
         assert isinstance(strategy_reduction_function(mixin), bnptl.PassthroughLossReduction)
 
+
+def test_megatron_perplexity_metric_with_single_microbatch_golden_value_without_parallelism(seed: int = 42):
+    """Test PerplexityLoggingCallback with a single microbatch without parallelism"""
+    with megatron_parallel_state_utils.distributed_model_parallel_state(seed=seed):
+        # setup test input
+        microbatch_size, max_sequence_length, vocab_size = 1, 1024, 2
+        microbatch_outputs = [get_random_microbatch(microbatch_size, max_sequence_length, vocab_size, seed)]
+        num_microbatches = len(microbatch_outputs)
+
+        # setup mock objects
+        mock_megatron_step = mock.MagicMock()
+        mock_megatron_step.pl_module.log.return_value = None
+        mock_megatron_step.trainer.training = False
+        mock_megatron_step.trainer.sanity_checking = False
+        mock_megatron_step.num_microbatches = num_microbatches
+
+        # setup metric
+        megatron_ppl_metric = MegatronPerplexityMetric(ignore_index=-100)
+
+        # compare to torchmetric
+        metric = Perplexity(ignore_index=-100).to(torch.cuda.current_device())
+        for microbatch_output in microbatch_outputs:
+            megatron_ppl_metric.update(
+                microbatch_output["forward_out"]["token_logits"].transpose(0, 1).contiguous(),
+                microbatch_output["batch"]["labels"],
+            )
+            metric.update(
+                microbatch_output["forward_out"]["token_logits"].transpose(0, 1).contiguous(),
+                microbatch_output["batch"]["labels"],
+            )
+        ppl_value = megatron_ppl_metric.compute()
+        ppl_golden_value = metric.compute()
+
+        torch.testing.assert_close(
+            ppl_value,
+            ppl_golden_value,
+        )
 
 def test_perplexity_logging_callback_with_single_microbatch_golden_value_without_parallelism(seed: int = 42):
     """Test PerplexityLoggingCallback with a single microbatch without parallelism"""

--- a/sub-packages/bionemo-llm/tests/bionemo/llm/test_lightning.py
+++ b/sub-packages/bionemo-llm/tests/bionemo/llm/test_lightning.py
@@ -202,10 +202,10 @@ def test_megatron_perplexity_metric_with_single_microbatch_golden_value_without_
         mock_megatron_step.num_microbatches = num_microbatches
 
         # setup metric
-        megatron_ppl_metric = MegatronPerplexityMetric(ignore_index=-100)
-
-        # compare to torchmetric
+        megatron_ppl_metric = MegatronPerplexityMetric(ignore_index=-100).to(torch.cuda.current_device())
         metric = Perplexity(ignore_index=-100).to(torch.cuda.current_device())
+
+        # compute values
         for microbatch_output in microbatch_outputs:
             megatron_ppl_metric.update(
                 microbatch_output["forward_out"]["token_logits"].transpose(0, 1).contiguous(),

--- a/sub-packages/bionemo-testing/src/bionemo/testing/lightning.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/lightning.py
@@ -20,7 +20,11 @@ import torch
 
 
 def get_random_microbatch(
-    microbatch_size: int, max_sequence_length: int, vocab_size: int, seed: int
+    microbatch_size: int,
+    max_sequence_length: int,
+    vocab_size: int,
+    seed: int,
+    mask_index: int = -100,
 ) -> Dict[str, Dict[str, torch.Tensor]]:
     """Generate random microbatches for testing.
 
@@ -35,8 +39,8 @@ def get_random_microbatch(
         device=torch.cuda.current_device(),
     )  # [b s]
     loss_mask = torch.randint(
-        low=1,
-        high=1 + 1,
+        low=0,
+        high=1+1,
         size=(microbatch_size, max_sequence_length),
         dtype=torch.long,
         device=torch.cuda.current_device(),
@@ -45,7 +49,7 @@ def get_random_microbatch(
     token_logits = torch.rand(
         max_sequence_length, microbatch_size, vocab_size, device=torch.cuda.current_device(), generator=generator
     )  # [s b v]
-    labels[loss_mask == 0] = -100  # propagate masking to labels
+    labels[loss_mask == 0] = mask_index  # propagate masking to labels
     microbatch_output = {
         "batch": {"labels": labels, "loss_mask": loss_mask},
         "forward_out": {"token_logits": token_logits},

--- a/sub-packages/bionemo-testing/src/bionemo/testing/lightning.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/lightning.py
@@ -40,7 +40,7 @@ def get_random_microbatch(
     )  # [b s]
     loss_mask = torch.randint(
         low=0,
-        high=1+1,
+        high=1 + 1,
         size=(microbatch_size, max_sequence_length),
         dtype=torch.long,
         device=torch.cuda.current_device(),


### PR DESCRIPTION
## Summary
Logging perplexity through `torchmetric.text.Perplexity`

## Details
Pipeline parallel last stage is handled in `training_step` and `validation_step`. Generic torchmetric seems to handle tensor parallelism without any noticeable difference, where the logits are already provided in `training/validation_step` and no backward pass is needed.

However, valid_ppl does not seem to work properly. 

## Usage
```python
python sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py --log_train_ppl --log_val_ppl
```

![W B Chart 12_28_2024, 12_09_19 PM](https://github.com/user-attachments/assets/342ccb7a-de92-4d75-b8ee-3a4c4d7b3afe)
![W B Chart 12_28_2024, 12_09_25 PM](https://github.com/user-attachments/assets/b1cfeeb1-bd60-4c2a-8c33-50b9ae07af2d)
![W B Chart 12_28_2024, 12_12_35 PM](https://github.com/user-attachments/assets/6120d907-4629-46f0-b0cc-e7e68b659cdc)
![W B Chart 12_28_2024, 12_12_40 PM](https://github.com/user-attachments/assets/a699abe2-95cf-43dc-8015-dd6d916f383b)
