### PR TITLE
pin transformers in esm2 golden values

### DIFF
--- a/models/esm2/pyproject.toml
+++ b/models/esm2/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "pytest",
     "torch",
     # "transformer_engine[pytorch]",
-    "transformers",
+    "transformers<4.56", # TODO: fix me, currently failing with a modelopt import from nemo.
 ]
 
 


### PR DESCRIPTION
ESM-2 model tests are currently failing on nightly since a transformers commit broke modelopt from nemo. We really need to decouple our golden value conversions from nemo.io, i suspect this will be an issue going forward with all the stuff they import