### PR TITLE
Remove index.md markdown to prevent 3.13 requirement

### DIFF
--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,4 +1,1 @@
 number = true        # options: {false, true}
-exclude = [
-    "docs/docs/index.md",	# Exclude highly formatted index page
-]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
     rev: 0.7.22             # Use the latest stable version
     hooks:
       - id: mdformat
-        language_version: python3.13
         additional_dependencies:
         - mdformat-tables
         - mdformat-gfm

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -3,50 +3,93 @@ hide:
   - navigation
 ---
 
+<p>
+  <strong>NVIDIA BioNeMo Framework</strong> is a collection of programming tools, libraries, and models for computational drug discovery.
+  It accelerates the most time-consuming and costly stages of building and adapting biomolecular AI models by providing domain-specific, optimized models and tooling that are easily integrated into GPU-based computational resources for the fastest performance on the market.
+  You can access BioNeMo Framework as a free community resource or learn more about getting an enterprise license for improved expert-level support at the
+  <a href="https://www.nvidia.com/en-us/clara/bionemo/">BioNeMo homepage</a>.
+</p>
 
-**NVIDIA BioNeMo Framework** is a collection of programming tools, libraries, and models for computational drug
-discovery. It accelerates the most time-consuming and costly stages of building and adapting biomolecular AI models by
-providing domain-specific, optimized models and tooling that are easily integrated into GPU-based computational
-resources for the fastest performance on the market. You can access BioNeMo Framework as a free community resource or
-learn more about getting an enterprise license for improved expert-level support at the
-[BioNeMo homepage](https://www.nvidia.com/en-us/clara/bionemo/).
+<div class="grid cards">
 
+<div class="card">
+    <div style="display: flex; align-items: center; gap: 0.5em;">
+      <div class="card-icon" style="margin: 0;">
+        <span class="twemoji lg">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <path d="M12 21.5c-1.35-.85-3.8-1.5-5.5-1.5-1.65 0-3.35.3-4.75 1.05-.1.05-.15.05-.25.05-.25 0-.5-.25-.5-.5V6c.6-.45 1.25-.75 2-1 1.11-.35 2.33-.5 3.5-.5 1.95 0 4.05.4 5.5 1.5 1.45-1.1 3.55-1.5 5.5-1.5 1.17 0 2.39.15 3.5.5.75.25 1.4.55 2 1v14.6c0 .25-.25.5-.5.5-.1 0-.15 0-.25-.05-1.4-.75-3.1-1.05-4.75-1.05-1.7 0-4.15.65-5.5 1.5M12 8v11.5c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5V7c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5m1 3.5c1.11-.68 2.6-1 4.5-1 .91 0 1.76.09 2.5.28V9.23c-.87-.15-1.71-.23-2.5-.23q-2.655 0-4.5.84zm4.5.17c-1.71 0-3.21.26-4.5.79v1.69c1.11-.65 2.6-.99 4.5-.99 1.04 0 1.88.08 2.5.24v-1.5c-.87-.16-1.71-.23-2.5-.23m2.5 2.9c-.87-.16-1.71-.24-2.5-.24-1.83 0-3.33.27-4.5.8v1.69c1.11-.66 2.6-.99 4.5-.99 1.04 0 1.88.08 2.5.24z"></path>
+          </svg>
+        </span>
+      </div>
+      <div class="card-title" style="margin: 0;">
+        <strong>Datasets</strong>
+      </div>
+    </div>
+    <hr />
+    <p>Install BioNeMo and set up your environment to start accelerating your bioinformatics workflows.</p>
+    <p>
+      <a href="main/about/overview/" class="md-button md-button">Get Started</a>
+    </p>
+  </div>
 
-<div class="grid cards" markdown>
+<div class="card">
+    <div style="display: flex; align-items: center; gap: 0.5em;">
+      <div class="card-icon" style="margin: 0;">
+        <span class="twemoji lg">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <path d="M10.41 7.41 15 12l-4.59 4.6L9 15.18 12.18 12 9 8.82M5 3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2z"></path>
+          </svg>
+        </span>
+      </div>
+      <div class="card-title" style="margin: 0;">
+        <strong>Datasets</strong>
+      </div>
+    </div>
+    <hr />
+    <p>Access comprehensive documentation on BioNeMo's sub-packages, functions, and classes.</p>
+    <p>
+      <a href="main/references/API_reference/bionemo/core/api/" class="md-button md-button">API Reference</a>
+    </p>
+  </div>
 
--   :material-book-open-variant:{ .lg } __User Guide__
+<div class="card">
+    <div style="display: flex; align-items: center; gap: 0.5em;">
+      <div class="card-icon" style="margin: 0;">
+        <span class="twemoji lg">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <path d="M21 16.5c0 .38-.21.71-.53.88l-7.9 4.44c-.16.12-.36.18-.57.18s-.41-.06-.57-.18l-7.9-4.44A.99.99 0 0 1 3 16.5v-9c0-.38.21-.71.53-.88l7.9-4.44c.16-.12.36-.18.57-.18s.41.06.57.18l7.9 4.44c.32.17.53.5.53.88zM12 4.15 6.04 7.5 12 10.85l5.96-3.35zM5 15.91l6 3.38v-6.71L5 9.21zm14 0v-6.7l-6 3.37v6.71z"></path>
+          </svg>
+        </span>
+      </div>
+      <div class="card-title" style="margin: 0;">
+        <strong>Datasets</strong>
+      </div>
+    </div>
+    <hr />
+    <p>Explore detailed instructions and best practices for using BioNeMo models in your research.</p>
+    <p>
+      <a href="models" class="md-button md-button">Explore Models</a>
+    </p>
+  </div>
 
-    ---
-
-    Install BioNeMo and set up your environment to start accelerating your bioinformatics workflows.
-
-    [Get Started](main/about/overview/){ .md-button .md-button }
-
--   :material-code-greater-than:{ .lg } __API Reference__
-
-    ---
-
-    Access comprehensive documentation on BioNeMo's sub-packages, functions, and classes.
-
-    [API Reference](main/references/API_reference/bionemo/core/api/){ .md-button .md-button }
-
--   :material-cube-outline:{ .lg } __Models__
-
-    ---
-
-    Explore detailed instructions and best practices for using BioNeMo models in your research.
-
-    [Explore Models](models){ .md-button .md-button }
-
-
-
--   :material-database-outline:{ .lg } __Datasets__
-
-    ---
-
-    Explore biomolecular datasets that come pre-packaged with the BioNeMo Framework.
-
-    [Explore Datasets](main/datasets/){ .md-button .md-button }
-
+<div class="card">
+    <div style="display: flex; align-items: center; gap: 0.5em;">
+      <div class="card-icon" style="margin: 0;">
+        <span class="twemoji lg">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <path d="M12 3C7.58 3 4 4.79 4 7v10c0 2.21 3.59 4 8 4s8-1.79 8-4V7c0-2.21-3.58-4-8-4m6 14c0 .5-2.13 2-6 2s-6-1.5-6-2v-2.23c1.61.78 3.72 1.23 6 1.23s4.39-.45 6-1.23zm0-4.55c-1.3.95-3.58 1.55-6 1.55s-4.7-.6-6-1.55V9.64c1.47.83 3.61 1.36 6 1.36s4.53-.53 6-1.36zM12 9C8.13 9 6 7.5 6 7s2.13-2 6-2 6 1.5 6 2-2.13 2-6 2"></path>
+          </svg>
+        </span>
+      </div>
+      <div class="card-title" style="margin: 0;">
+        <strong>Datasets</strong>
+      </div>
+    </div>
+    <hr />
+    <p>Explore biomolecular datasets that come pre-packaged with the BioNeMo Framework.</p>
+    <p>
+      <a href="main/datasets/" class="md-button md-button">Explore Datasets</a>
+    </p>
+  </div>
 
 </div>


### PR DESCRIPTION
The cards in the docs `index.md` require a specific format.
However, `mdformat` changes this format. To workaround this, we had to add excludes functionalty for `mdformat` that prevented it from formatting `index.md`. For some reason, the excludes functionality in `mdformat` which requires python 3.13. This is broke our nightly build.

To fix this, I've converted the `index.md` card logic from markdown to html, so that it no longer gets formatted. This removes the need for the excludes functionality and  the 3.13 dependency it brings.