### PR TITLE
draft: investigate perf oscillation

### DIFF
--- a/ci/benchmarks/partial-conv/esm2_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/esm2_pretrain.yaml
@@ -19,7 +19,7 @@ script_args:
   batch_size: 16
   max_steps: 500000
   stop_steps: 2000
-  num_workers: 4
+  num_workers: 0
 script: |-
   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY ${variant}_${model} \
     --train-cluster-path=${data_path}/train_clusters.parquet \

--- a/ci/benchmarks/partial-conv/esm2_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/esm2_pretrain.yaml
@@ -15,7 +15,7 @@ script_args:
   config_name: 650M
   precision: [bf16-mixed]
   nodes: [1]
-  gpus: 2
+  gpus: 8
   batch_size: 16
   max_steps: 500000
   stop_steps: 2000

--- a/ci/benchmarks/partial-conv/esm2_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/esm2_pretrain.yaml
@@ -15,11 +15,11 @@ script_args:
   config_name: 650M
   precision: [bf16-mixed]
   nodes: [1]
-  gpus: 1
+  gpus: 2
   batch_size: 16
   max_steps: 500000
   stop_steps: 2000
-  num_workers: 8
+  num_workers: 4
 script: |-
   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY ${variant}_${model} \
     --train-cluster-path=${data_path}/train_clusters.parquet \

--- a/ci/benchmarks/partial-conv/esm2_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/esm2_pretrain.yaml
@@ -14,7 +14,7 @@ script_args:
   variant: train
   config_name: 650M
   precision: [bf16-mixed]
-  nodes: [2]
+  nodes: [1]
   gpus: 8
   batch_size: 16
   max_steps: 500000

--- a/ci/benchmarks/partial-conv/esm2_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/esm2_pretrain.yaml
@@ -18,8 +18,8 @@ script_args:
   gpus: 8
   batch_size: 16
   max_steps: 500000
-  stop_steps: 2000
-  num_workers: 0
+  stop_steps: 200
+  num_workers: 4
 script: |-
   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY ${variant}_${model} \
     --train-cluster-path=${data_path}/train_clusters.parquet \

--- a/ci/benchmarks/partial-conv/esm2_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/esm2_pretrain.yaml
@@ -14,12 +14,12 @@ script_args:
   variant: train
   config_name: 650M
   precision: [bf16-mixed]
-  nodes: [1]
+  nodes: [2]
   gpus: 8
   batch_size: 16
   max_steps: 500000
   stop_steps: 2000
-  num_workers: 0
+  num_workers: 4
 script: |-
   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY ${variant}_${model} \
     --train-cluster-path=${data_path}/train_clusters.parquet \

--- a/ci/benchmarks/partial-conv/esm2_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/esm2_pretrain.yaml
@@ -3,6 +3,7 @@ time_limit: 3600
 key_segments:
   # Modify keys to be renamed (str) or excluded (False) from run identifier. By default, all args under script_args are included.
   data_path: False
+  num_workers: False
 script_args:
   # All arguments referenced in the script string must be specified here.
   # Arguments not referenced in the script string must have the 'arg' field specified.
@@ -18,6 +19,7 @@ script_args:
   batch_size: 16
   max_steps: 500000
   stop_steps: 2000
+  num_workers: 4
 script: |-
   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY ${variant}_${model} \
     --train-cluster-path=${data_path}/train_clusters.parquet \
@@ -27,6 +29,7 @@ script: |-
     --micro-batch-size=${batch_size} \
     --num-nodes=${nodes} \
     --num-gpus=${gpus} \
+    --num-dataset-workers=${num_workers} \
     --val-check-interval=1000 \
     --limit-val-batches=1 \
     --num-steps=${max_steps} \

--- a/ci/benchmarks/partial-conv/esm2_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/esm2_pretrain.yaml
@@ -1,5 +1,5 @@
 scope: partial-conv
-time_limit: 14400
+time_limit: 3600
 key_segments:
   # Modify keys to be renamed (str) or excluded (False) from run identifier. By default, all args under script_args are included.
   data_path: False
@@ -13,11 +13,11 @@ script_args:
   variant: train
   config_name: 650M
   precision: [bf16-mixed]
-  nodes: [4]
-  gpus: 8
+  nodes: [1]
+  gpus: 1
   batch_size: 16
   max_steps: 500000
-  stop_steps: 26000
+  stop_steps: 2000
 script: |-
   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY ${variant}_${model} \
     --train-cluster-path=${data_path}/train_clusters.parquet \

--- a/ci/benchmarks/partial-conv/esm2_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/esm2_pretrain.yaml
@@ -19,7 +19,7 @@ script_args:
   batch_size: 16
   max_steps: 500000
   stop_steps: 2000
-  num_workers: 4
+  num_workers: 8
 script: |-
   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY ${variant}_${model} \
     --train-cluster-path=${data_path}/train_clusters.parquet \

--- a/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
@@ -25,7 +25,7 @@ script_args:
   acc_grad: 1
   num_workers: 0
 script: |-
-   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY python -m cProfile -o ${tensorboard_dir}/profile_output.prof -c cumulative ${workspace}/sub-packages/bionemo-geneformer/src/bionemo/geneformer/run/main.py \
+   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY python -m cProfile -o ${tensorboard_dir}/profile_output.prof ${workspace}/sub-packages/bionemo-geneformer/src/bionemo/geneformer/run/main.py \
     --data-dir ${data_path} \
     --experiment-name ${batch_size}bs_${nodes}node_${gpus}gpu_${max_steps}s_${precision}prec \
     --num-gpus ${gpus} \

--- a/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
@@ -16,7 +16,7 @@ script_args:
   variant: train
   config_name: 10M
   precision: [bf16-mixed]
-  nodes: [2]
+  nodes: [1]
   gpus: 8
   batch_size: 32
   max_steps: 200

--- a/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
@@ -16,7 +16,7 @@ script_args:
   variant: train
   config_name: 10M
   precision: [bf16-mixed]
-  nodes: [1]
+  nodes: [2]
   gpus: 8
   batch_size: 32
   max_steps: 200

--- a/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
@@ -17,7 +17,7 @@ script_args:
   config_name: 10M
   precision: [bf16-mixed]
   nodes: [1]
-  gpus: 2
+  gpus: 8
   batch_size: 32
   max_steps: 1000
   lr: 0.001

--- a/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
@@ -16,16 +16,16 @@ script_args:
   variant: train
   config_name: 10M
   precision: [bf16-mixed]
-  nodes: [2]
+  nodes: [1]
   gpus: 8
   batch_size: 32
-  max_steps: 3000
+  max_steps: 200
   lr: 0.001
-  val_check_interval: 500
+  val_check_interval: 100
   acc_grad: 1
   num_workers: 0
 script: |-
-   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY ${variant}_${model} \
+   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY python -m cProfile -o ${tensorboard_dir}/profile_output.prof -c cumulative ${workspace}/sub-packages/bionemo-geneformer/src/bionemo/geneformer/run/main.py \
     --data-dir ${data_path} \
     --experiment-name ${batch_size}bs_${nodes}node_${gpus}gpu_${max_steps}s_${precision}prec \
     --num-gpus ${gpus} \

--- a/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
@@ -23,7 +23,7 @@ script_args:
   lr: 0.001
   val_check_interval: 500
   acc_grad: 1
-  num_workers: 4
+  num_workers: 0
 script: |-
    WANDB_API_KEY=$BIONEMO_WANDB_API_KEY ${variant}_${model} \
     --data-dir ${data_path} \

--- a/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
@@ -1,5 +1,5 @@
 scope: partial-conv
-time_limit: 14400
+time_limit: 3600
 key_segments:
   # Modify keys to be renamed (str) or excluded (False) from run identifier. By default, all args under script_args are included.
   data_path: False
@@ -15,10 +15,10 @@ script_args:
   variant: train
   config_name: 10M
   precision: [bf16-mixed]
-  nodes: [2]
-  gpus: 8
+  nodes: [1]
+  gpus: 1
   batch_size: 32
-  max_steps: 30000
+  max_steps: 1000
   lr: 0.001
   val_check_interval: 500
   acc_grad: 1

--- a/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
@@ -23,9 +23,9 @@ script_args:
   lr: 0.001
   val_check_interval: 100
   acc_grad: 1
-  num_workers: 0
+  num_workers: 4
 script: |-
-   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY python -m cProfile -o ${tensorboard_dir}/profile_output.prof ${workspace}/sub-packages/bionemo-geneformer/src/bionemo/geneformer/run/main.py \
+   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY python -m cProfile -o ${tensorboard_dir}/profile_output.prof ${workspace}/sub-packages/bionemo-geneformer/src/bionemo/geneformer/scripts/train_geneformer.py \
     --data-dir ${data_path} \
     --experiment-name ${batch_size}bs_${nodes}node_${gpus}gpu_${max_steps}s_${precision}prec \
     --num-gpus ${gpus} \

--- a/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
@@ -16,14 +16,14 @@ script_args:
   variant: train
   config_name: 10M
   precision: [bf16-mixed]
-  nodes: [1]
+  nodes: [2]
   gpus: 8
   batch_size: 32
-  max_steps: 1000
+  max_steps: 3000
   lr: 0.001
   val_check_interval: 500
   acc_grad: 1
-  num_workers: 0
+  num_workers: 4
 script: |-
    WANDB_API_KEY=$BIONEMO_WANDB_API_KEY ${variant}_${model} \
     --data-dir ${data_path} \

--- a/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
@@ -5,6 +5,7 @@ key_segments:
   data_path: False
   val_check_interval: False
   lr: False
+  num_workers: False
 script_args:
   # All arguments referenced in the script string must be specified here.
   # Arguments not referenced in the script string must have the 'arg' field specified.
@@ -22,6 +23,7 @@ script_args:
   lr: 0.001
   val_check_interval: 500
   acc_grad: 1
+  num_workers: 4
 script: |-
    WANDB_API_KEY=$BIONEMO_WANDB_API_KEY ${variant}_${model} \
     --data-dir ${data_path} \
@@ -30,7 +32,7 @@ script: |-
     --save-last-checkpoint \
     --num-nodes ${nodes} \
     --val-check-interval ${val_check_interval} \
-    --num-dataset-workers 8 \
+    --num-dataset-workers ${num_workers} \
     --num-steps ${max_steps} \
     --seq-length 2048 \
     --limit-val-batches 8 \

--- a/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
@@ -17,7 +17,7 @@ script_args:
   config_name: 10M
   precision: [bf16-mixed]
   nodes: [1]
-  gpus: 1
+  gpus: 2
   batch_size: 32
   max_steps: 1000
   lr: 0.001

--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/train_esm2.py
@@ -365,6 +365,10 @@ def main(
     else:
         auto_resume = None
 
+    from lightning.pytorch.profilers import PyTorchProfiler
+
+    profiler = PyTorchProfiler(dirpath=result_dir, filename="profiler")
+
     trainer = nl.Trainer(
         devices=devices,
         max_steps=num_steps if early_stop_on_step is None else early_stop_on_step,
@@ -375,6 +379,7 @@ def main(
         log_every_n_steps=log_every_n_steps,
         num_nodes=num_nodes,
         callbacks=callbacks,
+        profiler=profiler,
         plugins=nl.MegatronMixedPrecision(
             precision=precision,
             params_dtype=get_autocast_dtype(precision),

--- a/sub-packages/bionemo-geneformer/src/bionemo/geneformer/scripts/train_geneformer.py
+++ b/sub-packages/bionemo-geneformer/src/bionemo/geneformer/scripts/train_geneformer.py
@@ -290,6 +290,9 @@ def main(
                 geneformer_config, SimpleDataModule(tokenizer.vocab_size, global_batch_size), "bert"
             )
         )
+    from lightning.pytorch.profilers import PyTorchProfiler
+
+    profiler = PyTorchProfiler(dirpath=result_dir, filename="profiler")
 
     trainer = nl.Trainer(
         devices=devices,
@@ -302,6 +305,7 @@ def main(
         num_nodes=num_nodes,
         callbacks=callbacks,
         use_distributed_sampler=False,
+        profiler=profiler,
         plugins=nl.MegatronMixedPrecision(precision=precision),
         enable_checkpointing=create_checkpoint_callback,
     )
@@ -697,6 +701,7 @@ def entrypoint():
     # Parse the arguments and pull them out into local variables for ease of future refactor to a
     #   config management system.
     args = parser.parse_args()
+
     main(
         data_dir=args.data_dir,
         num_nodes=args.num_nodes,


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

* If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
* If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
