### PR TITLE
fix esm2 finetuning tutorial

### DIFF
--- a/sub-packages/bionemo-esm2/examples/finetune.ipynb
+++ b/sub-packages/bionemo-esm2/examples/finetune.ipynb
@@ -71,7 +71,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A class for calculating the supervised loss of the fine-tune model from targets. We inherit from Megatron Bert Masked Language Model Loss (`BERTMLMLossWithReduction`) and override the `forward()` pass to compute the sum of squared errors of the regression head within a micro-batch. The `reduce()` method of (`BERTMLMLossWithReduction`) is used for computing the average over the micro-batches, i.e. MSE loss.\n",
+    "A class for calculating the supervised loss of the fine-tune model from targets. We inherit from Megatron Bert Masked Language Model Loss (`BERTMLMLossWithReduction`) and override the `forward()` pass to compute the sum of squared errors of the regression head within a micro-batch. The averaging of the loss, i.e. the MSE loss is computed in https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/pipeline_parallel/schedules.py#L304-L314.\n",
     "\n",
     "```python\n",
     "class RegressorLossReduction(BERTMLMLossWithReduction):\n",
@@ -82,7 +82,7 @@
     "        regression_output = forward_out[\"regression_output\"]\n",
     "        targets = batch[\"labels\"].to(dtype=regression_output.dtype)  # [b, 1]\n",
     "        num_valid_tokens = torch.tensor(targets.numel(), dtype=torch.int, device=targets.device)\n",
-    "        loss_sum = ((regression_output - targets) ** 2).sum() # [b, 1]\n",
+    "        loss_sum = ((regression_output - targets) ** 2).sum()\n",
     "        loss_sum_and_ub_size = torch.cat([loss_sum.clone().detach().view(1), num_valid_tokens.view(1)])\n",
     "        return loss_sum, num_valid_tokens, {\"loss_sum_and_ub_size\": loss_sum_and_ub_size}\n",
     "```"
@@ -105,7 +105,7 @@
     "class MegatronMLPHead(MegatronModule):\n",
     "    def __init__(self, config: TransformerConfig):\n",
     "        super().__init__(config)\n",
-    "        layer_sizes = [config.hidden_size, 256, 1]\n",
+    "        layer_sizes = [config.hidden_size, config.mlp_hidden_size, config.mlp_target_size]\n",
     "        self.linear_layers = torch.nn.ModuleList(\n",
     "            [torch.nn.Linear(i, o) for i, o in zip(layer_sizes[:-1], layer_sizes[1:])]\n",
     "        )\n",
@@ -113,7 +113,11 @@
     "        self.dropout = torch.nn.Dropout(p=config.ft_dropout)\n",
     "\n",
     "    def forward(self, hidden_states: torch.Tensor) -> List[torch.Tensor]:\n",
-    "        ...\n",
+    "        for layer in self.linear_layers[:-1]:\n",
+    "            hidden_states = self.dropout(self.act(layer(hidden_states)))\n",
+    "\n",
+    "        output = self.linear_layers[-1](hidden_states)\n",
+    "        return output\n",
     "```"
    ]
   },
@@ -146,7 +150,7 @@
     "    def forward(self, *args, **kwargs,):\n",
     "        output = super().forward(*args, **kwargs)\n",
     "        ...\n",
-    "        output[\"regression_output\"] = self.regression_head(embeddings)\n",
+    "        output[\"regression_output\"] = self.regression_head(output[\"embeddings\"])\n",
     "        return output\n",
     "```"
    ]
@@ -167,8 +171,7 @@
     "The common arguments among different fine-tuning tasks are\n",
     "\n",
     "- `model_cls`: The fine-tune model class defined in previous step (`ESM2FineTuneSeqModel`)\n",
-    "- `initial_ckpt_path`: BioNeMo 2.0 ESM-2 pre-trained checkpoint\n",
-    "- `initial_ckpt_skip_keys_with_these_prefixes`: skips keys when loading parameters from a checkpoint. For example, we should not look for the key `regression_head` when initializing a `ESM2FineTuneSeqModel` with the encoder weights of the pretrained model checkpoint (`ESM2Model`).\n",
+    "- `initial_ckpt_skip_keys_with_these_prefixes`: skips keys when loading parameters from a checkpoint. For example, we should not look for the key `regression_head` when initializing a `ESM2FineTuneSeqModel` with the encoder weights of the pre-trained model checkpoint (`ESM2Model`).\n",
     "- `get_loss_reduction_class()`: Implements selection of the appropriate `MegatronLossReduction` class that we defined in the first step of this tutorial.\n",
     "\n",
     "```python\n",
@@ -178,17 +181,16 @@
     "    ESM2GenericConfig[ESM2FineTuneSeqModel, RegressorLossReduction], iom.IOMixinWithGettersSetters\n",
     "):\n",
     "    model_cls: Type[ESM2FineTuneSeqModel] = ESM2FineTuneSeqModel\n",
-    "    # The following checkpoint path is for nemo2 checkpoints. Config parameters not present in\n",
-    "    # self.override_parent_fields will be loaded from the checkpoint and override those values here.\n",
-    "    initial_ckpt_path: str | None = None\n",
     "    # typical case is fine-tune the base biobert that doesn't have this head. If you are instead loading a checkpoint\n",
     "    # that has this new head and want to keep using these weights, please drop this next line or set to []\n",
     "    initial_ckpt_skip_keys_with_these_prefixes: List[str] = field(default_factory=lambda: [\"regression_head\"])\n",
-    "\n",
     "    encoder_frozen: bool = True  # freeze encoder parameters\n",
-    "    ft_dropout: float = 0.25  # MLP layer dropout\n",
+    "    # MLP head layer parameters\n",
+    "    mlp_ft_dropout: float = 0.25  \n",
+    "    mlp_hidden_size: int = 256\n",
+    "    mlp_target_size: int = 1\n",
     "\n",
-    "    def get_loss_reduction_class(self) -> Type[MegatronLossReduction]:\n",
+    "    def get_loss_reduction_class(self) -> Type[BERTMLMLossWithReduction]:\n",
     "        return RegressorLossReduction\n",
     "```"
    ]
@@ -219,6 +221,7 @@
     "class InMemorySingleValueDataset(InMemoryProteinDataset):\n",
     "    def __init__(\n",
     "        self,\n",
+    "        sequences: pd.Series,\n",
     "        labels: pd.Series,\n",
     "        task_type: str = \"regression\",\n",
     "        tokenizer: tokenizer.BioNeMoESMTokenizer = tokenizer.get_tokenizer(),\n",
@@ -226,7 +229,7 @@
     "    ):\n",
     "        super().__init__(sequences, labels, task_type, tokenizer, seed)\n",
     "\n",
-    "    def transform_label(self, label: float) -> Tensor:\n",
+    "    def transform_label(self, label: float | str) -> Tensor:\n",
     "        return torch.tensor([label], dtype=torch.float)\n",
     "```\n",
     "\n",
@@ -448,7 +451,7 @@
     "We can assign a different LR for specific layers (e.g. task head) during fine-tuning by making it possible to specify the name of the target layer as well as the LR multiplier.\n",
     "\n",
     "- `--lr-multiplier`: is a float that scales `--lr`\n",
-    "- `--sclae-lr-layer`: is the name of the layers for which we scale the LR"
+    "- `--scale-lr-layer`: is the name of the layers for which we scale the LR"
    ]
   },
   {


### PR DESCRIPTION
### Description
update the esm2 finetuning tutorial 
### Type of changes
<!-- Mark the relevant option with an [x] -->

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [x]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

* If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
* If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully
