### PR TITLE
Remove llama-index from container to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -175,6 +175,8 @@ uv pip install nvidia-resiliency-ext/
 rm -rf nvidia-resiliency-ext/
 # ngcsdk causes strange dependency conflicts that we will resolve later
 sed -i "/ngcsdk/d" ./sub-packages/bionemo-core/pyproject.toml
+# Remove llama-index because bionemo doesn't use it and it adds CVEs to container
+sed -i "/llama-index/d" ./3rdparty/NeMo/requirements/requirements_nlp.txt
 uv pip install --no-build-isolation \
 ./3rdparty/*  \
 ./sub-packages/bionemo-* \


### PR DESCRIPTION
### Description
Removes llama-index from container to fix 2 HIGH and 1 CRIT CVE. We do not use this package and it's only used in nemo RAG here:

```
./3rdparty/NeMo/examples/nlp/rag/rag_generating.py:15:from llama_index.core import Settings, StorageContext, load_index_from_storage
./3rdparty/NeMo/examples/nlp/rag/rag_indexing.py:15:from llama_index.core import Settings, SimpleDirectoryReader, VectorStoreIndex
./3rdparty/NeMo/examples/nlp/rag/rag_indexing.py:16:from llama_index.core.node_parser import SentenceSplitter
./3rdparty/NeMo/nemo/collections/nlp/models/rag/custom_bert_embedder.py:19:from llama_index.core.bridge.pydantic import PrivateAttr
./3rdparty/NeMo/nemo/collections/nlp/models/rag/custom_bert_embedder.py:20:from llama_index.core.embeddings import BaseEmbedding
./3rdparty/NeMo/nemo/collections/nlp/models/rag/custom_gpt_llm.py:18:from llama_index.core.bridge.pydantic import PrivateAttr
./3rdparty/NeMo/nemo/collections/nlp/models/rag/custom_gpt_llm.py:19:from llama_index.core.llms import CompletionResponse, CompletionResponseGen, CustomLLM, LLMMetadata
./3rdparty/NeMo/nemo/collections/nlp/models/rag/custom_gpt_llm.py:20:from llama_index.core.llms.callbacks import llm_completion_callback
```


### Type of changes
<!-- Mark the relevant option with an [x] -->

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

* If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
* If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
