### PR TITLE
Turn on chatbot visibility by default

### DIFF
--- a/docs/docs/assets/css/chatbot.css
+++ b/docs/docs/assets/css/chatbot.css
@@ -13,5 +13,5 @@ img.open-icon {
 /* tempoarily make invisible to test in production.
   turn on in going md-container > md-main > md-contant > article */
 #chatbot > button {
-  display: none;
+  display: block;
 }


### PR DESCRIPTION
### Description
To ensure the endpoints worked as intended in the live docs, the documentation chatbot was originally created with `display: none;` so that we could toggle it on/off. This MR sets it to be visible by default.

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [x]  Documentation update
- [ ]  Other (please describe):
