### PR TITLE
add some fixes for recipes ci

### DIFF
--- a/.github/workflows/unit-tests-recipes.yml
+++ b/.github/workflows/unit-tests-recipes.yml
@@ -3,13 +3,12 @@ name: "BioNeMo Recipes CI"
 on:
   push:
     branches:
-      - main
       - "pull-request/[0-9]+"
       - "dependabot/**"
   merge_group:
     types: [checks_requested]
   schedule:
-    - cron: "0 7 * * *" # Runs at 7 AM UTC daily (12 AM MST)
+    - cron: "0 9 * * *" # Runs at 9 AM UTC daily (2 AM MST)
 
 defaults:
   run:
@@ -50,12 +49,22 @@ jobs:
         run: |
           # Get all recipe and model directories
           ALL_DIRS=$(ls -d recipes/*/ models/*/ 2>/dev/null | jq -R -s -c 'split("\n")[:-1] | map(rtrimstr("/"))')
-          CHANGED_FILES='${{ steps.changed-files.outputs.all_changed_files }}'
-          # Filter directories to only those that have changed files. Then assign a Docker image to each.
+
+          # Determine which directories to run: all for schedule, filtered for other events
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            DIRS="$ALL_DIRS"
+          else
+            CHANGED_FILES='${{ steps.changed-files.outputs.all_changed_files }}'
+            # Filter directories to only those that have changed files
+            DIRS=$(echo "$ALL_DIRS" | jq -c --argjson changed "$CHANGED_FILES" '
+              map(select(. as $dir | $changed | index($dir) != null))
+            ')
+          fi
+
+          # Assign Docker images to the selected directories
           # Currently, AMPLIFY is the only folder that needs a custom base image, since we have to support both TE and
           # xformers-based models for golden value testing. The rest of the models use the default pytorch image.
-          DIRS=$(echo "$ALL_DIRS" | jq -c --argjson changed "$CHANGED_FILES" '
-            map(select(. as $dir | $changed | index($dir) != null)) |
+          DIRS_WITH_IMAGES=$(echo "$DIRS" | jq -c '
             map({
               dir: .,
               image: (
@@ -67,7 +76,7 @@ jobs:
               )
             })
           ')
-          echo "dirs=$DIRS" >> $GITHUB_OUTPUT
+          echo "dirs=$DIRS_WITH_IMAGES" >> $GITHUB_OUTPUT
       - name: Show output
         run: |
           echo '${{ toJSON(steps.changed-files.outputs) }}'
@@ -78,6 +87,7 @@ jobs:
   unit-tests:
     needs: changed-dirs
     runs-on: linux-amd64-gpu-l4-latest-1
+    if: ${{ needs.changed-dirs.outputs.any_changed == 'true' }}
     container:
       image: ${{ matrix.recipe.image }}
     strategy:


### PR DESCRIPTION
* don't run recipes on `main` branch (we could add this later if we need coverage)
* on schedule events, run all folders
* don't trigger unit test matrix if no folders changed