### PR TITLE
run trufflehog on entire main branch on push action

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ '' if github.event_name == 'push' else github.event.repository.default_branch }}
+          base: ${{ github.event_name != 'push' && github.event.repository.default_branch || '' }}
           head: HEAD
           extra_args: --only-verified
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
+          base: ${{ "" if github.event_name == 'push' else github.event.repository.default_branch }}
           head: HEAD
           extra_args: --only-verified
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           image: nemoci.azurecr.io/bionemo/build-cache
           pull-request-cache: true
+          extra-cache-from: ${{ github.event_name == 'merge_group' && 'nemoci.azurecr.io/bionemo/build-cache:main' || '' }}
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ "" if github.event_name == 'push' else github.event.repository.default_branch }}
+          base: ${{ '' if github.event_name == 'push' else github.event.repository.default_branch }}
           head: HEAD
           extra_args: --only-verified
 


### PR DESCRIPTION
### Description
Trufflehog is currently failing on the main branch when we only run on diffs, since it ends up comparing the head of main against itself. This should allow us to check the entire main branch for secrets when it runs post-merge.

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
