### PR TITLE
Simplify BIONEMO_HOME env var setting in ci scripts.

### DIFF
--- a/ci/scripts/utils.sh
+++ b/ci/scripts/utils.sh
@@ -31,26 +31,26 @@ set_bionemo_home() {
     set +u
     if [ -z "$BIONEMO_HOME" ]; then
         echo "\$BIONEMO_HOME is unset. Setting \$BIONEMO_HOME to repository root."
-
-        # Ensure repository is clean
-        if ! check_git_repository; then
-            echo "Failed to set \$BIONEMO_HOME due to repository state." >&2
-            return 1
-        fi
-
-        REPOSITORY_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-        if [ $? -ne 0 ]; then
-            echo "ERROR: Could not determine the repository root. Ensure you're in a Git repository." >&2
-            return 1
-        fi
-
-        BIONEMO_HOME="${REPOSITORY_ROOT}"
-        echo "Setting \$BIONEMO_HOME to: $BIONEMO_HOME"
+	export BIONEMO_HOME=/workspace/bionemo2
+#        # Ensure repository is clean
+#        if ! check_git_repository; then
+#            echo "Failed to set \$BIONEMO_HOME due to repository state." >&2
+#            return 1
+#        fi
+#
+#        REPOSITORY_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+#        if [ $? -ne 0 ]; then
+#            echo "ERROR: Could not determine the repository root. Ensure you're in a Git repository." >&2
+#            return 1
+#        fi
+#
+#        BIONEMO_HOME="${REPOSITORY_ROOT}"
+#        echo "Setting \$BIONEMO_HOME to: $BIONEMO_HOME"
     fi
     set -u
 
     # Change directory to BIONEMO_HOME or exit if failed
-    cd "${BIONEMO_HOME}" || { echo "ERROR: Could not change directory to \$BIONEMO_HOME: $BIONEMO_HOME" >&2; return 1; }
+#    cd "${BIONEMO_HOME}" || { echo "ERROR: Could not change directory to \$BIONEMO_HOME: $BIONEMO_HOME" >&2; return 1; }
 }
 
 


### PR DESCRIPTION
### Description
Simplify `BIONEMO_HOME` env var setting to allow CI to run without error in the docker image.

Otherwise, `ci/scripts/run_pytest.sh`  will try to look for a .git file which doesn't exist in the image.

### Type of changes

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

### Usage
`ci/scripts/run_pytest.sh`

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
