### PR TITLE
don't eagerly download esm2 checkpoints

### DIFF
--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/scripts/test_infer_esm2.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/scripts/test_infer_esm2.py
@@ -32,10 +32,6 @@ from bionemo.llm.lightning import batch_collator
 from bionemo.llm.utils.callbacks import IntervalT
 
 
-esm2_650m_checkpoint_path = load("esm2/650m:2.0")
-esm2_3b_checkpoint_path = load("esm2/3b:2.0", source="ngc")
-
-
 # Function to check GPU memory
 def check_gpu_memory(threshold_gb):
     if torch.cuda.is_available():
@@ -140,7 +136,6 @@ def test_esm2_fine_tune_data_module_val_dataloader(data_module):
 
 @pytest.mark.parametrize("precision", ["fp32", "bf16-mixed"])
 @pytest.mark.parametrize("prediction_interval", get_args(IntervalT))
-@pytest.mark.skipif(check_gpu_memory(30), reason="Skipping test due to insufficient GPU memory")
 def test_infer_runs(
     tmpdir,
     dummy_protein_csv,
@@ -155,7 +150,7 @@ def test_infer_runs(
 
     infer_model(
         data_path=data_path,
-        checkpoint_path=esm2_650m_checkpoint_path,
+        checkpoint_path=load("esm2/650m:2.0"),
         results_path=result_dir,
         min_seq_length=min_seq_len,
         prediction_interval=prediction_interval,


### PR DESCRIPTION
Adding the load calls in the global namespace leads to these checkpoints being downloaded even when we don't use them. We really should call `load` as lazily as possible to avoid materializing data for tests we don't need.