### PR TITLE
short script to initialize environment for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,6 +24,7 @@
 		"NUMBA_CACHE_DIR": "/tmp/"
 	},
 	"postCreateCommand": "./.devcontainer/postCreateCommand.sh",
+	"initializeCommand": "./.devcontainer/initializeCommand.sh",
 	"remoteUser": "ubuntu",
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/initializeCommand.sh
+++ b/.devcontainer/initializeCommand.sh
@@ -1,0 +1,7 @@
+# Create the mounted config directories if they don't already exist
+
+mkdir -p ~/.aws
+mkdir -p ~/.ngc
+mkdir -p ~/.cache
+mkdir -p ~/.ssh
+[ ! -f ~/.netrc ] && touch ~/.netrc


### PR DESCRIPTION
Adds a short startup script to ensure opening the devcontainer doesn't crash because of a missing .ngc, .aws, or .netrc folder/file.