### PR TITLE
fix devcontainer initialize script

### DIFF
--- a/.devcontainer/initializeCommand.sh
+++ b/.devcontainer/initializeCommand.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Create the mounted config directories if they don't already exist
 
 mkdir -p ~/.aws
@@ -5,3 +6,4 @@ mkdir -p ~/.ngc
 mkdir -p ~/.cache
 mkdir -p ~/.ssh
 [ ! -f ~/.netrc ] && touch ~/.netrc
+exit 0


### PR DESCRIPTION
If this script exits unsuccessfully, the devcontainer launch stops. This makes sure that we exit successfully regardless of the status of ~/.netrc