### PR TITLE
hotfix: docker build in CI

### DIFF
--- a/ci/scripts/build_docker_image.sh
+++ b/ci/scripts/build_docker_image.sh
@@ -107,6 +107,7 @@ else
 fi
 
 # Get Git commit SHA and sanitized branch name
+git config --global --add safe.directory "$(pwd)"
 COMMIT_SHA=$(git rev-parse HEAD)
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 SANITIZED_BRANCH_NAME=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g' | sed -E 's/^-+|-+$//g' | cut -c1-128)

--- a/ci/scripts/build_docker_image.sh
+++ b/ci/scripts/build_docker_image.sh
@@ -106,12 +106,6 @@ else
     CONTAINER_REGISTRY_PATH=""
 fi
 
-# Ensure repository is clean
-git config --global --add safe.directory $(pwd)
-if ! set_bionemo_home; then
-    exit 1
-fi
-
 # Get Git commit SHA and sanitized branch name
 COMMIT_SHA=$(git rev-parse HEAD)
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
### Description
THe commit from merge of https://github.com/NVIDIA/bionemo-framework/pull/742 introduced a change that broke docker building in CI. Hot fixing it

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing


> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
