### PR TITLE
add continue-on-error to get-pr-info

### DIFF
--- a/.github/workflows/unit-tests-recipes.yml
+++ b/.github/workflows/unit-tests-recipes.yml
@@ -29,6 +29,7 @@ jobs:
     steps:
       - id: get-pr-info
         uses: nv-gha-runners/get-pr-info@main
+        continue-on-error: true
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Looks like get-pr-info can fail on submodule updates. Let's just continue on error here, or maybe we can revert to the PR labels action we use in bionemo-framework.