### PR TITLE
update root README.md for open file count error

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ With a locally cloned repository and initialized submodules, build the BioNeMo c
 ```bash
 docker buildx build . -t my-container-tag
 ```
-If you see an error message like `No file descriptors available (os error 24)`, add the option `--ulimit nofile=65535:65535` to the docker build command.  
+
+If you see an error message like `No file descriptors available (os error 24)`, add the option `--ulimit nofile=65535:65535` to the docker build command.
 
 #### VSCode Devcontainer for Interactive Debugging
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ With a locally cloned repository and initialized submodules, build the BioNeMo c
 ```bash
 docker buildx build . -t my-container-tag
 ```
+If you see an error message like `No file descriptors available (os error 24)`, add the option `--ulimit nofile=65535:65535` to the docker build command.  
 
 #### VSCode Devcontainer for Interactive Debugging
 


### PR DESCRIPTION
### Description

- On a colossus viking node,

"
Architecture:             x86_64
  CPU op-mode(s):         32-bit, 64-bit
  Address sizes:          52 bits physical, 57 bits virtual
  Byte Order:             Little Endian
CPU(s):                   224
  On-line CPU(s) list:    0-223
Vendor ID:                GenuineIntel
  Model name:             Intel(R) Xeon(R) Platinum 8480C
    CPU family:           6
    Model:                143
    Thread(s) per core:   2
    Core(s) per socket:   56
    Socket(s):            2
    Stepping:             8
    CPU(s) scaling MHz:   30%
    CPU max MHz:          3800.0000
    CPU min MHz:          800.0000
    BogoMIPS:             4000.00
"

I see the error 'No file descriptors available (os error 24)' at docker build time:
  - [build_image_r20250914T195410_dev-br_bnm2564_open_file_count-20250914T195410-7c03f87c.log](https://github.com/user-attachments/files/22324046/build_image_r20250914T195410_dev-br_bnm2564_open_file_count-20250914T195410-7c03f87c.log)



- With the recommended build option, the error is resolved:
[build_image_r20250914T203321_dev-br_bnm2564_open_file_count-20250914T203321-7c03f87c.log](https://github.com/user-attachments/files/22324055/build_image_r20250914T203321_dev-br_bnm2564_open_file_count-20250914T203321-7c03f87c.log)

### Type of changes
<!-- Mark the relevant option with an [x] -->

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Refactor
- [x]  Documentation update
- [ ]  Other (please describe):

### CI Pipeline Configuration
Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

* If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
* If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage
<!--- How does a user interact with the changed code -->
```python
TODO: Add code snippet
```

### Pre-submit Checklist
<!--- Ensure all items are completed before submitting -->

 - [ ] I have tested these changes locally
 - [ ] I have updated the documentation accordingly
 - [ ] I have added/updated tests as needed
 - [ ] All existing tests pass successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a troubleshooting tip to the README advising users to pass --ulimit nofile=65535:65535 when using docker buildx build to fix “No file descriptors available (os error 24)”.
  * Tip added near the build command in the Getting Started / local Docker build sections for visibility.
  * No code or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->