### PR TITLE
Remove temporary pins in docs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,5 +9,3 @@ mkdocs-include-dir-to-nav
 mkdocs-literate-nav
 mkdocs-site-urls
 mike
-griffe==1.6.2 # temporary pin for bionemo-noodles build issue with 1.6.3
-mistune==3.0.2 # temporary pin until https://github.com/lepture/mistune/issues/403 is resolved.


### PR DESCRIPTION
We added a number of temporary pins to our docs page to solve failures from pypi packages, but we can remove them now