### PR TITLE
Reset parameters for the ESM-2 contact head on HF export

### DIFF
--- a/sub-packages/bionemo-esm2/src/bionemo/esm2/model/convert.py
+++ b/sub-packages/bionemo-esm2/src/bionemo/esm2/model/convert.py
@@ -143,6 +143,7 @@ class HFESM2Exporter(io.ModelConnector[BionemoLightningModule, EsmForMaskedLM]):
         target = self.convert_state(source, target)
 
         target = target.cpu()
+        target.esm.contact_head.regression.reset_parameters()  # We don't initialize this head, so we need to reset.
         target.save_pretrained(output_path)
         self.tokenizer.save_pretrained(output_path)
 

--- a/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_convert.py
+++ b/sub-packages/bionemo-esm2/tests/bionemo/esm2/model/test_convert.py
@@ -57,6 +57,9 @@ def test_nemo2_export_8m_weights_equivalent(tmp_path):
     hf_model_from_nemo = AutoModelForMaskedLM.from_pretrained(output_path)
     hf_model_from_hf = AutoModelForMaskedLM.from_pretrained("facebook/esm2_t6_8M_UR50D")
 
+    # We should not have any NaNs in the model, even in heads that we don't explicitly initialize.
+    assert not {name: param for name, param in hf_model_from_nemo.named_parameters() if param.data.isnan().any()}
+
     del hf_model_from_nemo.esm.contact_head
     del hf_model_from_hf.esm.contact_head
 


### PR DESCRIPTION
Previously this weight was not initialized, and would be the result of whatever torch.empty() assigned to these values. If we want to use this layer in downstream tasks, we should at least randomly init these weights to reasonable values.