### PR TITLE
automated benchmarks: esm2 650M training analogous to bionemo-recipes

### DIFF
--- a/ci/benchmarks/partial-conv/esm2_pretrain_recipes.yaml
+++ b/ci/benchmarks/partial-conv/esm2_pretrain_recipes.yaml
@@ -12,7 +12,7 @@ script_args:
   data_path: /data/20240809_uniref_2024_03/data
   model: esm2
   variant: train
-  config_name: 650M
+  config_name: 650M-recipes
   precision: [bf16-mixed]
   nodes: [4]
   gpus: 8
@@ -34,8 +34,8 @@ script: |-
       sleep 1
   done
   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY ${variant}_${model} \
-    --train-cluster-path=$NEW_DATA_PATH/train_clusters.parquet \
-    --train-database-path=$NEW_DATA_PATH/train.db \
+    --train-cluster-path=$NEW_DATA_PATH/train_clusters_bionemo_recipes.parquet \
+    --train-database-path=$NEW_DATA_PATH/train_bionemo_recipes.parquet \
     --valid-cluster-path=$NEW_DATA_PATH/valid_clusters.parquet \
     --valid-database-path=$NEW_DATA_PATH/validation.db \
     --micro-batch-size=${batch_size} \

--- a/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
@@ -38,7 +38,7 @@ script: |-
       sleep 1
   done
   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY ${variant}_${model} \
-    --data-dir ${data_path} \
+    --data-dir $NEW_DATA_PATH \
     --experiment-name ${batch_size}bs_${nodes}node_${gpus}gpu_${max_steps}s_${precision}prec \
     --num-gpus ${gpus} \
     --save-last-checkpoint \


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

* If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
* If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
