### PR TITLE
Build multiarch images for amd64 and arm64 linux targets

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -79,6 +79,9 @@ jobs:
         with:
           submodules: "recursive"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -106,6 +109,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -195,7 +195,7 @@ uv pip install --no-build-isolation \
 -r /requirements-test.txt
 
 # Install back ngcsdk, as a WAR for the protobuf version conflict with nemo_toolkit.
-uv pip install ngcsdk
+uv pip install ngcsdk==3.63.0  # Remove when https://nvidia.slack.com/archives/CEX3JC6SF/p1744898511311379 is fixed.
 
 # Addressing security scan issue - CVE vulnerability https://github.com/advisories/GHSA-g4r7-86gm-pgqc The package is a
 # dependency of lm_eval from NeMo requirements_eval.txt. We also remove zstandard, another dependency of lm_eval, which


### PR DESCRIPTION
Configures the CPU workers to build and push multi-arch images so we test both the amd64 and arm64 build paths