### PR TITLE
updating setup tools in pyproject.toml of scspeedtest

### DIFF
--- a/sub-packages/bionemo-scspeedtest/pyproject.toml
+++ b/sub-packages/bionemo-scspeedtest/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
This pins a newer setuptools version in pyproject.toml to a newer version that is necessary for an editable install of this package. 