### PR TITLE
Fix test_train_evo2_stops test

### DIFF
--- a/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
+++ b/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
@@ -98,10 +98,6 @@ def test_train_evo2_runs(tmp_path):
 
 @pytest.mark.timeout(256)  # Optional: fail if the test takes too long.
 @pytest.mark.slow
-@pytest.mark.skip(
-    reason="This test fails due to error when the checkpoints are saved on L40. "
-    "Issue: https://github.com/NVIDIA/bionemo-framework/issues/760"
-)
 def test_train_evo2_stops(tmp_path):
     """
     This test runs the `train_evo2` command with mock data in a temporary directory.
@@ -124,7 +120,7 @@ def test_train_evo2_stops(tmp_path):
     args = parse_args(args=command_parts_no_program)
     train_stdout, trainer = run_train_with_std_redirect(args)
 
-    assert f"Training epoch 0, iteration 0/{max_steps - 1}" in train_stdout
+    assert f"Training epoch 0, iteration 0/{early_stop_steps - 1}" in train_stdout
     # Extract and validate global steps
     global_steps = extract_global_steps_from_log(train_stdout)
     assert global_steps[0] == 0


### PR DESCRIPTION
### Description
This PR enables the `test_train_evo2_stops()` test.

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [x]  Other (please describe): Enable a previously failing test

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

* If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
* If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [x] I have tested these changes locally
 - [x] I have updated the documentation accordingly
 - [x] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
