### PR TITLE
Un-xfail geneformer on H100 test

### DIFF
--- a/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_model.py
+++ b/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_model.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import math
-import re
 import tarfile
 from copy import deepcopy
 from pathlib import Path
@@ -261,9 +260,6 @@ class _DummyDataSet(torch.utils.data.Dataset):
         return {"text": self.input_ids[idx], "attention_mask": self.mask[idx]}
 
 
-@pytest.mark.xfail(
-    re.search(r"h[1-9]00", torch.cuda.get_device_name().lower()) is not None, reason="Known issue on H100 GPUs"
-)
 def test_geneformer_nemo1_v_nemo2_inference_golden_values(
     geneformer_config: GeneformerConfig, cells: List[List[str]], seed: int = 42
 ):


### PR DESCRIPTION
## Summary
Un-xfails a geneformer H100 test.

## Details
After base image upgrade to pytorch fw 24.12 (https://github.com/NVIDIA/bionemo-framework/pull/553) , H100 geneformer issue is fixed. 

## Usage and Testing
```python
pytest ./sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_model.py::test_geneformer_nemo1_v_nemo2_inference_golden_values
```