### PR TITLE
If desired, training can be stopped on a specific step without impacting the LR curve.

### DIFF
--- a/sub-packages/bionemo-evo2/src/bionemo/evo2/run/train.py
+++ b/sub-packages/bionemo-evo2/src/bionemo/evo2/run/train.py
@@ -482,7 +482,11 @@ def train(args: argparse.Namespace):
         callbacks.append(checkpoint_callback)
     if args.early_stop_on_step:
         # Ask the trainer to stop by setting should_stop to True rather than emitting a kill signal.
-        callbacks.append(SignalAfterGivenStepCallback(stop_step=args.early_stop_on_step, use_trainer_should_stop=True))
+        callbacks.append(
+            SignalAfterGivenStepCallback(
+                stop_step=args.early_stop_on_step, stop_before_step=True, use_trainer_should_stop=True
+            )
+        )
     if args.enable_preemption:
         callbacks.append(nl_callbacks.PreemptionCallback())
     if args.debug_ddp_parity_freq > 0:

--- a/sub-packages/bionemo-evo2/src/bionemo/evo2/run/train.py
+++ b/sub-packages/bionemo-evo2/src/bionemo/evo2/run/train.py
@@ -48,6 +48,7 @@ from nemo.lightning.pytorch.strategies.utils import RestoreConfig
 from nemo.utils.exp_manager import TimingCallback
 
 from bionemo.llm.utils.datamodule_utils import infer_global_batch_size
+from bionemo.testing.testing_callbacks import SignalAfterGivenStepCallback
 
 
 torch._dynamo.config.suppress_errors = True
@@ -119,7 +120,18 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--grad-acc-batches", type=int, default=1, help="Number of batches to accumulate gradients over."
     )
-    parser.add_argument("--max-steps", type=int, help="Number of training optimizer update steps.")
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        help="Number of training optimizer update steps. This controls the total number of steps as well as the "
+        "shape of the learning rate curve.",
+        default=500000,
+    )
+    parser.add_argument(
+        "--early-stop-on-step",
+        type=int,
+        help="Stop training on this step, if set. This may be useful for testing or debugging purposes.",
+    )
     parser.add_argument(
         "--val-check-interval", type=int, help="Number of steps between validation measurements and model checkpoints."
     )
@@ -468,7 +480,9 @@ def train(args: argparse.Namespace):
             save_context_on_train_end=True,
         )
         callbacks.append(checkpoint_callback)
-
+    if args.early_stop_on_step:
+        # Ask the trainer to stop by setting should_stop to True rather than emitting a kill signal.
+        callbacks.append(SignalAfterGivenStepCallback(stop_step=args.early_stop_on_step, use_trainer_should_stop=True))
     if args.enable_preemption:
         callbacks.append(nl_callbacks.PreemptionCallback())
     if args.debug_ddp_parity_freq > 0:

--- a/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
+++ b/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
@@ -126,8 +126,6 @@ def test_train_evo2_stops(tmp_path, num_steps=500000, early_stop_steps=3):
 
     global_step_ints = extract_global_steps(train_stdout)
     assert global_step_ints[-1] == early_stop_steps - 1
-    # Note we stop after we see a global step matching the value requested. So you end up getting
-    # i+1 steps.
     assert len(global_step_ints) == early_stop_steps
 
 

--- a/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
+++ b/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 import os
+import re
 import subprocess
 import sys
 
@@ -71,6 +72,60 @@ def test_train_evo2_runs(tmp_path, num_steps=5):
     # Assert that the command completed successfully.
     assert "reduced_train_loss:" in result.stdout
     assert result.returncode == 0, "train_evo2 command failed."
+
+
+@pytest.mark.timeout(256)  # Optional: fail if the test takes too long.
+@pytest.mark.slow
+def test_train_evo2_stops(tmp_path, num_steps=500000, early_stop_steps=3):
+    """
+    This test runs the `train_evo2` command with mock data in a temporary directory.
+    It uses the temporary directory provided by pytest as the working directory.
+    The command is run in a subshell, and we assert that it returns an exit code of 0.
+    """
+    open_port = find_free_network_port()
+    # a local copy of the environment
+    env = dict(**os.environ)
+    env["MASTER_PORT"] = str(open_port)
+
+    # Build the command string.
+    # Note: The command assumes that `train_evo2` is in your PATH.
+    command = (
+        f"train_evo2 --mock-data --experiment-dir {tmp_path}/test_train "
+        "--model-size 1b_nv --num-layers 4 --hybrid-override-pattern SDH* "
+        "--no-activation-checkpointing --add-bias-output "
+        f"--max-steps {num_steps} --early-stop-on-step {early_stop_steps} --warmup-steps 1 --no-wandb "
+        "--seq-length 128 --hidden-dropout 0.1 --attention-dropout 0.1 "
+    )
+
+    # Run the command in a subshell, using the temporary directory as the current working directory.
+    result = subprocess.run(
+        command,
+        shell=True,  # Use the shell to interpret wildcards (e.g. SDH*)
+        cwd=tmp_path,  # Run in the temporary directory
+        capture_output=True,  # Capture stdout and stderr for debugging
+        env=env,  # Pass in the env where we override the master port.
+        text=True,  # Decode output as text
+    )
+
+    # For debugging purposes, print the output if the test fails.
+    if result.returncode != 0:
+        sys.stderr.write("STDOUT:\n" + result.stdout + "\n")
+        sys.stderr.write("STDERR:\n" + result.stderr + "\n")
+
+    # Assert that the command completed successfully.
+    assert "reduced_train_loss:" in result.stdout
+    assert result.returncode == 0, "train_evo2 command failed."
+    pattern = r"\| global_step: (\d+) \|"
+
+    def extract_global_steps(log_string):
+        matches = re.findall(pattern, log_string)
+        return [int(step) for step in matches]
+
+    global_step_ints = extract_global_steps(result.stdout)
+    assert global_step_ints[-1] == early_stop_steps - 1
+    # Note we stop after we see a global step matching the value requested. So you end up getting
+    # i+1 steps.
+    assert len(global_step_ints) == early_stop_steps
 
 
 @pytest.mark.slow

--- a/sub-packages/bionemo-testing/src/bionemo/testing/testing_callbacks.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/testing_callbacks.py
@@ -49,15 +49,23 @@ class SignalAfterGivenStepCallback(Callback, CallbackMethods):
     Use this callback for pytest based Stop and go tests.
     """
 
-    def __init__(self, stop_step: int, signal_: signal.Signals = signal.SIGUSR2):
+    def __init__(
+        self, stop_step: int, signal_: signal.Signals = signal.SIGUSR2, use_trainer_should_stop: bool = False
+    ):
         """Initializes the callback with the given stop_step."""
         self.stop_step = stop_step
         self.signal = signal_
+        # If True, ask the trainer to stop by setting should_stop to True rather than emitting a kill signal.
+        self.use_trainer_should_stop = use_trainer_should_stop
 
     def on_megatron_step_start(self, step: MegatronStep) -> MegatronStep:
         """Stop training if the global step is greater than or equal to the stop_step."""
         if step.trainer.global_step >= self.stop_step:
-            os.kill(os.getpid(), self.signal)
+            if self.use_trainer_should_stop:
+                # Ask the trainer to stop by setting should_stop to True rather than emitting a kill signal.
+                step.trainer.should_stop = True
+            else:
+                os.kill(os.getpid(), self.signal)
         return step
 
 

--- a/sub-packages/bionemo-testing/src/bionemo/testing/testing_callbacks.py
+++ b/sub-packages/bionemo-testing/src/bionemo/testing/testing_callbacks.py
@@ -50,10 +50,19 @@ class SignalAfterGivenStepCallback(Callback, CallbackMethods):
     """
 
     def __init__(
-        self, stop_step: int, signal_: signal.Signals = signal.SIGUSR2, use_trainer_should_stop: bool = False
+        self,
+        stop_step: int,
+        signal_: signal.Signals = signal.SIGUSR2,
+        use_trainer_should_stop: bool = False,
+        stop_before_step: bool = False,
     ):
         """Initializes the callback with the given stop_step."""
-        self.stop_step = stop_step
+        # Note that the stop step will be one less than the requested step if stop_before_step is True.
+        #  this is because the first step is 0 so you get i+1 steps normally.
+        if stop_before_step:
+            self.stop_step = stop_step - 1
+        else:
+            self.stop_step = stop_step
         self.signal = signal_
         # If True, ask the trainer to stop by setting should_stop to True rather than emitting a kill signal.
         self.use_trainer_should_stop = use_trainer_should_stop


### PR DESCRIPTION
See new option `--early-stop-on-step` which may be used in JET tests to stop on a specific step without impacting the LR curve by changing `--max-steps`