### PR TITLE
edit to approval workflow to avoid marking a failed action

### DIFF
--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -1,6 +1,7 @@
 name: Enforce Tiered Approvals
 
 on:
+  pull_request: # TODO: remove
   pull_request_review:
 
 env:

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -70,3 +70,6 @@ jobs:
     needs: check_approval
     if : ${{ needs.check_approval.outputs.status == 'passed' }}
     runs-on: ubuntu-latest
+    steps:
+      - name: Approved
+        run: echo "This PR has been approved by a Tier 2 reviewer."

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -7,9 +7,10 @@ env:
   TIER2_REVIEWERS: "jstjohn,trvachov,pstjohn"
 
 jobs:
-  enforce_tiered_approvals:
+  check_approval:
     runs-on: ubuntu-latest
-
+    outputs:
+      status: ${{ steps.check_tier2.outputs.status }}
     steps:
       - name: Get PR reviews
         id: get_reviews
@@ -64,6 +65,7 @@ jobs:
             echo "status=failed" >> $GITHUB_OUTPUT
           fi
 
-      - name: required-approvals
-        if: ${{ steps.check_tier2.outputs.status == 'passed' }}
-        run: echo "Required approvals met for Tier 2 Reviewers."
+  has_approval:
+    needs: check_approval
+    if : ${{ needs.check_approval.outputs.status == 'passed' }}
+    runs-on: ubuntu-latest

--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -59,8 +59,11 @@ jobs:
           done
 
           if [[ "$TIER2_APPROVED" == "true" ]]; then
-            echo "A +2 reviewer has approved the pull request."
+            echo "status=passed" >> $GITHUB_OUTPUT
           else
-            echo "No +2 reviewer has approved the pull request."
-            exit 1
+            echo "status=failed" >> $GITHUB_OUTPUT
           fi
+
+      - name: required-approvals
+        if: ${{ steps.check_tier2.outputs.status == 'passed' }}
+        run: echo "Required approvals met for Tier 2 Reviewers."


### PR DESCRIPTION
Rather than having a bunch of red 'X's on PRs that haven't gotten the required +2 review, we could have a conditional step that only runs when the required approvals are met. If we mark this as the required step in our branch rules it has the same effect, without cluttering our PR status with a bunch of failed status checks