### PR TITLE
Fix database path in esm2_pretrain_recipes

### DIFF
--- a/ci/benchmarks/partial-conv/esm2_pretrain_recipes.yaml
+++ b/ci/benchmarks/partial-conv/esm2_pretrain_recipes.yaml
@@ -35,7 +35,7 @@ script: |-
   done
   WANDB_API_KEY=$BIONEMO_WANDB_API_KEY ${variant}_${model} \
     --train-cluster-path=$NEW_DATA_PATH/train_clusters_bionemo_recipes.parquet \
-    --train-database-path=$NEW_DATA_PATH/train_bionemo_recipes.parquet \
+    --train-database-path=$NEW_DATA_PATH/train.db \
     --valid-cluster-path=$NEW_DATA_PATH/valid_clusters.parquet \
     --valid-database-path=$NEW_DATA_PATH/validation.db \
     --micro-batch-size=${batch_size} \


### PR DESCRIPTION
The database path still needs to be the sqlite file, currently these jobs are failing with
```
 2: [rank2]: sqlite3.DatabaseError: file is not a database
```