### PR TITLE
Change NeMo to new organization NVIDIA-NeMo.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/NVIDIA/Megatron-LM.git
 [submodule "3rdparty/NeMo"]
 	path = 3rdparty/NeMo
-	url = https://github.com/NVIDIA/NeMo.git
+	url = https://github.com/NVIDIA-NeMo/NeMo.git


### PR DESCRIPTION
### Description

<!-- Provide a detailed description of the changes in this PR -->

- Update NeMo repository URL.

### Type of changes

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

### CI Pipeline Configuration

Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage

<!--- How does a user interact with the changed code -->

```
$ cye@605b786-lcedt:~/Workspace/bionemo-framework$ cat .gitmodules
[submodule "3rdparty/Megatron-LM"]
        path = 3rdparty/Megatron-LM
        url = https://github.com/NVIDIA/Megatron-LM.git
[submodule "3rdparty/NeMo"]
        path = 3rdparty/NeMo
        url = https://github.com/NVIDIA-NeMo/NeMo.git
$ rm -drf 3rdparty/NeMo
$ mkdir 3rdparty/NeMo
$ cye@605b786-lcedt:~/Workspace/bionemo-framework$ ls -lah 3rdparty/NeMo
total 8.0K
drwxr-xr-x 2 cye domain-users 4.0K Aug 28 13:49 .
drwxr-xr-x 4 cye domain-users 4.0K Aug 28 13:49 ..
$ cye@605b786-lcedt:~/Workspace/bionemo-framework$ git submodule update
Submodule path '3rdparty/NeMo': checked out '7ccb0d4c5544dbcc454930acb3a1fe29d9db5090'
$ cye@605b786-lcedt:~/Workspace/bionemo-framework$ ls -lah 3rdparty/NeMo
total 408K
drwxr-xr-x 13 cye domain-users 4.0K Aug 28 13:50 .
drwxr-xr-x  4 cye domain-users 4.0K Aug 28 13:49 ..
-rw-r--r--  1 cye domain-users 137K Aug 28 13:50 CHANGELOG.md
-rw-r--r--  1 cye domain-users 1.1K Aug 28 13:50 CITATION.cff
-rw-r--r--  1 cye domain-users  563 Aug 28 13:50 codecov.yml
-rw-r--r--  1 cye domain-users 4.3K Aug 28 13:50 CONTRIBUTING.md
-rw-r--r--  1 cye domain-users  840 Aug 28 13:50 .coveragerc
drwxr-xr-x  3 cye domain-users 4.0K Aug 28 13:50 docker
-rw-r--r--  1 cye domain-users  184 Aug 28 13:50 .dockerignore
drwxr-xr-x  3 cye domain-users 4.0K Aug 28 13:50 docs
drwxr-xr-x 14 cye domain-users 4.0K Aug 28 13:50 examples
drwxr-xr-x  3 cye domain-users 4.0K Aug 28 13:50 external
-rw-r--r--  1 cye domain-users  305 Aug 28 13:50 .flake8
-rw-r--r--  1 cye domain-users  305 Aug 28 13:50 .flake8.other
-rw-r--r--  1 cye domain-users  306 Aug 28 13:50 .flake8.speech
-rw-r--r--  1 cye domain-users   41 Aug 28 13:50 .git
drwxr-xr-x  6 cye domain-users 4.0K Aug 28 13:50 .github
-rw-r--r--  1 cye domain-users 2.6K Aug 28 13:50 .gitignore
-rw-r--r--  1 cye domain-users  12K Aug 28 13:50 LICENSE
-rw-r--r--  1 cye domain-users   70 Aug 28 13:50 MANIFEST.in
drwxr-xr-x  9 cye domain-users 4.0K Aug 28 13:50 nemo
-rw-r--r--  1 cye domain-users 7.6K Aug 28 13:50 nemo_dependencies.py
-rw-r--r--  1 cye domain-users 1.8K Aug 28 13:50 .pre-commit-config.yaml
-rw-r--r--  1 cye domain-users   85 Aug 28 13:50 .pylintrc
-rw-r--r--  1 cye domain-users  225 Aug 28 13:50 .pylintrc.other
-rw-r--r--  1 cye domain-users  115 Aug 28 13:50 .pylintrc.speech
-rw-r--r--  1 cye domain-users 5.3K Aug 28 13:50 pyproject.toml
-rw-r--r--  1 cye domain-users  32K Aug 28 13:50 README.md
-rw-r--r--  1 cye domain-users 1.2K Aug 28 13:50 .readthedocs.yml
drwxr-xr-x  2 cye domain-users 4.0K Aug 28 13:50 requirements
drwxr-xr-x 35 cye domain-users 4.0K Aug 28 13:50 scripts
-rw-r--r--  1 cye domain-users  73K Aug 28 13:50 .secrets.baseline
-rw-r--r--  1 cye domain-users 9.8K Aug 28 13:50 setup.py
drwxr-xr-x 14 cye domain-users 4.0K Aug 28 13:50 tests
drwxr-xr-x 11 cye domain-users 4.0K Aug 28 13:50 tools
drwxr-xr-x 12 cye domain-users 4.0K Aug 28 13:50 tutorials
```

### Pre-submit Checklist

<!--- Ensure all items are completed before submitting -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the source reference for a third-party component to its current official repository to ensure reliable fetching and future updates.
  * Improves maintainability for development environments without altering application behavior.
  * No changes to features, performance, or user interface; builds and runtime functionality remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->