### PR TITLE
Pass missing create_tensorboard_logger kwarg to finetune

### DIFF
--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/finetune_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/finetune_esm2.py
@@ -474,6 +474,7 @@ def finetune_esm2_entrypoint():
         label_column=args.label_column,
         lora_checkpoint_path=args.lora_checkpoint_path,
         lora_finetune=args.lora_finetune,
+        create_tensorboard_logger=args.create_tensorboard_logger,
     )
 
 


### PR DESCRIPTION
Previously we weren't passing this argparse kwarg to train_model