### PR TITLE
Fix ARM docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,14 +102,14 @@ fi
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
     mkdir -p /usr/lib/tiledb && \
     cd /usr/lib/tiledb && \
-    wget https://github.com/TileDB-Inc/TileDB/releases/download/2.27.0-rc3/tiledb-linux-arm64-2.27.0-rc3-8d581f2.tar.gz -O tiledb.tar.gz && \
+    wget https://github.com/TileDB-Inc/TileDB/releases/download/2.27.2/tiledb-linux-arm64-2.27.2-1757013.tar.gz -O tiledb.tar.gz && \
     tar -xvzf tiledb.tar.gz && export TILEDB_PATH=/usr/lib/tiledb && \
     cd / && \
     dpkg -l | awk '/libfmt/ {print $2}' | xargs apt-get remove -y && \
     dpkg -l | awk '/spdlog/ {print $2}' | xargs apt-get remove -y && \
     rm -f /usr/lib/*/cmake/spdlog/spdlogConfig.cmake && \
     rm -f /usr/lib/cmake/spdlog/spdlogConfig.cmake && \
-    git clone --single-branch --branch 1.15.0rc4 https://github.com/single-cell-data/TileDB-SOMA.git && \
+    git clone --single-branch --branch 1.16.1 https://github.com/single-cell-data/TileDB-SOMA.git && \
     cd TileDB-SOMA/apis/python && \
     pip install .; \
 fi
@@ -122,7 +122,16 @@ fi
 RUN pip --disable-pip-version-check --no-cache-dir install \
   git+https://github.com/state-spaces/mamba.git@v2.2.2 --no-deps
 
+# Nemo Run installation
 RUN pip install hatchling   # needed to install nemo-run
+# TorchX has a strange urllib3 dependency pin which doesn't seem necessary
+# We opened an issue for this: https://github.com/pytorch/torchx/issues/1040
+RUN git clone --depth=1 --branch v0.7.0 --single-branch https://github.com/pytorch/torchx.git \
+    && cd torchx \
+    && sed -i '/urllib3/d' requirements.txt \
+    && pip install . \
+    && cd .. \
+    && rm -rf torchx
 ARG NEMO_RUN_TAG=34259bd3e752fef94045a9a019e4aaf62bd11ce2
 RUN pip install nemo_run@git+https://github.com/NVIDIA/NeMo-Run.git@${NEMO_RUN_TAG}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,17 +123,10 @@ RUN pip --disable-pip-version-check --no-cache-dir install \
   git+https://github.com/state-spaces/mamba.git@v2.2.2 --no-deps
 
 # Nemo Run installation
-RUN pip install hatchling   # needed to install nemo-run
-# TorchX has a strange urllib3 dependency pin which doesn't seem necessary
-# We opened an issue for this: https://github.com/pytorch/torchx/issues/1040
-RUN git clone --depth=1 --branch v0.7.0 --single-branch https://github.com/pytorch/torchx.git \
-    && cd torchx \
-    && sed -i '/urllib3/d' requirements.txt \
-    && pip install . \
-    && cd .. \
-    && rm -rf torchx
-ARG NEMO_RUN_TAG=34259bd3e752fef94045a9a019e4aaf62bd11ce2
-RUN pip install nemo_run@git+https://github.com/NVIDIA/NeMo-Run.git@${NEMO_RUN_TAG}
+# Some things are pip installed in advance to avoid dependency issues during nemo_run installation
+RUN pip install hatchling urllib3  # needed to install nemo-run
+ARG NEMU_RUN_TAG=v0.3.0
+RUN pip install nemo_run@git+https://github.com/NVIDIA/NeMo-Run.git@${NEMU_RUN_TAG} --use-deprecated=legacy-resolver
 
 RUN mkdir -p /workspace/bionemo2/
 


### PR DESCRIPTION
### Description
ARM builds are still broken -- this should fix it. Just various dependency juggling. 

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

* If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
* If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [x] I have tested these changes locally
 - [x] I have updated the documentation accordingly
 - [x] I have added/updated tests as needed
 - [x] All existing tests pass successfully
