### PR TITLE
fix mdformat version at 3.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     rev: 0.7.22             # Use the latest stable version
     hooks:
       - id: mdformat
+        language_version: python3.9
         additional_dependencies:
         - mdformat-tables
         - mdformat-gfm


### PR DESCRIPTION
Fix mdformat version at 3.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling to run the Markdown formatting hook with Python 3.9 for consistent behavior across environments.
  * Ensures identical formatting output regardless of local Python versions, reducing spurious diffs in pull requests.
  * Improves parity between local setups and CI, helping maintain a cleaner commit history.
  * No user-facing functionality changes; this affects developer workflow and code formatting only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->