### PR TITLE
Add pre commit to verify test status

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -207,6 +207,9 @@ jobs:
     # This steps checks the status of all test jobs and fails if any of them failed or were cancelled.
     # It is a workaround for the lack of a built-in feature to finalize a pipeline by checking the status of multiple jobs
     needs: # List all your run-*-test jobs
+      - pre-commit
+      - get-pr-labels
+      - build-bionemo-image
       - run-tests
       - run-slow-tests
       - run-notebooks-docs

--- a/docs/docs/models/geneformer.md
+++ b/docs/docs/models/geneformer.md
@@ -150,11 +150,11 @@ NVIDIA believes Trustworthy AI is a shared responsibility and we have establishe
 
 ### geneformer-10M
 <!-- WandB Logs: https://wandb.ai/clara-discovery/Geneformer-pretraining-jsjconfigs/runs/i8LWOctg?nw=nwuserjomitchell -->
-Training was performed on 8 servers with 8 A100 GPUs each for a total of 81485 steps using the CELLxGENE split with a per-gpu micro batch size 32 and global batch size of 2048. Training took a total of 4 days, 8 hours of wallclock time. As can be seen in the following images, training and validation curves both decreased fairly smoothly throughout the course of training. 
+Training was performed on 8 servers with 8 A100 GPUs each for a total of 81485 steps using the CELLxGENE split with a per-gpu micro batch size 32 and global batch size of 2048. Training took a total of 4 days, 8 hours of wallclock time. As can be seen in the following images, training and validation curves both decreased fairly smoothly throughout the course of training.
 
 ![Training Loss Geneformer 10M](../assets/images/geneformer/geneformer_10m_training_loss.png)
 ![Validation Loss Geneformer 10M](../assets/images/geneformer/geneformer_10m_val_loss.png)
- 
+
 
 
 ### geneformer-106M


### PR DESCRIPTION
Previously if pre-commit failed, it would cause `run-tests` to be skipped, which would then mean that `verify-tests-status` would give the PR the green light. That's obviously a problem, so we need to make sure all these tests are added to the verify-tests-status check. Ideally we could put some more logic in that if block to check if we're in a merge queue, whether tests were intentionally skipped, etc.