### PR TITLE
fix: removes BIONEMO_HOME from repository [JIRA-BIONEMO-482]

### DIFF
--- a/ci/scripts/run_pytest.sh
+++ b/ci/scripts/run_pytest.sh
@@ -74,8 +74,6 @@ done
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "$SCRIPT_DIR/utils.sh" || { echo "Failed to source utils.sh" >&2; exit 1; }
 
-# Set up BioNeMo home directory
-set_bionemo_home || exit 1
 
 # Echo some useful information
 lscpu

--- a/ci/scripts/utils.sh
+++ b/ci/scripts/utils.sh
@@ -28,32 +28,6 @@ check_git_repository() {
     fi
 }
 
-set_bionemo_home() {
-    set +u
-    if [ -z "$BIONEMO_HOME" ]; then
-        echo "\$BIONEMO_HOME is unset. Setting \$BIONEMO_HOME to repository root."
-
-        # Ensure repository is clean
-        if ! check_git_repository; then
-            echo "Failed to set \$BIONEMO_HOME due to repository state." >&2
-            return 1
-        fi
-
-        REPOSITORY_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-        if [ $? -ne 0 ]; then
-            echo "ERROR: Could not determine the repository root. Ensure you're in a Git repository." >&2
-            return 1
-        fi
-
-        BIONEMO_HOME="${REPOSITORY_ROOT}"
-        echo "Setting \$BIONEMO_HOME to: $BIONEMO_HOME"
-    fi
-    set -u
-
-    # Change directory to BIONEMO_HOME or exit if failed
-    cd "${BIONEMO_HOME}" || { echo "ERROR: Could not change directory to \$BIONEMO_HOME: $BIONEMO_HOME" >&2; return 1; }
-}
-
 
 version_ge() {
         # Returns 0 (true) if $1 >= $2, 1 (false) otherwise

--- a/internal/scripts/run_dev.sh
+++ b/internal/scripts/run_dev.sh
@@ -35,7 +35,6 @@ docker run \
     --shm-size=4g \
     -e TMPDIR=/tmp/ \
     -e NUMBA_CACHE_DIR=/tmp/ \
-    -e BIONEMO_HOME=$DOCKER_REPO_PATH \
     -e WANDB_API_KEY=$WANDB_API_KEY \
     -e NGC_CLI_API_KEY=$NGC_CLI_API_KEY \
     -e NGC_CLI_ORG=$NGC_CLI_ORG \

--- a/justfile
+++ b/justfile
@@ -130,7 +130,6 @@ run is_dev is_interactive image_tag cmd: setup
   --shm-size=4g \
   -e TMPDIR=/tmp/ \
   -e NUMBA_CACHE_DIR=/tmp/ \
-  -e BIONEMO_HOME=$DOCKER_REPO_PATH \
   -e WANDB_API_KEY=$WANDB_API_KEY \
   -e NGC_CLI_API_KEY=$NGC_CLI_API_KEY \
   -e NGC_CLI_ORG=$NGC_CLI_ORG \


### PR DESCRIPTION
### Description
Removes all traced of BIONEMO_HOME ENVVAR and the setup_bionemo_home script from our repository.

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [X]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing


> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
