### PR TITLE
Fix CI issues on main branch.

### DIFF
--- a/ci/scripts/run_pytest.sh
+++ b/ci/scripts/run_pytest.sh
@@ -25,11 +25,13 @@ usage() {
 Usage: $(basename "$0") [OPTIONS]
 
 Options:
-    --skip-docs    Skip running tests in the docs directory
-    --no-nbval     Skip jupyter notebook validation tests
-    --skip-slow    Skip tests marked as slow (@pytest.mark.slow)
-    --only-slow    Only run tests marked as slow (@pytest.mark.slow)
+    --skip-docs         Skip running tests in the docs directory
+    --no-nbval          Skip jupyter notebook validation tests
+    --skip-slow         Skip tests marked as slow (@pytest.mark.slow)
+    --only-slow         Only run tests marked as slow (@pytest.mark.slow)
     --allow-no-tests    Allow sub-packages with no found tests (for example no slow tests if --only-slow is set)
+    --ignore-files      Skip files from tests using glob patterns (comma-separated, no spaces).
+                            Example: --ignore-files docs/*.ipynb,src/specific_test.py
 
 Note: Documentation tests (docs/) are only run when notebook validation
       is enabled (--no-nbval not set) and docs are not skipped
@@ -54,6 +56,8 @@ NO_NBVAL=false
 SKIP_SLOW=false
 ONLY_SLOW=false
 ALLOW_NO_TESTS=false
+# TODO(@cspades): Ignore this Evo2 notebook test, which has a tendency to leave a 32GB orphaned process in GPU.
+declare -a IGNORE_FILES=("sub-packages/bionemo-evo2/examples/fine-tuning-tutorial.ipynb")
 error=false
 
 # Parse command line arguments
@@ -64,6 +68,10 @@ while (( $# > 0 )); do
         --skip-slow) SKIP_SLOW=true ;;
         --only-slow) ONLY_SLOW=true ;;
         --allow-no-tests) ALLOW_NO_TESTS=true ;;
+        --ignore-files)
+            shift
+            IFS=',' read -ra IGNORE_FILES <<< "$1"
+            ;;
         -h|--help) usage ;;
         *) echo "Unknown option: $1" >&2; usage 1 ;;
     esac
@@ -78,11 +86,14 @@ uname -a
 # Set up pytest options
 PYTEST_OPTIONS=(
     -v
-    -s
     --cov=bionemo
     --cov-append
     --cov-report=xml:coverage.xml
 )
+# Add multiple file ignores if specified
+for ignore_file in "${IGNORE_FILES[@]}"; do
+    PYTEST_OPTIONS+=(--ignore-glob="$ignore_file")
+done
 [[ "$NO_NBVAL" != true ]] && PYTEST_OPTIONS+=(--nbval-lax)
 [[ "$SKIP_SLOW" == true ]] && PYTEST_OPTIONS+=(-m "not slow")
 [[ "$ONLY_SLOW" == true ]] && PYTEST_OPTIONS+=(-m "slow")

--- a/ci/scripts/run_pytest.sh
+++ b/ci/scripts/run_pytest.sh
@@ -78,6 +78,7 @@ uname -a
 # Set up pytest options
 PYTEST_OPTIONS=(
     -v
+    -s
     --cov=bionemo
     --cov-append
     --cov-report=xml:coverage.xml

--- a/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
+++ b/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
@@ -30,7 +30,7 @@ from bionemo.testing.megatron_parallel_state_utils import distributed_model_para
 from bionemo.testing.subprocess_utils import run_command_in_subprocess
 
 
-TEST_TIMEOUT = 512
+TEST_TIMEOUT = 3600
 
 
 def run_train_with_std_redirect(args: argparse.Namespace) -> Tuple[str, nl.Trainer]:

--- a/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
+++ b/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
@@ -30,9 +30,6 @@ from bionemo.testing.megatron_parallel_state_utils import distributed_model_para
 from bionemo.testing.subprocess_utils import run_command_in_subprocess
 
 
-TEST_TIMEOUT = 3600
-
-
 def run_train_with_std_redirect(args: argparse.Namespace) -> Tuple[str, nl.Trainer]:
     """
     Run a function with output capture.
@@ -60,7 +57,7 @@ def small_training_cmd(path, max_steps, val_check, devices: int = 1, additional_
     return cmd
 
 
-@pytest.mark.timeout(TEST_TIMEOUT)  # Optional: fail if the test takes too long.
+@pytest.mark.timeout(256)  # Optional: fail if the test takes too long.
 @pytest.mark.slow
 def test_train_evo2_runs(tmp_path):
     """
@@ -99,7 +96,7 @@ def test_train_evo2_runs(tmp_path):
     assert event_files, f"No TensorBoard event files found under {tensorboard_dir}"
 
 
-@pytest.mark.timeout(TEST_TIMEOUT)  # Optional: fail if the test takes too long.
+@pytest.mark.timeout(256)  # Optional: fail if the test takes too long.
 @pytest.mark.slow
 @pytest.mark.skip(
     reason="This test fails due to error when the checkpoints are saved on L40. "
@@ -153,7 +150,7 @@ def test_train_evo2_stops(tmp_path):
     assert "train_step_timing in s" in trainer.logged_metrics
 
 
-@pytest.mark.timeout(TEST_TIMEOUT)  # Optional: fail if the test takes too long.
+@pytest.mark.timeout(256)  # Optional: fail if the test takes too long.
 @pytest.mark.slow
 @pytest.mark.skip(
     reason="This test hangs on L40 on internal CI. Issue: https://github.com/NVIDIA/bionemo-framework/issues/769"

--- a/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
+++ b/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
@@ -30,6 +30,9 @@ from bionemo.testing.megatron_parallel_state_utils import distributed_model_para
 from bionemo.testing.subprocess_utils import run_command_in_subprocess
 
 
+TEST_TIMEOUT = 512
+
+
 def run_train_with_std_redirect(args: argparse.Namespace) -> Tuple[str, nl.Trainer]:
     """
     Run a function with output capture.
@@ -57,7 +60,7 @@ def small_training_cmd(path, max_steps, val_check, devices: int = 1, additional_
     return cmd
 
 
-@pytest.mark.timeout(256)  # Optional: fail if the test takes too long.
+@pytest.mark.timeout(TEST_TIMEOUT)  # Optional: fail if the test takes too long.
 @pytest.mark.slow
 def test_train_evo2_runs(tmp_path):
     """
@@ -96,7 +99,7 @@ def test_train_evo2_runs(tmp_path):
     assert event_files, f"No TensorBoard event files found under {tensorboard_dir}"
 
 
-@pytest.mark.timeout(256)  # Optional: fail if the test takes too long.
+@pytest.mark.timeout(TEST_TIMEOUT)  # Optional: fail if the test takes too long.
 @pytest.mark.slow
 @pytest.mark.skip(
     reason="This test fails due to error when the checkpoints are saved on L40. "
@@ -150,7 +153,7 @@ def test_train_evo2_stops(tmp_path):
     assert "train_step_timing in s" in trainer.logged_metrics
 
 
-@pytest.mark.timeout(256)  # Optional: fail if the test takes too long.
+@pytest.mark.timeout(TEST_TIMEOUT)  # Optional: fail if the test takes too long.
 @pytest.mark.slow
 @pytest.mark.skip(
     reason="This test hangs on L40 on internal CI. Issue: https://github.com/NVIDIA/bionemo-framework/issues/769"

--- a/sub-packages/bionemo-moco/src/bionemo/moco/testing/parallel_test_utils.py
+++ b/sub-packages/bionemo-moco/src/bionemo/moco/testing/parallel_test_utils.py
@@ -15,6 +15,7 @@
 
 
 import os
+import socket
 from contextlib import contextmanager
 
 import torch
@@ -25,6 +26,18 @@ from pytest import MonkeyPatch
 
 DEFAULT_MASTER_ADDR = "localhost"
 DEFAULT_MASTER_PORT = "29500"
+
+
+def find_free_network_port(address: str = "localhost") -> int:
+    """Finds a free port for the specified address. Defaults to localhost."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind((address, 0))
+    addr_port = s.getsockname()
+    s.close()
+    if addr_port is None:
+        # Could not find any free port.
+        return None, None
+    return addr_port
 
 
 @contextmanager
@@ -50,7 +63,8 @@ def parallel_context(
         if not os.environ.get("MASTER_ADDR", None):
             context.setenv("MASTER_ADDR", DEFAULT_MASTER_ADDR)
         if not os.environ.get("MASTER_PORT", None):
-            context.setenv("MASTER_PORT", DEFAULT_MASTER_PORT)
+            network_address, free_network_port = find_free_network_port(address=DEFAULT_MASTER_ADDR)
+            context.setenv("MASTER_PORT", free_network_port if free_network_port is not None else DEFAULT_MASTER_PORT)
         context.setenv("RANK", str(rank))
 
         dist.init_process_group(backend="nccl", world_size=world_size)


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

- Use a free port when instantiating the `MASTER_PORT` for the distributed environment.
- Unstage `sub-packages/bionemo-evo2/examples/fine-tuning-tutorial.ipynb` from `pytest`, due to an inclination of this notebook to leave behind a 32 GB orphaned GPU process.

### Testing

- Blossom: https://prod.blsm.nvidia.com/bionemo-external-bionemo-fw/job/branch_pipeline/1216/

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):
