### PR TITLE
remove zstandard to address nvbug 5149698

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,9 +111,10 @@ uv pip install --no-build-isolation \
   -r /requirements-cve.txt \
   -r /requirements-test.txt
 
-# Addressing security scan issue - CVE vulnerability https://github.com/advisories/GHSA-g4r7-86gm-pgqc
-# The package is a dependency of lm_eval from NeMo requirements_eval.txt
-uv pip uninstall sqlitedict
+# Addressing security scan issue - CVE vulnerability https://github.com/advisories/GHSA-g4r7-86gm-pgqc The package is a
+# dependency of lm_eval from NeMo requirements_eval.txt. We also remove zstandard, another dependency of lm_eval, which
+# seems to be causing issues with NGC downloads. See https://nvbugspro.nvidia.com/bug/5149698
+uv pip uninstall sqlitedict zstandard
 
 rm -rf ./3rdparty
 rm -rf /tmp/*


### PR DESCRIPTION
Removes `zstandard` after installing NeMo to avoid issues like the following downloading large binary files with ngcsdk. 

https://nvbugspro.nvidia.com/bug/5149698

```
    raise DecodeError(
urllib3.exceptions.DecodeError: ('Received response with content-encoding: zstd, but failed to decode it.', ZstdError('cannot use a decompressobj multiple times'))
...
requests.exceptions.ContentDecodingError: ('Received response with content-encoding: zstd, but failed to decode it.', ZstdError('cannot use a decompressobj multiple times'))
```