### PR TITLE
skip get-pr-info if we're not on a pull request branch

### DIFF
--- a/.github/workflows/unit-tests-recipes.yml
+++ b/.github/workflows/unit-tests-recipes.yml
@@ -28,6 +28,7 @@ jobs:
 
     steps:
       - id: get-pr-info
+        if: ${{ startsWith(github.ref_name, 'pull-request/') }}
         uses: nv-gha-runners/get-pr-info@main
 
       - uses: actions/checkout@v4
@@ -40,7 +41,7 @@ jobs:
         with:
           json: true
           matrix: true
-          base_sha:  ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
+          base_sha: main
           dir_names: true
           dir_names_max_depth: 2
           files: |
@@ -100,8 +101,7 @@ jobs:
         run: |
           echo '${{ toJSON(steps.changed-files.outputs) }}'
           echo '${{ toJSON(steps.set-dirs.outputs) }}'
-        shell:
-          bash
+        shell: bash
 
   unit-tests:
     needs: changed-dirs
@@ -120,7 +120,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          sparse-checkout: '${{ matrix.recipe.dir }}'
+          sparse-checkout: "${{ matrix.recipe.dir }}"
           sparse-checkout-cone-mode: false
 
       - name: Install dependencies


### PR DESCRIPTION
This step will fail if we're not on a pull request branch; causing the schedule CI to fail