### PR TITLE
pin ngcsdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -195,7 +195,7 @@ uv pip install --no-build-isolation \
 -r /requirements-test.txt
 
 # Install back ngcsdk, as a WAR for the protobuf version conflict with nemo_toolkit.
-uv pip install ngcsdk
+uv pip install ngcsdk==3.63.0  # Remove when https://nvidia.slack.com/archives/CEX3JC6SF/p1744898511311379 is fixed.
 
 # Addressing security scan issue - CVE vulnerability https://github.com/advisories/GHSA-g4r7-86gm-pgqc The package is a
 # dependency of lm_eval from NeMo requirements_eval.txt. We also remove zstandard, another dependency of lm_eval, which


### PR DESCRIPTION
The most recent version of ngcsdk seems to have a bug.
Reported to the ngcsdk team, but in the meantime we need to pin to fix our CI