### PR TITLE
Fix batch_collate function in multi-gpu case and add test

### DIFF
--- a/sub-packages/bionemo-llm/tests/bionemo/llm/test_lightning.py
+++ b/sub-packages/bionemo-llm/tests/bionemo/llm/test_lightning.py
@@ -75,6 +75,20 @@ def test_batch_collate_list():
     assert torch.equal(result[1], torch.tensor([i + 1 for i in range(10)]))
 
 
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="test requires at least 2 GPUs")
+def test_batch_collate_multi_gpu():
+    # Create tensors on different GPUs
+    tensor1 = torch.tensor([1, 2, 3], device="cuda:0")
+    tensor2 = torch.tensor([4, 5, 6], device="cuda:1")
+
+    result = batch_collator([tensor1, tensor2])
+
+    # Result should be on the first GPU and contain all values
+    expected = torch.tensor([1, 2, 3, 4, 5, 6], device="cuda:0")
+    assert result.device == torch.device("cuda:0")
+    assert torch.equal(result, expected)
+
+
 def test_batch_collate_none():
     assert batch_collator([None, None]) is None
 


### PR DESCRIPTION
### Description
If the tensors passed to the batch_collate function are on different GPUs, they will now be consolidated onto one. This preferred GPU can be specified.

Fixes https://nvbugspro.nvidia.com/bug/5289774

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [x] I have tested these changes locally
 - [x] I have updated the documentation accordingly
 - [x] I have added/updated tests as needed
 - [x] All existing tests pass successfully
