### PR TITLE
Mark geneformer test_pretrain_cli as slow

### DIFF
--- a/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/scripts/test_train_geneformer.py
+++ b/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/scripts/test_train_geneformer.py
@@ -181,6 +181,7 @@ def test_throws_tok_not_in_vocab_error(tmpdir, data_path):
     assert "not in the tokenizer vocab." in str(error_info.value)
 
 
+@pytest.mark.slow
 def test_pretrain_cli(tmpdir, data_path):
     result_dir = Path(tmpdir.mkdir("results"))
     open_port = find_free_network_port()

--- a/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/scripts/test_train_geneformer.py
+++ b/sub-packages/bionemo-geneformer/tests/bionemo/geneformer/scripts/test_train_geneformer.py
@@ -181,7 +181,7 @@ def test_throws_tok_not_in_vocab_error(tmpdir, data_path):
     assert "not in the tokenizer vocab." in str(error_info.value)
 
 
-@pytest.mark.slow
+@pytest.mark.slow  # TODO: https://jirasw.nvidia.com/browse/BIONEMO-677, figure out why this is so slow.
 def test_pretrain_cli(tmpdir, data_path):
     result_dir = Path(tmpdir.mkdir("results"))
     open_port = find_free_network_port()


### PR DESCRIPTION
This is one remaining outlier in our current test suite that takes a long time to run (~3 minutes by itself). https://app.codecov.io/gh/NVIDIA/bionemo-framework/tests/main

With #634 we'll run these tests anyways during the merge queue step, but marking this as slow should speed up the coverage runs in PRs and post-merge