### PR TITLE
pin importlib-resources

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,4 @@ mkdocs-literate-nav
 mkdocs-site-urls
 mike
 mistune==3.0.2 # temporary pin until https://github.com/lepture/mistune/issues/403 is resolved.
+importlib-resources<=6.5.0 # temporary pin until https://github.com/python/importlib_resources/issues/323 is resolved.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,4 +10,4 @@ mkdocs-literate-nav
 mkdocs-site-urls
 mike
 mistune==3.0.2 # temporary pin until https://github.com/lepture/mistune/issues/403 is resolved.
-importlib-resources<=6.5.0 # temporary pin until https://github.com/python/importlib_resources/issues/323 is resolved.
+importlib-resources<6.5.0 # temporary pin until https://github.com/python/importlib_resources/issues/323 is resolved.


### PR DESCRIPTION
Temporary pin for importlib-resources due to an undeclared dependency in a recently published version (this morning) in importlib-resources.

python/importlib_resources#323