### PR TITLE
hotfix CI:  failing test test_train_evo2_stops

### DIFF
--- a/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
+++ b/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
@@ -79,6 +79,10 @@ def test_train_evo2_runs(tmp_path, num_steps=5):
 
 @pytest.mark.timeout(256)  # Optional: fail if the test takes too long.
 @pytest.mark.slow
+@pytest.mark.skip(
+    reason="This test fails due to error when the checkpoints are saved. "
+    "Issue: https://github.com/NVIDIA/bionemo-framework/issues/760"
+)
 def test_train_evo2_stops(tmp_path, num_steps=500000, early_stop_steps=3):
     """
     This test runs the `train_evo2` command with mock data in a temporary directory.


### PR DESCRIPTION
### Description
Marking as skip failing unit test for Evo2

```
sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py::test_train_evo2_stops FAILED [ 79%]
.
.
.
11:44:55  /usr/local/lib/python3.12/dist-packages/lightning/pytorch/callbacks/model_checkpoint.py:385: in _save_topk_checkpoint
11:44:55      self._save_monitor_checkpoint(trainer, monitor_candidates)
11:44:55  /usr/local/lib/python3.12/dist-packages/lightning/pytorch/callbacks/model_checkpoint.py:705: in _save_monitor_checkpoint
11:44:55      self._update_best_and_save(current, trainer, monitor_candidates)
11:44:55  /usr/local/lib/python3.12/dist-packages/lightning/pytorch/callbacks/model_checkpoint.py:757: in _update_best_and_save
11:44:55      self._save_checkpoint(trainer, filepath)
11:44:55  /usr/local/lib/python3.12/dist-packages/nemo/lightning/pytorch/callbacks/model_checkpoint.py:628: in _save_checkpoint
11:44:55      TrainerContext.from_trainer(trainer).io_dump(ckpt_to_dir(filepath) / "context", yaml_attrs=["model"])
11:44:55  /usr/local/lib/python3.12/dist-packages/nemo/lightning/io/mixin.py:249: in io_dump
11:44:55      json = serialization.dump_json(io)
11:44:55  /usr/local/lib/python3.12/dist-packages/fiddle/_src/experimental/serialization.py:826: in dump_json
11:44:55      return json.dumps(Serialization(value, pyref_policy).result, indent=indent)
11:44:55  /usr/local/lib/python3.12/dist-packages/fiddle/_src/experimental/serialization.py:527: in __init__
11:44:55      _ROOT_KEY: self._serialize(self._root, (), all_paths=((),)),
11:44:55  /usr/local/lib/python3.12/dist-packages/nemo/lightning/io/fdl_torch.py:134: in _modified_serialize
11:44:55      return self._original_serialize(to_config(value), current_path, all_paths)
11:44:55  /usr/local/lib/python3.12/dist-packages/fiddle/_src/experimental/serialization.py:662: in _serialize
11:44:55      serialized_value = self._serialize(
11:44:55  /usr/local/lib/python3.12/dist-packages/nemo/lightning/io/fdl_torch.py:134: in _modified_serialize
11:44:55      return self._original_serialize(to_config(value), current_path, all_paths)
11:44:55  /usr/local/lib/python3.12/dist-packages/fiddle/_src/experimental/serialization.py:662: in _serialize
11:44:55      serialized_value = self._serialize(
11:44:55  /usr/local/lib/python3.12/dist-packages/nemo/lightning/io/fdl_torch.py:134: in _modified_serialize
11:44:55      return self._original_serialize(to_config(value), current_path, all_paths)
11:44:55  /usr/local/lib/python3.12/dist-packages/fiddle/_src/experimental/serialization.py:662: in _serialize
11:44:55      serialized_value = self._serialize(
11:44:55  /usr/local/lib/python3.12/dist-packages/nemo/lightning/io/fdl_torch.py:134: in _modified_serialize
11:44:55      return self._original_serialize(to_config(value), current_path, all_paths)
11:44:55  /usr/local/lib/python3.12/dist-packages/fiddle/_src/experimental/serialization.py:640: in _serialize
11:44:55      output = self._pyref(value, current_path)
11:44:55  /usr/local/lib/python3.12/dist-packages/fiddle/_src/experimental/serialization.py:579: in _pyref
11:44:55      if value is not import_symbol(self._pyref_policy, module_name, symbol):
11:44:55  /usr/local/lib/python3.12/dist-packages/fiddle/_src/experimental/serialization.py:293: in import_symbol
11:44:55      with reraised_exception.try_with_lazy_message(make_message):
11:44:55  /usr/lib/python3.12/contextlib.py:158: in __exit__
11:44:55      self.gen.throw(value)
11:44:55  /usr/local/lib/python3.12/dist-packages/fiddle/_src/reraised_exception.py:82: in try_with_lazy_message
11:44:55      raise decorate_exception(exc, message) from None
11:44:55  /usr/local/lib/python3.12/dist-packages/fiddle/_src/reraised_exception.py:74: in try_with_lazy_message
11:44:55      yield
11:44:55  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
11:44:55  
11:44:55  policy = <fiddle._src.experimental.serialization.DefaultPyrefPolicy object at 0x7f45b1797920>
11:44:55  module = 'megatron.core.utils', symbol = 'init_method_normal.<locals>.init_'
11:44:55  
11:44:55      def import_symbol(policy: PyrefPolicy, module: str, symbol: str):
11:44:55        """Returns the value obtained from importing `symbol` from `module`.
11:44:55      
11:44:55        Args:
11:44:55          policy: The `PyrefPolicy` governing which symbols can be imported.
11:44:55          module: The module to import `symbol` from.
11:44:55          symbol: The symbol to import from `module`.
11:44:55      
11:44:55        Raises:
11:44:55          ModuleNotFoundError: If `module` can't be found.
11:44:55          AttributeError: If `symbol` can't be accessed on `module`.
11:44:55          PyrefPolicyError: If importing `symbol` from `module` is disallowed by
11:44:55            this `PyrefPolicy`.
11:44:55        """
11:44:55        value = PyrefPolicyError.PRE_IMPORT
11:44:55        if policy.allows_import(module, symbol):
11:44:55          module = special_overrides.maybe_get_module_override_for_migrated_serialization_symbol(
11:44:55              module, symbol
11:44:55          )
11:44:55          make_message = functools.partial(_fiddle_pyref_context, module, symbol)
11:44:55          with reraised_exception.try_with_lazy_message(make_message):
11:44:55            value = importlib.import_module(module)
11:44:55            for attr_name in symbol.split('.'):
11:44:55  >           value = getattr(value, attr_name)
11:44:55  E           AttributeError: 'function' object has no attribute '<locals>'
11:44:55  E           Fiddle context: Error occurred while importing pyref to 'init_method_normal.<locals>.init_' from 'megatron.core.utils'.
```

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing


> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
