### PR TITLE
add temporary mistune pin to fix docs build issue

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,4 @@ mkdocs-include-dir-to-nav
 mkdocs-literate-nav
 mkdocs-site-urls
 mike
+mistune==3.0.2 # temporary pin until https://github.com/lepture/mistune/issues/403 is resolved.


### PR DESCRIPTION
Pins mistune to fix a jupyter notebook build issue introduced in 3.1.0

lepture/mistune#403
