### PR TITLE
Add fp8 stop and go test for evo2

### DIFF
--- a/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
+++ b/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
@@ -150,9 +150,23 @@ def test_train_evo2_stops(tmp_path):
     assert "train_step_timing in s" in trainer.logged_metrics
 
 
+@pytest.mark.parametrize(
+    "additional_args",
+    [
+        pytest.param("", id="no_fp8"),
+        pytest.param(
+            "--fp8",
+            marks=[
+                pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8),
+                pytest.mark.xfail(reason="FP8 test currently broken - TODO: fix"),
+            ],
+            id="fp8",
+        ),
+    ],
+)
 @pytest.mark.timeout(256)  # Optional: fail if the test takes too long.
 @pytest.mark.slow
-def test_train_evo2_stop_at_max_steps_and_continue(tmp_path):
+def test_train_evo2_stop_at_max_steps_and_continue(tmp_path, additional_args):
     max_steps_first_run = 4
     max_steps_second_run = 6
     val_check_interval = 2
@@ -160,60 +174,9 @@ def test_train_evo2_stop_at_max_steps_and_continue(tmp_path):
     log_dir = tmp_path / "evo2"
     checkpoints_dir = log_dir / "checkpoints"
 
-    command_first_run = small_training_cmd(tmp_path, max_steps_first_run, val_check_interval)
-
-    # The first training command to finish at max_steps_first_run
-    stdout_first_run = run_command_in_subprocess(command=command_first_run, path=str(tmp_path))
-
-    assert f"Training epoch 0, iteration 0/{max_steps_first_run - 1}" in stdout_first_run
-    # Extract and validate global steps
-    global_steps_first_run = extract_global_steps_from_log(stdout_first_run)
-
-    assert global_steps_first_run[0] == 0
-    assert global_steps_first_run[-1] == max_steps_first_run - 1
-    assert len(global_steps_first_run) == max_steps_first_run
-
-    expected_checkpoint_first_run_suffix = f"{max_steps_first_run}.0-last"
-    # Check if checkpoints dir exists
-    assert checkpoints_dir.exists(), "Checkpoints folder does not exist."
-    # Check if any ckpt subfolder ends with the expected suffix
-    matching_subfolders = [
-        p for p in checkpoints_dir.iterdir() if p.is_dir() and (expected_checkpoint_first_run_suffix in p.name)
-    ]
-    assert matching_subfolders, (
-        f"No checkpoint subfolder ending with '{expected_checkpoint_first_run_suffix}' found in {checkpoints_dir}."
+    command_first_run = small_training_cmd(
+        tmp_path, max_steps_first_run, val_check_interval, additional_args=additional_args
     )
-
-    # The second training command to continue from max_steps_first_run and finish at max_steps_second_run
-    command_second_run = small_training_cmd(tmp_path, max_steps_second_run, val_check_interval)
-    stdout_second_run = run_command_in_subprocess(command=command_second_run, path=str(tmp_path))
-    global_steps_second_run = extract_global_steps_from_log(stdout_second_run)
-
-    assert global_steps_second_run[0] == max_steps_first_run
-    assert global_steps_second_run[-1] == max_steps_second_run - 1
-    assert len(global_steps_second_run) == max_steps_second_run - max_steps_first_run
-
-    expected_checkpoint_second_run_suffix = f"{max_steps_second_run}.0-last"
-    matching_subfolders = [
-        p for p in checkpoints_dir.iterdir() if p.is_dir() and (expected_checkpoint_second_run_suffix in p.name)
-    ]
-    assert matching_subfolders, (
-        f"No checkpoint subfolder ending with '{expected_checkpoint_second_run_suffix}' found in {checkpoints_dir}."
-    )
-
-
-@pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
-@pytest.mark.timeout(256)  # Optional: fail if the test takes too long.
-@pytest.mark.slow
-def test_train_evo2_stop_at_max_steps_and_continue_fp8(tmp_path):
-    max_steps_first_run = 4
-    max_steps_second_run = 6
-    val_check_interval = 2
-    # Expected location of logs and checkpoints
-    log_dir = tmp_path / "evo2"
-    checkpoints_dir = log_dir / "checkpoints"
-
-    command_first_run = small_training_cmd(tmp_path, max_steps_first_run, val_check_interval, additional_args="--fp8")
 
     # The first training command to finish at max_steps_first_run
     stdout_first_run = run_command_in_subprocess(command=command_first_run, path=str(tmp_path))
@@ -239,7 +202,7 @@ def test_train_evo2_stop_at_max_steps_and_continue_fp8(tmp_path):
 
     # The second training command to continue from max_steps_first_run and finish at max_steps_second_run
     command_second_run = small_training_cmd(
-        tmp_path, max_steps_second_run, val_check_interval, additional_args="--fp8"
+        tmp_path, max_steps_second_run, val_check_interval, additional_args=additional_args
     )
     stdout_second_run = run_command_in_subprocess(command=command_second_run, path=str(tmp_path))
     global_steps_second_run = extract_global_steps_from_log(stdout_second_run)

--- a/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
+++ b/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
@@ -160,6 +160,59 @@ def test_train_evo2_stop_at_max_steps_and_continue(tmp_path):
     log_dir = tmp_path / "evo2"
     checkpoints_dir = log_dir / "checkpoints"
 
+    command_first_run = small_training_cmd(tmp_path, max_steps_first_run, val_check_interval)
+
+    # The first training command to finish at max_steps_first_run
+    stdout_first_run = run_command_in_subprocess(command=command_first_run, path=str(tmp_path))
+
+    assert f"Training epoch 0, iteration 0/{max_steps_first_run - 1}" in stdout_first_run
+    # Extract and validate global steps
+    global_steps_first_run = extract_global_steps_from_log(stdout_first_run)
+
+    assert global_steps_first_run[0] == 0
+    assert global_steps_first_run[-1] == max_steps_first_run - 1
+    assert len(global_steps_first_run) == max_steps_first_run
+
+    expected_checkpoint_first_run_suffix = f"{max_steps_first_run}.0-last"
+    # Check if checkpoints dir exists
+    assert checkpoints_dir.exists(), "Checkpoints folder does not exist."
+    # Check if any ckpt subfolder ends with the expected suffix
+    matching_subfolders = [
+        p for p in checkpoints_dir.iterdir() if p.is_dir() and (expected_checkpoint_first_run_suffix in p.name)
+    ]
+    assert matching_subfolders, (
+        f"No checkpoint subfolder ending with '{expected_checkpoint_first_run_suffix}' found in {checkpoints_dir}."
+    )
+
+    # The second training command to continue from max_steps_first_run and finish at max_steps_second_run
+    command_second_run = small_training_cmd(tmp_path, max_steps_second_run, val_check_interval)
+    stdout_second_run = run_command_in_subprocess(command=command_second_run, path=str(tmp_path))
+    global_steps_second_run = extract_global_steps_from_log(stdout_second_run)
+
+    assert global_steps_second_run[0] == max_steps_first_run
+    assert global_steps_second_run[-1] == max_steps_second_run - 1
+    assert len(global_steps_second_run) == max_steps_second_run - max_steps_first_run
+
+    expected_checkpoint_second_run_suffix = f"{max_steps_second_run}.0-last"
+    matching_subfolders = [
+        p for p in checkpoints_dir.iterdir() if p.is_dir() and (expected_checkpoint_second_run_suffix in p.name)
+    ]
+    assert matching_subfolders, (
+        f"No checkpoint subfolder ending with '{expected_checkpoint_second_run_suffix}' found in {checkpoints_dir}."
+    )
+
+
+@pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+@pytest.mark.timeout(256)  # Optional: fail if the test takes too long.
+@pytest.mark.slow
+def test_train_evo2_stop_at_max_steps_and_continue_fp8(tmp_path):
+    max_steps_first_run = 4
+    max_steps_second_run = 6
+    val_check_interval = 2
+    # Expected location of logs and checkpoints
+    log_dir = tmp_path / "evo2"
+    checkpoints_dir = log_dir / "checkpoints"
+
     command_first_run = small_training_cmd(tmp_path, max_steps_first_run, val_check_interval, additional_args="--fp8")
 
     # The first training command to finish at max_steps_first_run
@@ -188,59 +241,6 @@ def test_train_evo2_stop_at_max_steps_and_continue(tmp_path):
     command_second_run = small_training_cmd(
         tmp_path, max_steps_second_run, val_check_interval, additional_args="--fp8"
     )
-    stdout_second_run = run_command_in_subprocess(command=command_second_run, path=str(tmp_path))
-    global_steps_second_run = extract_global_steps_from_log(stdout_second_run)
-
-    assert global_steps_second_run[0] == max_steps_first_run
-    assert global_steps_second_run[-1] == max_steps_second_run - 1
-    assert len(global_steps_second_run) == max_steps_second_run - max_steps_first_run
-
-    expected_checkpoint_second_run_suffix = f"{max_steps_second_run}.0-last"
-    matching_subfolders = [
-        p for p in checkpoints_dir.iterdir() if p.is_dir() and (expected_checkpoint_second_run_suffix in p.name)
-    ]
-    assert matching_subfolders, (
-        f"No checkpoint subfolder ending with '{expected_checkpoint_second_run_suffix}' found in {checkpoints_dir}."
-    )
-
-
-@pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
-@pytest.mark.timeout(256)  # Optional: fail if the test takes too long.
-@pytest.mark.slow
-def test_train_evo2_stop_at_max_steps_and_continue_fp8(tmp_path):
-    max_steps_first_run = 4
-    max_steps_second_run = 6
-    val_check_interval = 2
-    # Expected location of logs and checkpoints
-    log_dir = tmp_path / "evo2"
-    checkpoints_dir = log_dir / "checkpoints"
-
-    command_first_run = small_training_cmd(tmp_path, max_steps_first_run, val_check_interval)
-
-    # The first training command to finish at max_steps_first_run
-    stdout_first_run = run_command_in_subprocess(command=command_first_run, path=str(tmp_path))
-
-    assert f"Training epoch 0, iteration 0/{max_steps_first_run - 1}" in stdout_first_run
-    # Extract and validate global steps
-    global_steps_first_run = extract_global_steps_from_log(stdout_first_run)
-
-    assert global_steps_first_run[0] == 0
-    assert global_steps_first_run[-1] == max_steps_first_run - 1
-    assert len(global_steps_first_run) == max_steps_first_run
-
-    expected_checkpoint_first_run_suffix = f"{max_steps_first_run}.0-last"
-    # Check if checkpoints dir exists
-    assert checkpoints_dir.exists(), "Checkpoints folder does not exist."
-    # Check if any ckpt subfolder ends with the expected suffix
-    matching_subfolders = [
-        p for p in checkpoints_dir.iterdir() if p.is_dir() and (expected_checkpoint_first_run_suffix in p.name)
-    ]
-    assert matching_subfolders, (
-        f"No checkpoint subfolder ending with '{expected_checkpoint_first_run_suffix}' found in {checkpoints_dir}."
-    )
-
-    # The second training command to continue from max_steps_first_run and finish at max_steps_second_run
-    command_second_run = small_training_cmd(tmp_path, max_steps_second_run, val_check_interval)
     stdout_second_run = run_command_in_subprocess(command=command_second_run, path=str(tmp_path))
     global_steps_second_run = extract_global_steps_from_log(stdout_second_run)
 


### PR DESCRIPTION
### Description
Add fp8 stop and go test for evo2

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

* If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
* If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
