### PR TITLE
fix esm2 downstream task finetune config saving issue

### DIFF
--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/finetune_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/finetune_esm2.py
@@ -299,32 +299,40 @@ def train_model(
             metric_name="val_acc",
         )
 
-    config = config_class(
-        task_type=task_type,
-        encoder_frozen=encoder_frozen,
-        params_dtype=get_autocast_dtype(precision),
-        pipeline_dtype=get_autocast_dtype(precision),
-        autocast_dtype=get_autocast_dtype(precision),  # setting this speeds things up a lot
-        tensor_model_parallel_size=tensor_model_parallel_size,
-        pipeline_model_parallel_size=pipeline_model_parallel_size,
-        initial_ckpt_path=str(restore_from_checkpoint_path),
-        initial_ckpt_skip_keys_with_these_prefixes=[f"{task_type}_head"],
-        train_metric=train_metric,
-        valid_metric=valid_metric,
-    )
-    # Mapping of task-dependent config attributes to their new values
-    task_dependent_attr = {
-        "mlp_ft_dropout": mlp_ft_dropout,
-        "mlp_hidden_size": mlp_hidden_size,
-        "mlp_target_size": mlp_target_size,
-        "cnn_dropout": cnn_dropout,
-        "cnn_hidden_size": cnn_hidden_size,
-        "cnn_num_classes": cnn_num_classes,
-    }
-    # Update attributes only if they exist in the config
-    for attr, value in task_dependent_attr.items():
-        if hasattr(config, attr):
-            setattr(config, attr, value)
+    if config_class == ESM2FineTuneSeqConfig:
+        config = config_class(
+            task_type=task_type,
+            encoder_frozen=encoder_frozen,
+            params_dtype=get_autocast_dtype(precision),
+            pipeline_dtype=get_autocast_dtype(precision),
+            autocast_dtype=get_autocast_dtype(precision),  # setting this speeds things up a lot
+            tensor_model_parallel_size=tensor_model_parallel_size,
+            pipeline_model_parallel_size=pipeline_model_parallel_size,
+            initial_ckpt_path=str(restore_from_checkpoint_path),
+            initial_ckpt_skip_keys_with_these_prefixes=[f"{task_type}_head"],
+            train_metric=train_metric,
+            valid_metric=valid_metric,
+            mlp_ft_dropout=mlp_ft_dropout,
+            mlp_hidden_size=mlp_hidden_size,
+            mlp_target_size=mlp_target_size
+        )
+    else:
+            config = config_class(
+            task_type=task_type,
+            encoder_frozen=encoder_frozen,
+            params_dtype=get_autocast_dtype(precision),
+            pipeline_dtype=get_autocast_dtype(precision),
+            autocast_dtype=get_autocast_dtype(precision),  # setting this speeds things up a lot
+            tensor_model_parallel_size=tensor_model_parallel_size,
+            pipeline_model_parallel_size=pipeline_model_parallel_size,
+            initial_ckpt_path=str(restore_from_checkpoint_path),
+            initial_ckpt_skip_keys_with_these_prefixes=[f"{task_type}_head"],
+            train_metric=train_metric,
+            valid_metric=valid_metric,
+            cnn_dropout=cnn_dropout,
+            cnn_hidden_size=cnn_hidden_size,
+            cnn_num_classes=cnn_num_classes
+        )
 
     optimizer = MegatronOptimizerModule(
         config=OptimizerConfig(


### PR DESCRIPTION
### Description
When doing esm2 downstream task finetuning, the task head related configs (mlp,cnn) are not saved correctly in the checkpoint files, causing tensor shape mismatching error when doing inference. This PR is to fix this issue.

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

* If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
* If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [x] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
