### PR TITLE
fix: fixes trainer.global_step bug in ESM2 training

### DIFF
--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -26,7 +26,7 @@ from nemo.lightning import resume
 from nemo.lightning.pytorch import callbacks as nl_callbacks
 from nemo.lightning.pytorch.callbacks.flops_callback import FLOPsMeasurementCallback
 from nemo.lightning.pytorch.optim import MegatronOptimizerModule
-from nemo.utils.exp_manager import TimingCallback
+from nemo.utils.exp_manager import DeltaTimingCallback
 
 from bionemo.core.utils.dtypes import PrecisionTypes, get_autocast_dtype
 from bionemo.esm2.api import ESM2Config
@@ -304,7 +304,7 @@ def main(
         RichModelSummary(max_depth=4),
         LearningRateMonitor(),
         nl_callbacks.PreemptionCallback(),
-        TimingCallback(),
+        DeltaTimingCallback(),
     ]
 
     if nsys_profiling:


### PR DESCRIPTION
What? The trainer.global_step was being set to the validation step count when using the [TimingCallback](https://github.com/NVIDIA/NeMo/blob/main/nemo/utils/exp_manager.py#L269) exp_manager. This change removes that callback in place of the [DeltaTimingCallback](https://github.com/NVIDIA/NeMo/blob/main/nemo/utils/exp_manager.py#L385) from exp_manager.

Now, the trainer.global_step will be constant during validation, and it will pick up where it left off when resuming training.

### Description

We changed the thing that logs to WandB and the logger during training to use the [DeltaTimingCallback](https://github.com/NVIDIA/NeMo/blob/main/nemo/utils/exp_manager.py#L385) from NeMo's exp_manager. 
WandB link (before change): https://wandb.ai/clara-discovery/esm2-650M_pretraining/runs/9ymtej3j?nw=nwuserjomitchell
WandB link (with change): https://wandb.ai/clara-discovery/esm2-650M_pretraining/runs/38oe5dcs?nw=nwuserjomitchell

Note. This change may also increase accuracy during training, if optimizers are reliant on `trainer.global_step` in order to find the LR schedule. This assumption has not been tested yet, and will not be tested in this MR (out of scope) but its worth looking back here if we do see a sudden improvement in training.

Pictures:
#### Before change
![trainer_global_step](https://github.com/user-attachments/assets/eb44dd2b-935a-422d-a8ad-dcbd3f480a3c)

#### After change
![Screenshot 2025-06-03 at 12 38 59 PM](https://github.com/user-attachments/assets/8ee8d1b4-6fdd-45b7-9abc-01987f3508e7)

Here we can see that during the validation stage, the trainer.global_steps is now constant. 

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [X]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

* If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
* If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
