### PR TITLE
Fix typos in ESM2 finetune notebook

### DIFF
--- a/sub-packages/bionemo-esm2/examples/finetune.ipynb
+++ b/sub-packages/bionemo-esm2/examples/finetune.ipynb
@@ -867,14 +867,14 @@
     "print(f\"sequence_classification_target {sequence_classification_target}\")\n",
     "print(f\"predicted_classes {predicted_classes}\")\n",
     "assert test_acc > 0.55\n",
-    "print(f\"test acc is {test_loss}\")"
+    "print(f\"test acc is {test_acc}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Toke-level Classification data"
+    "### Token-level Classification data"
    ]
   },
   {
@@ -1187,12 +1187,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "lora_checkpoint_path = (\n",
-    "    f\"{work_dir}/lora-token-level-classification/checkpoints/checkpoint-step=49-consumed_samples=100.0-last/weights\"\n",
+    "    f\"{work_dir}/lora-token-level-classification/checkpoints/checkpoint-step=49-consumed_samples=100.0-last\"\n",
     ")\n",
     "results_path = f\"{work_dir}/lora-token-level-classification/infer/\""
    ]
@@ -1216,12 +1216,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "%%capture --no-display --no-stderr cell_output\n",
-    "data_path = os.path.join(work_dir, \"sequences.csv\")\n",
+    "data_path = os.path.join(work_dir, \"test_token_classification.csv\")\n",
     "\n",
     "! infer_esm2 --checkpoint-path {pretrain_checkpoint_path} \\\n",
     "             --config-class ESM2FineTuneTokenConfig \\\n",
@@ -1234,6 +1234,15 @@
     "             --include-hiddens \\\n",
     "             --include-input-ids \\\n",
     "             --lora-checkpoint-path {lora_checkpoint_path}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert _exit_code == 0  # noqa: F821"
    ]
   }
  ],


### PR DESCRIPTION
### Description
Fixes path references in the ESM2 fine-tune Jupyter notebook.

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [ ]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

* If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
* If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [x] I have tested these changes locally
 - [x] I have updated the documentation accordingly
 - [x] I have added/updated tests as needed
 - [x] All existing tests pass successfully
