### PR TITLE
use gha cache for bionemo test data

### DIFF
--- a/.github/workflows/unit-tests-framework.yml
+++ b/.github/workflows/unit-tests-framework.yml
@@ -167,6 +167,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Cache bionemo test data
+        uses: actions/cache@v4
+        with:
+          path: /root/.cache/bionemo
+          key: ${{ runner.os }}-bionemo-test-data-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-bionemo-test-data
+
       - name: Run tests
         # Tests in this stage generate code coverage metrics for the repository
         # Coverage data is uploaded to Codecov in subsequent stages

--- a/Dockerfile
+++ b/Dockerfile
@@ -190,7 +190,8 @@ ENV UV_LINK_MODE=copy \
   UV_COMPILE_BYTECODE=1 \
   UV_PYTHON_DOWNLOADS=never \
   UV_SYSTEM_PYTHON=true \
-  UV_BREAK_SYSTEM_PACKAGES=1
+  UV_BREAK_SYSTEM_PACKAGES=1 \
+  PIP_NO_CACHE_DIR=1
 
 # Install the bionemo-geometric requirements ahead of copying over the rest of the repo, so that we can cache their
 # installation. These involve building some torch extensions, so they can take a while to install.


### PR DESCRIPTION
This might reduce some of the intermittent connection errors we're seeing in CI. Unfortunately the cache is stored on github's servers so it will still be a network request to get the data to our runners, but it might be faster as a single download.

Also tries to remove the ~/.cache/pip folder in our container, which is currently 1.5 Gb of unneeded files.