### PR TITLE
Fix `train_evo2` constant steps description

### DIFF
--- a/sub-packages/bionemo-evo2/src/bionemo/evo2/run/train.py
+++ b/sub-packages/bionemo-evo2/src/bionemo/evo2/run/train.py
@@ -274,7 +274,7 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--constant-steps",
         type=int,
-        help="Number of steps to keep the learning rate constant before annealing. This controls the "
+        help="Number of steps to keep the learning rate constant at minimum after annealing. This controls the "
         "shape of the learning rate curve.",
         default=80000,
     )


### PR DESCRIPTION
### Description

Fixes the `--help` description of `--constant-steps` in `train_evo2` which says the constant steps happen before cosine annealing but they happen afterwards. You can see the implementation [here](https://github.com/NVIDIA-NeMo/NeMo/blob/main/nemo/lightning/pytorch/optim/lr_scheduler.py) and below is an example of what happens when using the default 80k constant steps:

<img width="1400" height="725" alt="image" src="https://github.com/user-attachments/assets/a5713781-46eb-4c37-a8cc-60c8b1d7efaf" />

### Type of changes

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [x] Documentation update
- [ ] Other (please describe):

### CI Pipeline Configuration

Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage

<!--- How does a user interact with the changed code -->

```python
train_evo2 --help | grep --after-context=3 "^  --constant-steps"
```

### Pre-submit Checklist

<!--- Ensure all items are completed before submitting -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly
- [x] I have added/updated tests as needed
- [x] All existing tests pass successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI help text for the --constant-steps option to say “constant at minimum after annealing” for improved accuracy.
  * Explicitly notes this is a wording change only — no defaults, functionality, or runtime behavior were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->