### PR TITLE
Revert "pin cdifflib version (#593)"

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,7 +13,3 @@ pyfaidx==0.8.1.3
 # See https://nvidia.slack.com/archives/C02A7LYGHK8/p1734727482697309
 pytorch-lightning<2.5.0
 lightning<2.5.0
-
-# Temporary cdifflib pin, see
-# https://github.com/mduggan/cdifflib/issues/13
-cdifflib<=1.2.6


### PR DESCRIPTION
This reverts commit 2e90bf5872bef1987ac15b2619cc3a4196e77e53.

### Description
We don't need this anymore (assuming tests pass with the new version) thanks to quick action here: mduggan/cdifflib#13

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by checking relevant boxes below. This will automatically apply labels.

- [ ] [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [ ] [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
