### PR TITLE
move ignoring notebooks in pytest to project.toml

### DIFF
--- a/ci/scripts/run_pytest.sh
+++ b/ci/scripts/run_pytest.sh
@@ -30,12 +30,14 @@ Options:
     --skip-slow         Skip tests marked as slow (@pytest.mark.slow)
     --only-slow         Only run tests marked as slow (@pytest.mark.slow)
     --allow-no-tests    Allow sub-packages with no found tests (for example no slow tests if --only-slow is set)
-    --ignore-files      Skip files from tests using glob patterns (comma-separated, no spaces).
-                            Example: --ignore-files docs/*.ipynb,src/specific_test.py
 
 Note: Documentation tests (docs/) are only run when notebook validation
       is enabled (--no-nbval not set) and docs are not skipped
       (--skip-docs not set)
+
+To ignore specific tests or files:
+    - Use @pytest.mark.skip or @pytest.mark.skipif decorators in your test code
+    - Add file paths to the --ignore-glob option in pyproject.toml under [tool.pytest.ini_options] addopts
     -h, --help     Display this help message
 EOF
     exit "${1:-0}"
@@ -56,8 +58,6 @@ NO_NBVAL=false
 SKIP_SLOW=false
 ONLY_SLOW=false
 ALLOW_NO_TESTS=false
-# TODO(@cspades): Ignore this Evo2 notebook test, which has a tendency to leave a 32GB orphaned process in GPU.
-declare -a IGNORE_FILES=("sub-packages/bionemo-evo2/examples/fine-tuning-tutorial.ipynb", "sub-packages/bionemo-moco/examples/discrete_data_interpolant_tutorial.ipynb")
 error=false
 
 # Parse command line arguments
@@ -68,10 +68,6 @@ while (( $# > 0 )); do
         --skip-slow) SKIP_SLOW=true ;;
         --only-slow) ONLY_SLOW=true ;;
         --allow-no-tests) ALLOW_NO_TESTS=true ;;
-        --ignore-files)
-            shift
-            IFS=',' read -ra IGNORE_FILES <<< "$1"
-            ;;
         -h|--help) usage ;;
         *) echo "Unknown option: $1" >&2; usage 1 ;;
     esac
@@ -90,10 +86,7 @@ PYTEST_OPTIONS=(
     --cov-append
     --cov-report=xml:coverage.xml
 )
-# Add multiple file ignores if specified
-for ignore_file in "${IGNORE_FILES[@]}"; do
-    PYTEST_OPTIONS+=(--ignore-glob="$ignore_file")
-done
+
 [[ "$NO_NBVAL" != true ]] && PYTEST_OPTIONS+=(--nbval-lax)
 [[ "$SKIP_SLOW" == true ]] && PYTEST_OPTIONS+=(-m "not slow")
 [[ "$ONLY_SLOW" == true ]] && PYTEST_OPTIONS+=(-m "slow")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,13 @@ convention = "google"
 
 [tool.pytest.ini_options]
 norecursedirs = ["3rdparty"]
-addopts = ["--durations-min=30.0", "--durations=0", "--ignore=3rdparty"]
+addopts = [
+    "--durations-min=30.0",
+    "--durations=0",
+    "--ignore=3rdparty",
+    "--ignore-glob=sub-packages/bionemo-evo2/examples/fine-tuning-tutorial.ipynb",
+    "--ignore-glob=sub-packages/bionemo-moco/examples/discrete_data_interpolant_tutorial.ipynb"
+]
 markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 
 [tool.pyright]


### PR DESCRIPTION
### Description
Move ignoring notebooks in pytest to project.toml to avoid dependency on what is ignored in pytest execution between CI systems.

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

* If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
* If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
