### PR TITLE
Trigger and skip trufflehog scan in merge group

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 permissions:
   contents: read
@@ -25,6 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: TruffleHog OSS
+        if: github.event_name != 'merge_group'
         id: trufflehog
         uses: trufflesecurity/trufflehog@main
         continue-on-error: true


### PR DESCRIPTION
This is a required check, but isn't really needed and doesn't seem to work properly in a merge queue. Here we skip the scan if we're in a merge queue