### PR TITLE
Bump NeMo to use a trunk commit instead of a branch for Evo2 fixes and inference.

### DIFF
--- a/sub-packages/bionemo-evo2/src/bionemo/evo2/run/predict.py
+++ b/sub-packages/bionemo-evo2/src/bionemo/evo2/run/predict.py
@@ -27,7 +27,8 @@ import torch
 from lightning.pytorch import LightningDataModule
 from megatron.core import parallel_state
 from megatron.core.tensor_parallel.mappings import _gather_along_last_dim
-from nemo.collections.llm.gpt.model.base import get_batch_on_this_context_parallel_rank, get_packed_seq_params
+from megatron.core.utils import get_batch_on_this_cp_rank
+from nemo.collections.llm.gpt.model.base import get_packed_seq_params
 from nemo.collections.llm.gpt.model.hyena import HYENA_MODEL_OPTIONS, HyenaModel
 from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenizer
 from nemo.lightning import NeMoLogger
@@ -254,7 +255,7 @@ def hyena_predict_data_step(dataloader_iter) -> dict[str, torch.Tensor]:
             _batch_required_keys[key] = None
 
     # slice batch along sequence dimension for context parallelism
-    output = get_batch_on_this_context_parallel_rank(_batch_required_keys)
+    output = get_batch_on_this_cp_rank(_batch_required_keys)
 
     return output
 


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

- https://github.com/NVIDIA/bionemo-framework/pull/798 (https://github.com/NVIDIA/bionemo-framework/pull/855) depends on a NeMo branch, which has been merged into NeMo `main`: https://github.com/NVIDIA/NeMo/pull/13436. Update to point to this trunk commit.

### Details

- NeMo ToT reverted the `cp_size` argument for `masked_token_loss` (https://github.com/NVIDIA/NeMo/pull/13295), so we do the CP reduction on our side now...
  - Future Megatron bump will add the `* cp_size` multiplier to the loss, and break our inference unit tests due to `torch.inference_mode()` usage in Megatron.
