### PR TITLE
Draft: outline push-to-gitlab-registry step

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -243,6 +243,7 @@ jobs:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # todo, get access to repo and set up auth for below login
       # - name: Login to GitLab Registry
       #   uses: docker/login-action@v3
       #   with:
@@ -253,7 +254,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: "recursive"
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Pull Docker image and verify tags
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -114,7 +114,6 @@ jobs:
             type=registry,ref=svcbionemo023/bionemo-build-cache:main
           cache-to: ${{ steps.cache.outputs.cache-to }}
 
-
   run-tests:
     needs:
       - build-bionemo-image
@@ -176,7 +175,6 @@ jobs:
         #  to run package by package like we do with the fast tests.
         run: ./ci/scripts/run_pytest.sh --no-nbval --only-slow --allow-no-tests
 
-
   run-notebooks-docs:
     needs:
       - build-bionemo-image
@@ -223,3 +221,53 @@ jobs:
             echo "All test jobs have completed successfully or been skipped!"
             exit 0
           fi
+
+  push-to-gitlab-registry:
+    needs:
+      - verify-tests-status # run after everything else
+      - build-bionemo-image # need docke stuff from
+    runs-on: linux-amd64-cpu16
+    # todo: remove third debugging check
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.ref == 'refs/heads/jwilber/642-ci-push-to-gitlab-registry'
+    steps:
+      - name: Debug information
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Ref: ${{ github.ref }}"
+          echo "Actor: ${{ github.actor }}"
+          echo "Run ID: ${{ github.run_id }}"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # - name: Login to GitLab Registry
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: gitlab-master.nvidia.com:5005
+      #     username: ${{ secrets.GITLAB_USERNAME }}
+      #     password: ${{ secrets.GITLAB_TOKEN }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Pull Docker image and verify tags
+        run: |
+          # Get CPU architecture
+          CPU_ARCH=$(uname -m)
+          echo "CPU Architecture: $CPU_ARCH"
+
+          # Get commit SHA
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          echo "Commit SHA: $COMMIT_SHA"
+
+          # Pull the Docker image from Docker Hub
+          echo "Would pull: svcbionemo023/bionemo-framework:${{ github.run_id }}"
+
+          # Show what would be pushed (for debugging)
+          echo "Would tag as: gitlab-master.nvidia.com:5005/clara-discovery/bionemo/bionemo-inter:main--${CPU_ARCH}--cache"
+          echo "Would tag as: gitlab-master.nvidia.com:5005/clara-discovery/bionemo/bionemo-inter:main--${CPU_ARCH}--${COMMIT_SHA}"


### PR DESCRIPTION
### Description
This corresponds to ticket https://jirasw.nvidia.com/browse/BIONEMO-642: add pushing images to gitlab registry from github actions.

Currently, it's a draft, as I don't have repo rights to add the required authentication tokens.

Changes:
- Added new `push-to-gitlab-registry` job

With steps to:
- debug info
- login to docker
- checkout repo
- verify docker image tags from prev build step
- check cpu architecture
- once I've verified this works + have authentication, I'll add the `buildx imagetools create` step to publish
