### PR TITLE
Loss disagreement between TP=1 and TP=2

### DIFF
--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/model/model.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/model/model.py
@@ -362,3 +362,6 @@ class ESM2Config(ESM2GenericConfig, iom.IOMixinWithGettersSetters):
     model_cls: Type[ESM2Model] = ESM2Model
     num_layers: int = 33  # 650M
     hidden_size: int = 1280  # 650M
+    output_layer_init_method: Callable = (
+        torch.nn.init.zeros_
+    )  # TODO make param init reproducible; remove after debugging

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -31,7 +31,6 @@ from bionemo.esm2.api import ESM2Config
 from bionemo.esm2.data.datamodule import ESMDataModule
 from bionemo.esm2.data.dataset import RandomMaskStrategy
 from bionemo.esm2.data.tokenizer import get_tokenizer
-from bionemo.llm.lightning import PerplexityLoggingCallback
 from bionemo.llm.model.biobert.lightning import biobert_lightning_module
 from bionemo.llm.model.biobert.model import BiobertSpecOption
 from bionemo.llm.model.lr_scheduler import WarmupAnnealDecayHoldScheduler
@@ -211,7 +210,6 @@ def main(
     )
 
     callbacks = [
-        PerplexityLoggingCallback(log_train=False, log_val=True),
         RichModelSummary(max_depth=4),
         LearningRateMonitor(),
         nl_callbacks.PreemptionCallback(),

--- a/sub-packages/bionemo-llm/src/bionemo/llm/model/biobert/model.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/model/biobert/model.py
@@ -444,12 +444,14 @@ class MegatronBioBertModel(LanguageModule):
         # logits and loss
         output_weight = None
         if self.share_embeddings_and_output_weights:
-            output_weight = self.shared_embedding_or_output_weight()
+            output_weight = self.shared_embedding_or_output_weight()  # noqa: F841
 
         hidden_states_after_lm_head = self.lm_head(hidden_states=hidden_states)
         if not self.skip_logits:
             # TODO add , runtime_gather_output=runtime_gather_output once supported in ColumnParallelLinear
-            logits, _ = self.output_layer(hidden_states_after_lm_head, weight=output_weight)
+            # TODO replace tensor_parallel.ColumnParallelLinear with torch.nn.Linear to debug; remove once complete
+            # logits, _ = self.output_layer(hidden_states_after_lm_head, weight=output_weight)
+            logits = self.output_layer(hidden_states_after_lm_head)
         else:
             logits = None
 

--- a/sub-packages/bionemo-llm/src/bionemo/llm/model/loss.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/model/loss.py
@@ -197,6 +197,8 @@ class BERTMLMLossWithReduction(_Nemo2CompatibleLossReduceMixin, MegatronLossRedu
             forward_out_report = {}
 
         # NOTE: token_logits is [sequence, batch] but labels and other fiels, including the loss are [batch, sequence]
+        # TODO: logits always match on tp=1 and tp=2, and among tp ranks
+        #  however, unreduced_token_loss does not match between tp=1 and tp=2. only match among tp ranks at tp=2
         unreduced_token_loss = unreduced_token_loss_fn(forward_out["token_logits"], batch["labels"])  # [b s]
 
         # TODO(@jstjohn) also handle different output keys, like the sequence loss.


### PR DESCRIPTION
### Description
Loss values from `unreduced_token_loss_fn` disagrees even though the `logits` are the same when TP=1 and TP=2. Interestingly, this introduces a nearly-constant offset in training curve and does not impact `grad_norm`. The offset slowly shrinks over 100 training steps.

Suspected root cause:
`vocab_parallel_cross_entropy` takes into account of `logits` at the padded vocab dimensions while it should have ignored them. As training progresses, more probabilities are then assigned to "real vocabs" so the padding vacabs slowly becomes less relevant, leading to the closing gap between TP=1 and TP=2 loss curves.

`logits` dimensions also expanded from 128 to 256 when replacing `ColumnParallelLinear` with `torch.nn.Linear` although the reason is still unclear.

On a related issue, `unreduced_token_loss_fn` introduces inplace operation on the token logits.
https://github.com/NVIDIA/bionemo-framework/blob/sichu/loss-curve-tp-shift/sub-packages/bionemo-llm/tests/bionemo/llm/model/test_loss.py#L158

### Type of changes
- [x]  Bug fix (non-breaking change which fixes an issue)

### Usage
<!--- How does a user interact with the changed code -->
```bash
DATADIR=$(download_bionemo_data esm2/testdata_esm2_pretrain:2.0 --source pbss)/2024_03_sanity

NUM_DEVICES=${1}
TP=${NUM_DEVICES}

test_data_flags="""
    --train-cluster-path=${DATADIR}/train_clusters_sanity.parquet \
    --train-database-path=${DATADIR}/train_sanity.db \
    --valid-cluster-path=${DATADIR}/valid_clusters.parquet \
    --valid-database-path=${DATADIR}/validation.db
"""
hparam_flags_8m="""
    --num-layers=6 \
    --hidden-size=320 \
    --num-attention-heads=20 \
    --ffn-hidden-size=1280 \
    --micro-batch-size=4
"""
test_run_flags="""
    --num-nodes=1 \
    --num-gpus=${num_devices} \
    --num-steps=100 \
    --limit-val-batches=2
"""

launcher="torchrun --nproc-per-node=${NUM_DEVICES}"
script="sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py"
cmd="""
${launcher} $script \
    $test_data_flags \
    $hparam_flags_8m \
    $test_run_flags \
    --log-every-n-steps=5 \
    --val-check-interval=5 \
    --tensor-model-parallel-size=${TP}
"""
eval $cmd
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
