### PR TITLE
Add checkpointing documentation

### DIFF
--- a/docs/docs/main/about/background/SUMMARY.md
+++ b/docs/docs/main/about/background/SUMMARY.md
@@ -1,2 +1,2 @@
-- [NeMo2 Parallelism](nemo2.md)
+- [NeMo2](nemo2.md)
 - [Megatron Dataset Considerations](megatron_datasets.md)

--- a/sub-packages/bionemo-evo2/src/bionemo/evo2/run/train.py
+++ b/sub-packages/bionemo-evo2/src/bionemo/evo2/run/train.py
@@ -971,6 +971,11 @@ def train(args: argparse.Namespace) -> nl.Trainer:
         )
         callbacks.append(checkpoint_callback)
 
+        # Note: `nl.AutoResume` is only created if a `ModelCheckpoint` exists, because `nl.AutoResume.setup()`
+        # expects the trainer to have a `checkpoint_callback` set. See: https://github.com/NVIDIA/NeMo/blob/29c230b8a3352bef2128ba2d226a327d52d05be3/nemo/lightning/resume.py#L128
+        #
+        # In principle, this shouldn't be a constraint — it should be possible to create `nl.AutoResume` even if
+        # checkpointing is not enabled.
         auto_resume = nl.AutoResume(
             resume_if_exists=True,
             resume_ignore_no_checkpoint=True,


### PR DESCRIPTION
### Description

Add docs and note about checkpointing  

### Type of changes

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [x] Documentation update
- [ ] Other (please describe):

### CI Pipeline Configuration

Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> \[!NOTE\]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage

<!--- How does a user interact with the changed code -->

```python
# TODO: Add code snippet
```

### Pre-submit Checklist

<!--- Ensure all items are completed before submitting -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly
- [x] I have added/updated tests as needed
- [x] All existing tests pass successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Safer training auto-resume: auto-resume now only initializes when a checkpoint mechanism exists and respects resume vs. restore precedence and directory rules.

- Documentation
  - Renamed “NeMo2 Parallelism” to “NeMo2” in navigation and page title.
  - Added detailed checkpointing section with precedence rules, resume/restore flow, and flowchart.
  - Reorganized and expanded parallelism topics (DDP/FSDP/pipeline/tensor/sequence/context) with deeper headings, examples, and clarified guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->