### PR TITLE
Add initial amplify package structure

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,6 +47,7 @@
 					"./sub-packages/bionemo-geneformer/src",
 					"./sub-packages/bionemo-llm/src",
 					"./sub-packages/bionemo-testing/src",
+					"./sub-packages/bionemo-amplify/src",
 					"./sub-packages/bionemo-example_model/src",
 					"./3rdparty/NeMo",
 					"./3rdparty/Megatron-LM"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ nemo_toolkit = { workspace = true }
 megatron-core = { workspace = true }
 # in sub-packages/
 bionemo-core = { workspace = true }
+bionemo-amplify = { workspace = true }
 bionemo-esm2 = { workspace = true }
 bionemo-example_model = { workspace = true }
 bionemo-fw = { workspace = true }

--- a/sub-packages/bionemo-amplify/README.md
+++ b/sub-packages/bionemo-amplify/README.md
@@ -1,0 +1,11 @@
+# bionemo-amplify
+
+To install, execute the following:
+```bash
+pip install -e .
+```
+
+To run unit tests, execute:
+```bash
+pytest -v .
+```

--- a/sub-packages/bionemo-amplify/VERSION
+++ b/sub-packages/bionemo-amplify/VERSION
@@ -1,0 +1,1 @@
+VERSION

--- a/sub-packages/bionemo-amplify/pyproject.toml
+++ b/sub-packages/bionemo-amplify/pyproject.toml
@@ -1,0 +1,31 @@
+
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bionemo-amplify"
+readme = "README.md"
+description = ""
+authors = [{ name = "BioNeMo Team", email = "bionemofeedback@nvidia.com" }]
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+dynamic = ["version"]
+dependencies = [
+    # internal
+    'bionemo-core',
+    'bionemo-llm',
+    # external
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["bionemo.*"]
+namespaces = true
+exclude = ["test*."]
+
+[tool.uv]
+cache-keys = [{ git = true }]
+
+[tool.setuptools.dynamic]
+version = { file = "VERSION" }

--- a/sub-packages/bionemo-amplify/src/bionemo/amplify/__init__.py
+++ b/sub-packages/bionemo-amplify/src/bionemo/amplify/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sub-packages/bionemo-amplify/tests/bionemo/amplify/__init__.py
+++ b/sub-packages/bionemo-amplify/tests/bionemo/amplify/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/data/__init__.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/data/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sub-packages/bionemo-fw/pyproject.toml
+++ b/sub-packages/bionemo-fw/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     'bionemo-scdl',
     'bionemo-size-aware-batching',
     'bionemo-webdatamodule',
+    'bionemo-amplify',
     #
     # NOTE: DO **NOT** INCLUDE:
     #    bionemo-testing (test-time only dependency)


### PR DESCRIPTION
Adds a new empty bionemo sub-package to house the AMPLIFY model. Also adds a missing __init__ file in the esm2 test suite to distinguish future tests with similar names.