### PR TITLE
CI hotfix: NGC access

### DIFF
--- a/sub-packages/bionemo-core/tests/bionemo/core/data/test_load.py
+++ b/sub-packages/bionemo-core/tests/bionemo/core/data/test_load.py
@@ -45,8 +45,9 @@ def test_load_raises_error_on_invalid_tag(tmp_path):
 def test_load_cli():
     # It looks like there's some issues with our NGC resources, but this is blocking CI. TODO: Revert to ngc when these
     # resources are available.
+    # FIXME (dorotat): set source=ngc once the access issue with NGC is resolved (https://github.com/NVIDIA/bionemo-framework/issues/682)
     result = subprocess.run(
-        ["download_bionemo_data", "--source", "ngc", "single_cell/testdata-20240506"],
+        ["download_bionemo_data", "--source", "pbss", "single_cell/testdata-20240506"],
         stdout=subprocess.PIPE,  # Capture stdout
         stderr=subprocess.PIPE,  # Capture stderr (optional)
         text=True,  # Return output as string rather than bytes

--- a/sub-packages/bionemo-core/tests/bionemo/core/data/test_load_notebook.ipynb
+++ b/sub-packages/bionemo-core/tests/bionemo/core/data/test_load_notebook.ipynb
@@ -42,8 +42,9 @@
     }
    ],
    "source": [
+    "# FIXME (dorotat): set source=ngc once the access issue with NGC is resolved (https://github.com/NVIDIA/bionemo-framework/issues/682)\n",
     "with tempfile.TemporaryDirectory() as cache_dir:\n",
-    "    load(\"scdl/sample\", source=\"ngc\", cache_dir=Path(cache_dir))"
+    "    load(\"scdl/sample\", source=\"pbss\", cache_dir=Path(cache_dir))"
    ]
   }
  ],


### PR DESCRIPTION
### Description
The unit tests in CI are failing due to issues with NGC. Temporary changes source=ngc to source=pbss in the failing unit tests

Issue to track: https://github.com/NVIDIA/bionemo-framework/issues/682

### Type of changes

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing


> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [x] I have tested these changes locally
 - [x] I have updated the documentation accordingly
 - [x] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
