### PR TITLE
catch ngc api key validation errors and default to not using an api key

### DIFF
--- a/sub-packages/bionemo-core/src/bionemo/core/data/load.py
+++ b/sub-packages/bionemo-core/src/bionemo/core/data/load.py
@@ -21,11 +21,9 @@ import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Optional, Sequence, TextIO
+from typing import TYPE_CHECKING, Literal, Optional, Sequence, TextIO
 
-import boto3
 import nest_asyncio
-import ngcsdk
 import pooch
 from botocore.config import Config
 from tqdm import tqdm
@@ -33,6 +31,9 @@ from tqdm import tqdm
 from bionemo.core import BIONEMO_CACHE_DIR
 from bionemo.core.data.resource import Resource, get_all_resources
 
+
+if TYPE_CHECKING:
+    import ngcsdk
 
 logger = pooch.get_logger()
 
@@ -49,6 +50,8 @@ DEFAULT_SOURCE: SourceOptions = os.environ.get("BIONEMO_DATA_SOURCE", "ngc")  # 
 
 def default_pbss_client():
     """Create a default S3 client for PBSS."""
+    import boto3
+
     retry_config = Config(retries={"max_attempts": 10, "mode": "standard"})
     return boto3.client("s3", endpoint_url="https://pbss.s8k.io", config=retry_config)
 
@@ -72,11 +75,13 @@ def _s3_download(url: str, output_file: str | Path, _: pooch.Pooch) -> None:
         s3.download_file(bucket, key, output_file, Callback=progress_callback)
 
 
-def default_ngc_client(use_guest_if_api_key_invalid: bool = True) -> ngcsdk.Client:
+def default_ngc_client(use_guest_if_api_key_invalid: bool = True) -> "ngcsdk.Client":
     """Create a default NGC client.
 
     This should load the NGC API key from ~/.ngc/config, or from environment variables passed to the docker container.
     """
+    import ngcsdk
+
     client = ngcsdk.Client()
 
     try:

--- a/sub-packages/bionemo-core/src/bionemo/core/data/load.py
+++ b/sub-packages/bionemo-core/src/bionemo/core/data/load.py
@@ -34,6 +34,9 @@ from bionemo.core import BIONEMO_CACHE_DIR
 from bionemo.core.data.resource import Resource, get_all_resources
 
 
+logger = pooch.get_logger()
+
+
 __all__: Sequence[str] = (
     "load",
     "default_ngc_client",
@@ -69,12 +72,31 @@ def _s3_download(url: str, output_file: str | Path, _: pooch.Pooch) -> None:
         s3.download_file(bucket, key, output_file, Callback=progress_callback)
 
 
-def default_ngc_client() -> ngcsdk.Client:
+def default_ngc_client(use_guest_if_api_key_invalid: bool = True) -> ngcsdk.Client:
     """Create a default NGC client.
 
     This should load the NGC API key from ~/.ngc/config, or from environment variables passed to the docker container.
     """
-    return ngcsdk.Client()
+    client = ngcsdk.Client()
+
+    try:
+        client.configure()
+
+    except ValueError as e:
+        if use_guest_if_api_key_invalid:
+            logger.error(f"Error configuring NGC client: {e}, signing in as guest.")
+            client = ngcsdk.Client("no-apikey")
+            client.configure(
+                api_key="no-apikey",  # pragma: allowlist secret
+                org_name="no-org",
+                team_name="no-team",
+                ace_name="no-ace",
+            )
+
+        else:
+            raise
+
+    return client
 
 
 @dataclass
@@ -91,7 +113,6 @@ class NGCDownloader:
     def __call__(self, url: str, output_file: str | Path, _: pooch.Pooch) -> None:
         """Download a file from NGC."""
         client = default_ngc_client()
-        client.configure()
         nest_asyncio.apply()
 
         download_fns = {

--- a/sub-packages/bionemo-core/tests/bionemo/core/data/test_load.py
+++ b/sub-packages/bionemo-core/tests/bionemo/core/data/test_load.py
@@ -269,10 +269,18 @@ def test_default_pbss_client():
     assert client.meta.endpoint_url == "https://pbss.s8k.io"
 
 
-@pytest.mark.xfail(reason="Logging into NGC is not required to download artifacts in BioNeMo.")
-def test_default_ngc_client():
-    clt = default_ngc_client()
-    assert clt.api_key is not None
+@patch("ngcbpc.api.authentication.Authentication.validate_api_key")
+def test_default_ngc_client_raises_when_api_key_invalid(mocked_validate_api_key):
+    mocked_validate_api_key.return_value = False
+    with pytest.raises(ValueError, match="Invalid apikey for NGC service location"):
+        default_ngc_client(use_guest_if_api_key_invalid=False)
+
+
+@patch("ngcbpc.api.authentication.Authentication.validate_api_key")
+def test_default_ngc_client_returns_guest_key_when_api_key_invalid(mocked_validate_api_key):
+    mocked_validate_api_key.return_value = False
+    client = default_ngc_client()
+    assert client.api_key == "no-apikey"  # pragma: allowlist secret
 
 
 @patch("bionemo.core.data.load.default_ngc_client")

--- a/sub-packages/bionemo-core/tests/bionemo/core/data/test_load.py
+++ b/sub-packages/bionemo-core/tests/bionemo/core/data/test_load.py
@@ -21,6 +21,7 @@ import tarfile
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import ngcbpc.environ
 import pytest
 
 from bionemo.core.data.load import default_ngc_client, default_pbss_client, load
@@ -270,14 +271,16 @@ def test_default_pbss_client():
 
 
 @patch("ngcbpc.api.authentication.Authentication.validate_api_key")
-def test_default_ngc_client_raises_when_api_key_invalid(mocked_validate_api_key):
+def test_default_ngc_client_raises_when_api_key_invalid(mocked_validate_api_key, monkeypatch):
+    monkeypatch.setattr(ngcbpc.environ, "NGC_CLI_API_KEY", "invalidapikey")  # pragma: allowlist secret
     mocked_validate_api_key.return_value = False
     with pytest.raises(ValueError, match="Invalid apikey for NGC service location"):
         default_ngc_client(use_guest_if_api_key_invalid=False)
 
 
 @patch("ngcbpc.api.authentication.Authentication.validate_api_key")
-def test_default_ngc_client_returns_guest_key_when_api_key_invalid(mocked_validate_api_key):
+def test_default_ngc_client_returns_guest_key_when_api_key_invalid(mocked_validate_api_key, monkeypatch):
+    monkeypatch.setattr(ngcbpc.environ, "NGC_CLI_API_KEY", "invalidapikey")  # pragma: allowlist secret
     mocked_validate_api_key.return_value = False
     client = default_ngc_client()
     assert client.api_key == "no-apikey"  # pragma: allowlist secret


### PR DESCRIPTION
Should fix issues like https://nvbugspro.nvidia.com/bug/5063178, where the SLURM environment picks up a stray and incorrect NGC api key.