### PR TITLE
Exposes TflopsCallback to pydantic workflow

### DIFF
--- a/sub-packages/bionemo-geneformer/src/bionemo/geneformer/run/main.py
+++ b/sub-packages/bionemo-geneformer/src/bionemo/geneformer/run/main.py
@@ -93,7 +93,7 @@ def main():  # noqa: D103
             "--create-tflops-callback",
             action="store_true",
             default=False,
-            help="Creates a special callback for measuring tflops. Results are logged to wandb"
+            help="Creates a special callback for measuring tflops. Results are logged to wandb",
         )
 
         return parser.parse_args()
@@ -110,7 +110,7 @@ def main():  # noqa: D103
         model_config_cls: Optional[str],
         data_config_cls: Optional[str],
         create_checkpoint_callback: bool,
-        create_tflops_callback
+        create_tflops_callback,
     ) -> MainConfig:
         with open(config_path, "r") as f:
             config_dict = yaml.safe_load(f)
@@ -140,7 +140,13 @@ def main():  # noqa: D103
         return MainConfig[model_config_cls, data_config_cls](**config_dict)
 
     args = parse_args()
-    config = load_config(args.config, args.model_config_cls, args.data_config_cls, args.create_checkpoint_callback, args.create_tflops_callback)
+    config = load_config(
+        args.config,
+        args.model_config_cls,
+        args.data_config_cls,
+        args.create_checkpoint_callback,
+        args.create_tflops_callback,
+    )
 
     if args.nsys_profiling:
         nsys_config = NsysConfig(

--- a/sub-packages/bionemo-geneformer/src/bionemo/geneformer/run/main.py
+++ b/sub-packages/bionemo-geneformer/src/bionemo/geneformer/run/main.py
@@ -89,6 +89,12 @@ def main():  # noqa: D103
             dest="create_checkpoint_callback",
             help="Disable creating a ModelCheckpoint callback.",
         )
+        parser.add_argument(
+            "--create-tflops-callback",
+            action="store_true",
+            default=False,
+            help="Creates a special callback for measuring tflops. Results are logged to wandb"
+        )
 
         return parser.parse_args()
 
@@ -104,6 +110,7 @@ def main():  # noqa: D103
         model_config_cls: Optional[str],
         data_config_cls: Optional[str],
         create_checkpoint_callback: bool,
+        create_tflops_callback
     ) -> MainConfig:
         with open(config_path, "r") as f:
             config_dict = yaml.safe_load(f)
@@ -123,6 +130,9 @@ def main():  # noqa: D103
             config_dict["training_config"]["enable_checkpointing"] = create_checkpoint_callback
             config_dict["experiment_config"]["create_checkpoint_callback"] = create_checkpoint_callback
 
+        if create_tflops_callback:
+            config_dict["training_config"]["create_tflops_callback"] = create_checkpoint_callback
+
         if data_config_cls is None:
             data_config_cls = GeneformerPretrainingDataConfig
         elif isinstance(data_config_cls, str):
@@ -130,7 +140,7 @@ def main():  # noqa: D103
         return MainConfig[model_config_cls, data_config_cls](**config_dict)
 
     args = parse_args()
-    config = load_config(args.config, args.model_config_cls, args.data_config_cls, args.create_checkpoint_callback)
+    config = load_config(args.config, args.model_config_cls, args.data_config_cls, args.create_checkpoint_callback, args.create_tflops_callback)
 
     if args.nsys_profiling:
         nsys_config = NsysConfig(

--- a/sub-packages/bionemo-llm/src/bionemo/llm/run/config_models.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/run/config_models.py
@@ -279,6 +279,7 @@ class ParallelConfig(BaseModel):
     accumulate_grad_batches: int = 1
     ddp: Literal["megatron"] = "megatron"
     remove_unused_parameters: bool = True
+    use_distributed_optimizer: bool = True
     num_devices: int = 1
     num_nodes: int = 1
 
@@ -314,6 +315,7 @@ class TrainingConfig(BaseModel):
     log_train_ppl: bool = False
     log_val_ppl: bool = True
     enable_checkpointing: bool = True
+    create_tflops_callback: bool = False
 
 
 class OptimizerSchedulerConfig(BaseModel):
@@ -332,6 +334,10 @@ class OptimizerSchedulerConfig(BaseModel):
     """
 
     lr: float = 1e-4
+    sgd_momentum: float = 0.9
+    adam_eps: float = 1e-8
+    weight_decay: float = 0.01
+    use_distributed_optimizer: bool = True
     optimizer: str = "adam"
     interval: str = "step"
     monitor: str = "val_loss"

--- a/sub-packages/bionemo-llm/src/bionemo/llm/train.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/train.py
@@ -17,10 +17,9 @@
 import math
 import pathlib
 from dataclasses import field
-from typing import Optional
 from types import SimpleNamespace
+from typing import Optional
 
-from nemo.lightning.pytorch.callbacks.flops_callback import FLOPsMeasurementCallback
 from lightning.pytorch.callbacks import LearningRateMonitor, RichModelSummary
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.optimizer import OptimizerConfig
@@ -28,6 +27,7 @@ from nemo import lightning as nl
 from nemo.collections import llm
 from nemo.lightning import resume
 from nemo.lightning.pytorch import callbacks as nl_callbacks
+from nemo.lightning.pytorch.callbacks.flops_callback import FLOPsMeasurementCallback
 from nemo.lightning.pytorch.optim import MegatronOptimizerModule
 from nemo.lightning.pytorch.optim.lr_scheduler import CosineAnnealingScheduler
 from nemo.utils import logging
@@ -270,7 +270,7 @@ def train(
         )
         flop_meas_callback = FLOPsMeasurementCallback(
             bionemo_model_config,
-            dummy_data_module, 
+            dummy_data_module,
             "bert",
         )
         callbacks.append(flop_meas_callback)

--- a/sub-packages/bionemo-llm/src/bionemo/llm/utils/callbacks.py
+++ b/sub-packages/bionemo-llm/src/bionemo/llm/utils/callbacks.py
@@ -29,7 +29,12 @@ IntervalT = Literal["epoch", "batch"]
 
 
 class PredictionWriter(BasePredictionWriter, pl.Callback):
-    """A callback that writes predictions to disk at specified intervals during training."""
+    """A callback that writes predictions to disk at specified intervals during training.
+
+    Logits, Embeddings, Hiddens, Input IDs, and Labels may all be saved to the disk depending on trainer configuration.
+    Batch Idxs are provided for each prediction in the same dictionary. These must be used to maintain order between
+    multi device predictions and single device predictions.
+    """
 
     def __init__(
         self,
@@ -42,14 +47,27 @@ class PredictionWriter(BasePredictionWriter, pl.Callback):
 
         Args:
             output_dir: The directory where predictions will be written.
-            write_interval: The interval at which predictions will be written. (batch, epoch)
+            write_interval: The interval at which predictions will be written (batch, epoch). Epoch may not be used with multi-device trainers.
             batch_dim_key_defaults: The default batch dimension for each key, if different from the standard 0.
             seq_dim_key_defaults: The default sequence dimension for each key, if different from the standard 1.
         """
         super().__init__(write_interval)
+        self.write_interval = write_interval
         self.output_dir = str(output_dir)
         self.batch_dim_key_defaults = batch_dim_key_defaults
         self.seq_dim_key_defaults = seq_dim_key_defaults
+
+    def setup(self, trainer: pl.Trainer, pl_module: pl.LightningModule, *args, **kwargs) -> None:  # noqa: D417
+        """Invoked with Trainer.fit, validate, test, and predict are called. Will immediately fail when 'write_interval' is 'epoch' and 'trainer.num_devices' > 1.
+
+        Args:
+            trainer: The Trainer instance.
+            pl_module: The LightningModule instance.
+        """
+        if trainer.num_devices > 1 and self.write_interval == "epoch":
+            raise ValueError(
+                "Multi-GPU predictions are not permitted as outputs are not ordered and batch indices are lost."
+            )
 
     def write_on_batch_end(
         self,
@@ -62,6 +80,9 @@ class PredictionWriter(BasePredictionWriter, pl.Callback):
         dataloader_idx: int,
     ) -> None:
         """Writes predictions to disk at the end of each batch.
+
+        Predictions files follow the naming pattern, where rank is the active GPU in which the predictions were made.
+        predictions__rank_{rank}__batch_{batch_idx}.pt
 
         Args:
             trainer: The Trainer instance.
@@ -78,6 +99,8 @@ class PredictionWriter(BasePredictionWriter, pl.Callback):
 
         # batch_indices is not captured due to a lightning bug when return_predictions = False
         # we use input IDs in the prediction to map the result to input
+        prediction["batch_idx"] = batch_idx
+
         torch.save(prediction, result_path)
         logging.info(f"Inference predictions are stored in {result_path}\n{prediction.keys()}")
 
@@ -90,14 +113,23 @@ class PredictionWriter(BasePredictionWriter, pl.Callback):
     ) -> None:
         """Writes predictions to disk at the end of each epoch.
 
+        Writing all predictions on epoch end is memory intensive. It is recommended to use the batch writer instead for
+        large predictions.
+
+        Multi-device predictions will likely yield predictions in an order that is inconsistent with single device predictions and the input data.
+
         Args:
             trainer: The Trainer instance.
             pl_module: The LightningModule instance.
             predictions: The predictions made by the model.
             batch_indices: The indices of the batch.
+
+        Raises:
+            Multi-GPU predictions are output in an inconsistent order with multiple devices.
         """
         # this will create N (num processes) files in `output_dir` each containing
         # the predictions of it's respective rank
+
         result_path = os.path.join(self.output_dir, f"predictions__rank_{trainer.global_rank}.pt")
 
         # collate multiple batches / ignore empty ones
@@ -106,13 +138,14 @@ class PredictionWriter(BasePredictionWriter, pl.Callback):
             collate_kwargs["batch_dim_key_defaults"] = self.batch_dim_key_defaults
         if self.seq_dim_key_defaults is not None:
             collate_kwargs["seq_dim_key_defaults"] = self.seq_dim_key_defaults
+
         prediction = batch_collator([item for item in predictions if item is not None], **collate_kwargs)
 
         # batch_indices is not captured due to a lightning bug when return_predictions = False
         # we use input IDs in the prediction to map the result to input
-        torch.save(prediction, result_path)
         if isinstance(prediction, dict):
             keys = prediction.keys()
         else:
             keys = "tensor"
+        torch.save(prediction, result_path)
         logging.info(f"Inference predictions are stored in {result_path}\n{keys}")


### PR DESCRIPTION
training_config now has an additional property -- include_tflops_callback. This matches the workflow in the `train_geneformer` and `train_esm2` entrypoints. This parameter may also be set via CLI when submitting a config. Additionally exposes the option to disable the use of distributed optimizers. this allows for use of non-adam optimizers such as SGD.
