### PR TITLE
Add prediction_interval in call to infer_model in infer_esm2.py

### DIFF
--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/infer_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/infer_esm2.py
@@ -180,6 +180,7 @@ def infer_esm2_entrypoint():
         pipeline_model_parallel_size=args.pipeline_model_parallel_size,
         devices=args.num_gpus,
         num_nodes=args.num_nodes,
+        prediction_interval=args.prediction_interval,
         config_class=args.config_class,
         lora_checkpoint_path=args.lora_checkpoint_path,
     )


### PR DESCRIPTION
### Description
Add prediction_interval in call to infer_model in infer_esm2.py

Fixes https://nvbugspro.nvidia.com/bug/5289774

(cherry picked from commit 681455a80cf43e4c01afe50c96d051b949a52971)

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):


### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [x] I have tested these changes locally
 - [x] I have updated the documentation accordingly
 - [x] I have added/updated tests as needed
 - [x] All existing tests pass successfully
