### PR TITLE
Allow for  multiline copyright licenses

### DIFF
--- a/internal/infra-bionemo/src/infra_bionemo/license_check.py
+++ b/internal/infra-bionemo/src/infra_bionemo/license_check.py
@@ -44,7 +44,9 @@ __all__: Sequence[str] = (
     "main",
 )
 
-NVIDIA_COPYRIGHT: str = "# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved."
+NVIDIA_COPYRIGHT: str = (
+    "# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved."
+)
 APACHE_BLOCK: str = """
 # SPDX-License-Identifier: LicenseRef-Apache2
 #
@@ -138,12 +140,13 @@ def is_valid_python(pyfile_contents: str) -> Optional[SyntaxError]:
 
 def has_header(pyfile_contents: str, *, license_header: str = LICENSE_HEADER) -> bool:
     """Check if file has valid license header.
+
     First checks if file has multiple copyright lines - if so, validates structure only.
     If not, and custom license_header provided, does exact string match.
     Otherwise validates basic structure.
     """
-    lines = pyfile_contents.split('\n')
-    
+    lines = pyfile_contents.split("\n")
+
     # Count copyright lines at start of file
     copyright_count = 0
     for line in lines:
@@ -151,43 +154,43 @@ def has_header(pyfile_contents: str, *, license_header: str = LICENSE_HEADER) ->
             copyright_count += 1
         else:
             break
-            
+
     # If file has multiple copyrights, only validate structure
     if copyright_count > 1:
         # Must start with NVIDIA copyright
         if not lines or not lines[0].strip() == NVIDIA_COPYRIGHT:
             return False
-            
+
         # Find where Apache block starts
         apache_start = None
         for i, line in enumerate(lines):
             if line.strip().startswith("# SPDX-License-Identifier: LicenseRef-Apache2"):
                 apache_start = i
                 break
-                
+
         if apache_start is None:
             return False
-            
+
         # All lines between NVIDIA copyright and Apache block must be valid SPDX copyright lines
         for line in lines[1:apache_start]:
             if line.strip() and not line.strip().startswith("# SPDX-FileCopyrightText: Copyright"):
                 return False
-                
+
         # Check Apache block matches exactly
-        apache_lines = APACHE_BLOCK.split('\n')
+        apache_lines = APACHE_BLOCK.split("\n")
         if len(lines[apache_start:]) < len(apache_lines):
             return False
-            
-        for actual, expected in zip(lines[apache_start:apache_start + len(apache_lines)], apache_lines):
+
+        for actual, expected in zip(lines[apache_start : apache_start + len(apache_lines)], apache_lines):
             if actual.strip() != expected.strip():
                 return False
-                
+
         return True
-    
+
     # Otherwise, if custom header provided, use exact match
     if license_header != LICENSE_HEADER:
         return pyfile_contents.startswith(license_header)
-        
+
     # Otherwise do basic structure validation
     return lines[0].strip() == NVIDIA_COPYRIGHT and pyfile_contents.startswith(LICENSE_HEADER)
 

--- a/internal/infra-bionemo/src/infra_bionemo/license_check.py
+++ b/internal/infra-bionemo/src/infra_bionemo/license_check.py
@@ -44,8 +44,8 @@ __all__: Sequence[str] = (
     "main",
 )
 
-LICENSE_HEADER: str = """
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+NVIDIA_COPYRIGHT: str = "# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved."
+APACHE_BLOCK: str = """
 # SPDX-License-Identifier: LicenseRef-Apache2
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,6 +60,9 @@ LICENSE_HEADER: str = """
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """.strip()
+
+# default header (split to allow for intermediate copyright headers)
+LICENSE_HEADER = f"{NVIDIA_COPYRIGHT}\n{APACHE_BLOCK}"
 
 
 @dataclass(frozen=True)
@@ -134,8 +137,59 @@ def is_valid_python(pyfile_contents: str) -> Optional[SyntaxError]:
 
 
 def has_header(pyfile_contents: str, *, license_header: str = LICENSE_HEADER) -> bool:
-    """True if the :param:`pyfile_contents` starts with the :param:`license_header`. False otherwise."""
-    return pyfile_contents.startswith(license_header)
+    """Check if file has valid license header.
+    First checks if file has multiple copyright lines - if so, validates structure only.
+    If not, and custom license_header provided, does exact string match.
+    Otherwise validates basic structure.
+    """
+    lines = pyfile_contents.split('\n')
+    
+    # Count copyright lines at start of file
+    copyright_count = 0
+    for line in lines:
+        if line.strip().startswith("# SPDX-FileCopyrightText: Copyright"):
+            copyright_count += 1
+        else:
+            break
+            
+    # If file has multiple copyrights, only validate structure
+    if copyright_count > 1:
+        # Must start with NVIDIA copyright
+        if not lines or not lines[0].strip() == NVIDIA_COPYRIGHT:
+            return False
+            
+        # Find where Apache block starts
+        apache_start = None
+        for i, line in enumerate(lines):
+            if line.strip().startswith("# SPDX-License-Identifier: LicenseRef-Apache2"):
+                apache_start = i
+                break
+                
+        if apache_start is None:
+            return False
+            
+        # All lines between NVIDIA copyright and Apache block must be valid SPDX copyright lines
+        for line in lines[1:apache_start]:
+            if line.strip() and not line.strip().startswith("# SPDX-FileCopyrightText: Copyright"):
+                return False
+                
+        # Check Apache block matches exactly
+        apache_lines = APACHE_BLOCK.split('\n')
+        if len(lines[apache_start:]) < len(apache_lines):
+            return False
+            
+        for actual, expected in zip(lines[apache_start:apache_start + len(apache_lines)], apache_lines):
+            if actual.strip() != expected.strip():
+                return False
+                
+        return True
+    
+    # Otherwise, if custom header provided, use exact match
+    if license_header != LICENSE_HEADER:
+        return pyfile_contents.startswith(license_header)
+        
+    # Otherwise do basic structure validation
+    return lines[0].strip() == NVIDIA_COPYRIGHT and pyfile_contents.startswith(LICENSE_HEADER)
 
 
 def append_license_header(pyfile_contents: str, *, license_header: str = LICENSE_HEADER, n_sep_lines: int = 2) -> str:


### PR DESCRIPTION
### Description
The current license check isn't flexible for licenses with multiple copyright lines. While we can pass in custom `license_header` files, we can't a per-file level, so doing so would overwrite any custom licenses.

To account for this, I've modified the license header check rule (`has_header`) to check for the NV copyright line, followed by zero or more other copyright lines, followed by our Apache block.

The new validation is then:
- Any files with single copyright lines (e.g. the regular license) follow the original logic of the script.
- Any file with multiple copyright lines is validated _only for structure_ (NVIDIA first, then other copyrights, then Apache). In other words, if you pass in a custom license_header (our default behavior), it will not affect any license with multiple copyright lines. The logic here being that we don't want to blindly overwrite these licenses by accident for e.g. a year update in `./license_header`.

Specifically:

1. If file has multiple copyright lines (copyright_count > 1):
- We ONLY validate the structure: NVIDIA first, then other copyrights, then Apache
- We ignore any custom license_header completely
- File is kept unchanged if structure is valid


2. If file has single/no copyright lines AND custom license_header is provided:
- Use exact string matching with the provided license_header
- File will be modified if it doesn't match exactly


3. If file has single/no copyright lines AND no custom license_header:
- Validate against default LICENSE_HEADER (NVIDIA + Apache)
- File will be modified if it doesn't match




### Type of changes
<!-- Mark the relevant option with an [x] -->

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [x]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing


> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
