### PR TITLE
draft: adding FIXME/XFAIL issue linter to pre commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,19 @@ repos:
         additional_dependencies: ["click==8.1.7"]
         pass_filenames: false
         always_run: true
+  - repo: local
+    hooks:
+      - id: lint-xfail-fixme
+        name: Lint XFAIL and FIXME markers
+        entry: python internal/scripts/lint_xfail_fixme.py
+        language: python
+        files: \.(py|sh|dockerfile|yaml|yml)$
+        exclude: |
+            (?x)^(
+                \.|
+                __pycache__/|
+                build/|
+                dist/|
+                3rdparty/
+            )
+        additional_dependencies: [ typing ]

--- a/internal/scripts/lint_xfail_fixme.py
+++ b/internal/scripts/lint_xfail_fixme.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Linter enforcing issue tracking for XFAILs and technical debt markers.
+
+This script scans source code files to ensure proper issue tracking by:
+1. Verifying pytest.mark.xfail decorators have associated GitHub issue links
+2. Ensuring FIXME/XXX/HACK comments have corresponding issue links
+
+Usage:
+    python lint_xfail_fixme.py
+
+Exit codes:
+    0: All checks passed
+    1: Issues found
+
+Examples:
+    # Run from project root
+    $ python lint_xfail_fixme.py
+    Scanning files from: /path/to/project
+
+    Linter found 2 issues:
+      Line 45: XFAIL missing required issue link
+        > @pytest.mark.xfail(reason="Known issue with batch processing")
+
+      Line 123: FIXME missing required issue link
+        > # FIXME: Handle edge case with empty input
+
+Good practices:
+    @pytest.mark.xfail(reason="Known issue https://github.com/NVIDIA/bionemo-framework/issues/123")
+    # FIXME: Need better error handling https://github.com/NVIDIA/bionemo-framework/issues/456
+"""
+
+import os
+import re
+import sys
+from typing import List, Optional, Set, Tuple
+
+
+THIS_FILENAME = os.path.abspath(__file__)
+ISSUE_PATTERN = r"https://github\.com/NVIDIA/bionemo-framework/issues/\d+"
+TODO_PATTERN = r"\b( fix|FIXME|XXX)\b"
+SKIP_DIRS = [".git", "__pycache__", ".pytest_cache", "build", "dist", "3rdparty"]
+SOURCE_EXTENSIONS = (".py", ".sh", "Dockerfile", ".yaml", ".yml")
+
+
+def find_all_files(root_dir: str) -> Set[str]:
+    """Find all source code files recursively from the root directory."""
+    all_files = []
+    for root, _, files in os.walk(root_dir):
+        if any(skip in root.split(os.path.sep) for skip in SKIP_DIRS):
+            continue
+        for file in files:
+            if file.endswith(SOURCE_EXTENSIONS):
+                all_files.append(os.path.join(root, file))
+    return set(all_files)
+
+
+def check_xfail_issues(file_path: str) -> List[Tuple[int, str, str]]:
+    """Check if pytest.mark.xfail has associated issue links."""
+    errors = []
+    if not os.path.basename(file_path).startswith("test_"):
+        return errors
+
+    with open(file_path, "r", encoding="utf-8") as f:
+        for line_num, line in enumerate(f, 1):
+            if "pytest.mark.xfail" in line:
+                if not re.search(ISSUE_PATTERN, line):
+                    errors.append(
+                        (line_num, f"XFAIL in {file_path}:{line_num} missing required issue link", line.strip())
+                    )
+    return errors
+
+
+def check_fixme_issues(file_path: str) -> List[Tuple[int, str, str]]:
+    """Check if FIXME comments have associated issue links."""
+    errors = []
+    with open(file_path, "r", encoding="utf-8") as f:
+        for line_num, line in enumerate(f, 1):
+            if re.search(TODO_PATTERN, line, re.IGNORECASE):
+                if not re.search(ISSUE_PATTERN, line):
+                    errors.append(
+                        (line_num, f"FIXME in {file_path}:{line_num} missing required issue link", line.strip())
+                    )
+    return errors
+
+
+def main(files: Optional[Set[str]] = None) -> None:
+    """Main entry point for the linter script."""
+    root_dir = os.getcwd()
+    if files is None:
+        print(f"Scanning files from: {root_dir}")
+        files = find_all_files(root_dir)
+    errors = []
+
+    for file_path in files:
+        if file_path in THIS_FILENAME:
+            continue
+        rel_path = os.path.relpath(file_path, root_dir)
+        try:
+            file_errors = check_xfail_issues(file_path)
+            errors.extend(
+                [
+                    (line_num, msg.replace(file_path, rel_path), line_content)
+                    for line_num, msg, line_content in file_errors
+                ]
+            )
+
+            file_errors = check_fixme_issues(file_path)
+            errors.extend(
+                [
+                    (line_num, msg.replace(file_path, rel_path), line_content)
+                    for line_num, msg, line_content in file_errors
+                ]
+            )
+        except UnicodeDecodeError:
+            print(f"Warning: Skipping binary file {rel_path}")
+            continue
+
+    if errors:
+        for line_num, error, line_content in sorted(errors, key=lambda x: x[1]):
+            print(f"  Line {line_num}: {error}")
+            print(f"    > {line_content}")
+            print()
+        sys.exit(1)
+    sys.exit(0)
+
+
+def get_files_from_precommit() -> Optional[Set[str]]:
+    """Captures filenames passed from command line or by pre-commit hook."""
+    files = None
+    if len(sys.argv) > 1:
+        files = set(sys.argv[1:])
+    if "PRE_COMMIT_FILES" in os.environ:
+        files = set(os.environ["PRE_COMMIT_FILES"].split())
+    return files
+
+
+def entrypoint():
+    """Entrypoint of the linter script."""
+    files = get_files_from_precommit()
+    main(files)
+
+
+if __name__ == "__main__":
+    entrypoint()


### PR DESCRIPTION
### Description
We want to ensure that all issues marked to be fixed in the codebase have corresponding github issue created ie
* pytest.mark.xfail has associated github issue link
* FIXME comments have associated issue links

This promotes good practices such as
@pytest.mark.xfail(reason="Known issue https://github.com/NVIDIA/bionemo-framework/issues/123")
# FIXME: Need better error handling https://github.com/NVIDIA/bionemo-framework/issues/456

Implemented this simple and lightweight  linter scripted employed with pre commit hook, which can also be run from the command line

### Type of changes

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing


> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

### Usage

```bash
# or pre-commit run --all-files
python internal/scripts/lint_xfail_fixme.py

Scanning files from: /Users/dorotat/experiments/bionemo-framework
  Line 170: FIXME in .github/workflows/unit-tests.yml:170 missing required issue link
    > # TODO: figure out way of cleaning up working directory (requires sudo or for us to fix file ownership from release container)

  Line 13: FIXME in .pre-commit-config.yaml:13 missing required issue link
    > # 1. Attempt to automatically fix any lint issues.

  Line 37: FIXME in .pre-commit-config.yaml:37 missing required issue link
    > - id: lint-xfail-fixme

  Line 38: FIXME in .pre-commit-config.yaml:38 missing required issue link
    > name: Lint XFAIL and FIXME markers

  Line 184: FIXME in Dockerfile:184 missing required issue link
    > # FIXME the following result in unstable training curves even if they are faster

  Line 240: FIXME in Dockerfile:240 missing required issue link
    > # FIXME the following results in unstable training curves even if faster.

  Line 109: FIXME in internal/infra-bionemo/tests/test_infra_bionemo/test_license_check.py:109 missing required issue link
    > # valid w/o license header, but automatic fix works

  Line 207: FIXME in internal/infra-bionemo/tests/test_infra_bionemo/test_license_check.py:207 missing required issue link
    > # can fix if there are no invalid files

  Line 139: FIXME in sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/finetune_esm2.py:139 missing required issue link
    > resume_if_exists (bool): attempt to resume if the checkpoint exists [FIXME @skothenhill this doesn't work yet]

  Line 530: FIXME in sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/finetune_esm2.py:530 missing required issue link
    > # FIXME (@skothenhill) figure out how checkpointing and resumption should work with the new nemo trainer

  Line 129: FIXME in sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py:129 missing required issue link
    > resume_if_exists (bool): attempt to resume if the checkpoint exists [FIXME @skothenhill this doesn't work yet]

  Line 467: FIXME in sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py:467 missing required issue link
    > # FIXME (@skothenhill) figure out how checkpointing and resumption should work with the new nemo trainer

  Line 343: FIXME in sub-packages/bionemo-example_model/src/bionemo/example_model/lightning/lightning_basic.py:343 missing required issue link
    > # FIXME add an assertion that the user is not trying to do tensor parallelism since this doesn't use

  Line 132: FIXME in sub-packages/bionemo-geneformer/src/bionemo/geneformer/scripts/train_geneformer.py:132 missing required issue link
    > resume_if_exists (bool): attempt to resume if the checkpoint exists [FIXME @skothenhill this doesn't work yet]

  Line 298: FIXME in sub-packages/bionemo-geneformer/src/bionemo/geneformer/scripts/train_geneformer.py:298 missing required issue link
    > bias_dropout_fusion=True,  # TODO fix the recompilation issue, but for now it's faster even with recompilations

  Line 405: FIXME in sub-packages/bionemo-geneformer/src/bionemo/geneformer/scripts/train_geneformer.py:405 missing required issue link
    > # FIXME (@skothenhill) figure out how checkpointing and resumption should work with the new nemo trainer

  Line 63: FIXME in sub-packages/bionemo-geneformer/tests/bionemo/geneformer/test_stop_and_go.py:63 missing required issue link
    > # FIXME: for now the test doesn't work unless dropout is inactivated because the megatron rng state is not saved

  Line 103: FIXME in sub-packages/bionemo-llm/src/bionemo/llm/model/biobert/model.py:103 missing required issue link
    > "activation_func",  # FIXME hack: update the ESM2 checkpoint with the updated activation function and don't override

  Line 119: FIXME in sub-packages/bionemo-llm/src/bionemo/llm/train.py:119 missing required issue link
    > overlap_param_gather=False,  # TODO waiting for NeMo fix

  Line 27: XFAIL in sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_convert.py:27 missing required issue link
    > # pytestmark = pytest.mark.xfail(

  Line 157: XFAIL in sub-packages/bionemo-llm/tests/bionemo/llm/model/test_loss.py:157 missing required issue link
    > @pytest.mark.xfail(reason="tensor_parallel.vocab_parallel_cross_entropy modifies input token_logits")

  Line 168: XFAIL in sub-packages/bionemo-llm/tests/bionemo/llm/test_lightning.py:168 missing required issue link
    > @pytest.mark.xfail(reason="MegatronStrategy no longer has '_get_loss_reduction' attribute")

  Line 311: XFAIL in sub-packages/bionemo-noodles/tests/bionemo/noodles/test_nvfaidx.py:311 missing required issue link
    > @pytest.mark.xfail(reason="This is a known failure mode for pyfaidx that we are trying to prevent with nvfaidx.")

```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
