### PR TITLE
[DRAFT] Add ESM2 Finetuning Benchmark Configuration

### DIFF
--- a/ci/benchmarks/partial-conv/esm2_finetuning.yaml
+++ b/ci/benchmarks/partial-conv/esm2_finetuning.yaml
@@ -158,24 +158,3 @@ script: |-
 
   # Execute the command
   eval $CMD
-tests:
-  - logic_type: dynamic
-    logic_spec:
-      exit_codes:
-        - 0
-      baselines:
-        # For sequence classification
-        - variant: seq_classification
-          val_acc:
-            operator: gt
-            value: 0.77
-        # For token classification
-        - variant: token_classification
-          val_acc:
-            operator: gt
-            value: 0.86
-        # For sequence regression
-        - variant: seq_regression
-          val_mse:
-            operator: lt
-            value: 50.0

--- a/ci/benchmarks/partial-conv/esm2_finetuning.yaml
+++ b/ci/benchmarks/partial-conv/esm2_finetuning.yaml
@@ -1,5 +1,5 @@
 scope: partial-conv
-time_limit: 7200
+time_limit: 14400
 key_segments:
   # Modify keys to be renamed (str) or excluded (False) from run identifier. By default, all args under script_args are included.
   train_data_path: False
@@ -36,7 +36,8 @@ script_args:
       mlp_ft_dropout: 0.25
       mlp_hidden_size: 256
       mlp_target_size: 10
-      num_steps: 1485
+      # num_steps: 1485
+      num_steps: 100
       experiment_name: seq-level-classification
       lr: 0.0005
       batch_size: 64
@@ -54,7 +55,8 @@ script_args:
       cnn_dropout: 0.25
       cnn_hidden_size: 32
       cnn_num_classes: 3
-      num_steps: 1500
+      # num_steps: 1500
+      num_steps: 100
       experiment_name: token-level-classification
       lr: 0.0005
       batch_size: 64
@@ -72,7 +74,8 @@ script_args:
       mlp_ft_dropout: 0.1
       mlp_hidden_size: 128
       mlp_target_size: 1
-      num_steps: 6980
+      # num_steps: 6980
+      num_steps: 100
       experiment_name: seq-level-regression
       lr: 0.0005
       batch_size: 32

--- a/ci/benchmarks/partial-conv/esm2_finetuning.yaml
+++ b/ci/benchmarks/partial-conv/esm2_finetuning.yaml
@@ -1,0 +1,181 @@
+scope: partial-conv
+time_limit: 7200
+key_segments:
+  # Modify keys to be renamed (str) or excluded (False) from run identifier. By default, all args under script_args are included.
+  train_data_path: False
+  valid_data_path: False
+  checkpoint_path: False
+  num_workers: False
+  limit_val_batches: False
+  limit_test_batches: False
+  val_check_interval: False
+  log_every_n_steps: False
+script_args:
+  # All arguments referenced in the script string must be specified here.
+  # Arguments not referenced in the script string must have the 'arg' field specified.
+  # See jet/core/configs.py for the specification of the configuration class
+  workspace: /workspace/bionemo2
+  checkpoint_path: /data/checkpoints/esm2nv650m_v2.0
+  data_base_path: /data/FLIP
+  nodes: [1]
+  gpus: 1
+  precision: [bf16-mixed]
+  encoder_frozen: true
+  num_workers: 8
+  limit_val_batches: 1000
+  limit_test_batches: 1000
+  log_every_n_steps: 1
+  accumulate_grad_batches: 2
+  products:
+    - variant: seq_classification
+      train_data_path: scl/train/x000.csv
+      valid_data_path: scl/val/x000.csv
+      task_type: classification
+      config_class: ESM2FineTuneSeqConfig
+      dataset_class: InMemorySingleValueDataset
+      mlp_ft_dropout: 0.25
+      mlp_hidden_size: 256
+      mlp_target_size: 10
+      num_steps: 1485
+      experiment_name: seq-level-classification
+      lr: 0.0005
+      batch_size: 64
+      label_column: scl_label
+      val_check_interval: 100
+      min_seq_length: null
+      labels_mask_column: null
+      expected_val_acc: 77
+    - variant: token_classification
+      train_data_path: secondary_structure/train/x000.csv
+      valid_data_path: secondary_structure/val/x000.csv
+      task_type: classification
+      config_class: ESM2FineTuneTokenConfig
+      dataset_class: InMemoryPerTokenValueDataset
+      cnn_dropout: 0.25
+      cnn_hidden_size: 32
+      cnn_num_classes: 3
+      num_steps: 1500
+      experiment_name: token-level-classification
+      lr: 0.0005
+      batch_size: 64
+      label_column: 3state
+      val_check_interval: 100
+      min_seq_length: 1024
+      labels_mask_column: resolved
+      expected_val_acc: 86
+    - variant: seq_regression
+      train_data_path: meltome/train/x000.csv
+      valid_data_path: meltome/val/x000.csv
+      task_type: regression
+      config_class: ESM2FineTuneSeqConfig
+      dataset_class: InMemorySingleValueDataset
+      mlp_ft_dropout: 0.1
+      mlp_hidden_size: 128
+      mlp_target_size: 1
+      num_steps: 6980
+      experiment_name: seq-level-regression
+      lr: 0.0005
+      batch_size: 32
+      label_column: target
+      val_check_interval: 100
+      min_seq_length: null
+      labels_mask_column: null
+      expected_val_mse: 50
+script: |-
+  # Set up paths
+  FULL_TRAIN_PATH="${data_base_path}/${train_data_path}"
+  FULL_VALID_PATH="${data_base_path}/${valid_data_path}"
+
+  # Copy data to local storage for faster access
+  COPY_FLAG="/tmp/copy_done_${{SLURMD_NODENAME}}_${variant}";
+  NEW_DATA_PATH="/dev/shm/flip_${variant}_${{SLURMD_NODENAME}}";
+  if [ "$SLURM_LOCALID" = "0" ]; then
+      df -h;
+      echo "Copying data to $NEW_DATA_PATH";
+      mkdir -p $(dirname $NEW_DATA_PATH/${train_data_path});
+      mkdir -p $(dirname $NEW_DATA_PATH/${valid_data_path});
+      time cp $FULL_TRAIN_PATH $NEW_DATA_PATH/${train_data_path};
+      time cp $FULL_VALID_PATH $NEW_DATA_PATH/${valid_data_path};
+      touch $COPY_FLAG
+  fi
+  # All ranks wait until copy is done
+  while [ ! -f $COPY_FLAG ]; do
+      sleep 1
+  done
+
+  # Build the command with common arguments
+  CMD="WANDB_API_KEY=$BIONEMO_WANDB_API_KEY python ${workspace}/sub-packages/bionemo-esm2/src/bionemo/esm2/scripts/finetune_esm2.py \
+    --train-data-path=$NEW_DATA_PATH/${train_data_path} \
+    --valid-data-path=$NEW_DATA_PATH/${valid_data_path} \
+    --task-type=${task_type} \
+    --restore-from-checkpoint-path=${checkpoint_path} \
+    --config-class=${config_class} \
+    --dataset-class=${dataset_class} \
+    --num-steps=${num_steps} \
+    --experiment-name=${experiment_name}_${batch_size}bs_${nodes}node_${gpus}gpu_${num_steps}s_${precision}prec \
+    --lr=${lr} \
+    --result-dir=${tensorboard_dir} \
+    --micro-batch-size=${batch_size} \
+    --limit-val-batches=${limit_val_batches} \
+    --limit-test-batches=${limit_test_batches} \
+    --precision=${precision} \
+    --label-column=${label_column} \
+    --num-gpus=${gpus} \
+    --num-nodes=${nodes} \
+    --accumulate-grad-batches=${accumulate_grad_batches} \
+    --val-check-interval=${val_check_interval} \
+    --log-every-n-steps=${log_every_n_steps} \
+    --num-dataset-workers=${num_workers} \
+    --wandb-project=${wandb_project_name} \
+    --wandb-group=esm2_finetune_${variant}__${target} \
+    --wandb-job-type=${pipeline_label} \
+    --create-tensorboard-logger"
+
+  # Add encoder-frozen flag if enabled
+  if [ "${encoder_frozen}" = "true" ]; then
+      CMD="$CMD --encoder-frozen"
+  fi
+
+  # Add variant-specific arguments based on config class
+  if [ "${config_class}" = "ESM2FineTuneSeqConfig" ]; then
+      CMD="$CMD --mlp-ft-dropout=${mlp_ft_dropout} \
+        --mlp-hidden-size=${mlp_hidden_size} \
+        --mlp-target-size=${mlp_target_size}"
+  elif [ "${config_class}" = "ESM2FineTuneTokenConfig" ]; then
+      CMD="$CMD --cnn-dropout=${cnn_dropout} \
+        --cnn-hidden-size=${cnn_hidden_size} \
+        --cnn-num-classes=${cnn_num_classes}"
+  fi
+
+  # Add optional arguments if they are not null
+  if [ "${min_seq_length}" != "null" ]; then
+      CMD="$CMD --min-seq-length=${min_seq_length}"
+  fi
+
+  if [ "${labels_mask_column}" != "null" ]; then
+      CMD="$CMD --labels-mask-column=${labels_mask_column}"
+  fi
+
+  # Execute the command
+  eval $CMD
+tests:
+  - logic_type: dynamic
+    logic_spec:
+      exit_codes:
+        - 0
+      baselines:
+        # For sequence classification
+        - variant: seq_classification
+          val_acc:
+            operator: gt
+            value: 0.77
+        # For token classification
+        - variant: token_classification
+          val_acc:
+            operator: gt
+            value: 0.86
+        # For sequence regression
+        - variant: seq_regression
+          val_mse:
+            operator: lt
+            value: 50.0


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

**⚠️ This is a DRAFT PR - Work in Progress**

This PR adds a new YAML configuration file for benchmarking ESM2 finetuning across three different task types: sequence classification, token classification, and sequence regression.

**Current Status:**
- ✅ Basic YAML structure created following existing patterns
- ✅ Three finetuning variants configured (seq_classification, token_classification, seq_regression)
- ✅ Data copying to local storage implemented
- ✅ Dynamic command generation based on task type
- 🚧 Step counts reduced to 100 for testing (original values commented out)
- 🚧 Test assertions temporarily removed for initial validation
- 🚧 Need to validate data paths and checkpoint locations

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

* If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
* If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage
<!--- How does a user interact with the changed code -->
```bash
# The benchmark will be triggered through the CI pipeline
# Currently configured for quick validation runs (100 steps)
# Production values are (maybe):
# - Sequence Classification: 1485 steps
# - Token Classification: 1500 steps  
# - Sequence Regression: 6980 steps
```

### TODO Before Merging
- [ ] Restore original step counts after validation
- [ ] Add test assertions back with appropriate thresholds
- [ ] Verify data paths exist on CI infrastructure
- [ ] Confirm checkpoint path accessibility
- [ ] Run full benchmark to validate expected metrics

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [x] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully

### Notes for Reviewers
- Based on validated training commands from the ESM2 finetuning work
- Time limit increased to 14400s (4 hours) to accommodate full training runs
- Currently using reduced steps (100) for quick iteration and testing
- Test assertions have been temporarily removed to allow initial validation runs
- Please review the command structure and parameter mapping for correctness