### PR TITLE
fix memory error on nightly a bnm2712

### DIFF
--- a/sub-packages/bionemo-evo2/tests/bionemo/evo2/test_evo2.py
+++ b/sub-packages/bionemo-evo2/tests/bionemo/evo2/test_evo2.py
@@ -75,49 +75,49 @@ def determine_memory_requirement_and_skip_if_not_met(ckpt_name: str, test_name: 
                 "model_size": "1b",
                 "seq_len_cap": 6000,
                 "memory_needed_by_test": 18,
-            },  # checked in isolation
+            },  # checked both variants in isolation
             {
                 "test_name": "test_forward",
                 "model_size": "7b",
                 "seq_len_cap": 4000,
                 "memory_needed_by_test": 33,
-            },  # checked in isolation
+            },  # checked both variants in isolation
             {
                 "test_name": "test_forward_manual",
                 "model_size": "1b",
                 "seq_len_cap": 6000,
-                "memory_needed_by_test": 6,
-            },  # checked in isolation
+                "memory_needed_by_test": 18,
+            },  # checked both variants in isolation
             {
                 "test_name": "test_forward_manual",
                 "model_size": "7b",
                 "seq_len_cap": 4000,
                 "memory_needed_by_test": 21,
-            },  # checked in isolation
+            },  # checked both variants in isolation
             {
                 "test_name": "test_batch_generate",
                 "model_size": "1b",
                 "seq_len_cap": -1,
                 "memory_needed_by_test": 16,
-            },  # checked in isolation
+            },  # checked both variants in isolation
             {
                 "test_name": "test_batch_generate",
                 "model_size": "7b",
                 "seq_len_cap": -1,
                 "memory_needed_by_test": 43,
-            },  # checked in isolation
+            },  # checked both variants in isolation
             {
                 "test_name": "test_batch_generate_coding_sequences",
                 "model_size": "1b",
                 "seq_len_cap": -1,
                 "memory_needed_by_test": 6,
-            },  # checked in isolation
+            },  # checked both variants in isolation
             {
                 "test_name": "test_batch_generate_coding_sequences",
                 "model_size": "7b",
                 "seq_len_cap": -1,
                 "memory_needed_by_test": 21,
-            },  # checked in isolation
+            },  # checked both variants in isolation
             {
                 "test_name": "test_generate_speed",
                 "model_size": "1b",
@@ -721,7 +721,7 @@ def test_batch_generate(
         ("evo2/1b-8k:1.0", get_model_and_tokenizer, [86.4, 78.8, 87.6]),
         ("evo2_mamba/7b-8k:0.1", get_model_and_tokenizer_ignore_vortex, [86.5, 88.4, 88.2]),
         ("evo2/7b-8k:1.0", get_model_and_tokenizer, [88.8, 88.5, 82.2]),
-        # ("evo2/7b-1m:1.0", get_model_and_tokenizer, [88.8, 88.5, 82.2]),
+        ("evo2/7b-1m:1.0", get_model_and_tokenizer, [88.8, 88.5, 82.2]),
     ],
 )
 def test_batch_generate_coding_sequences(


### PR DESCRIPTION
### Description

- A recent run of the nightly blossum pipeline showed the error below.  
  - https://prod.blsm.nvidia.com/bionemo-external-bionemo-fw/job/test_pytest/2411/pipeline-console/log?nodeId=90

`[2025-08-29T13:07:20.866Z] E       torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 12.81 GiB. GPU 0 has a total capacity of 39.50 GiB of which 12.39 GiB is free. Process 500601 has 27.10 GiB memory in use. Of the allocated memory 25.96 GiB is allocated by PyTorch, with 2.00 MiB allocated in private pools (e.g., CUDA Graphs), and 176.45 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)`

`[2025-08-29T12:42:04.086Z] sub-packages/bionemo-evo2/tests/bionemo/evo2/test_evo2.py::test_batch_generate[evo2/7b-1m:1.0-get_model_and_tokenizer-expected_matchpercents4] FAILED [ 51%] `

  - The nightline CI pipeline is run on A100-40GB.  See ticket for more detail https://jirasw.nvidia.com/browse/BIONEMO-2712, 



- We update the logic for selecting memory threshold for affected tests.

### Type of changes


### Local pytest results

**1. sub-packages/bionemo-evo2/tests/bionemo/evo2/test_evo2.py -  single H100 80GB device**
   -  [pytests_nightly_ci_memory_errors_80gb-device_sub-packages-bionemo-evo2-tests-bionemo-evo2-test_evo2_notslow_br_bnm2712_memory_error_on_nightly_a_20250903T2236_5f4ce5d5.log](https://github.com/user-attachments/files/22128577/pytests_nightly_ci_memory_errors_80gb-device_sub-packages-bionemo-evo2-tests-bionemo-evo2-test_evo2_notslow_br_bnm2712_memory_error_on_nightly_a_20250903T2236_5f4ce5d5.log)
 - 18 passed, 2 skipped, 6 deselected, 1655 warnings in 1736.85s (0:28:56)
   - max memory reserved for tensors etc: 41.426 GB


**2. sub-packages/bionemo-evo2/tests/bionemo/evo2/test_evo2.py - single H100 80GB device, restricted to 40GB**
running

[pytests_nightly_ci_memory_errors_40gb-device_sub-packages-bionemo-evo2-tests-bionemo-evo2-test_evo2_notslow_br_bnm2712_memory_error_on_nightly_a_20250903T2343_5f4ce5d5.log](https://github.com/user-attachments/files/22128575/pytests_nightly_ci_memory_errors_40gb-device_sub-packages-bionemo-evo2-tests-bionemo-evo2-test_evo2_notslow_br_bnm2712_memory_error_on_nightly_a_20250903T2343_5f4ce5d5.log)



<img width="669" height="57" alt="image" src="https://github.com/user-attachments/assets/1c31d587-0c88-4e59-92e3-da542f1248fb" />



**3. sub-packages/bionemo-evo2/tests/bionemo/evo2/test_evo2.py - single H100 80GB device, restricted to 20GB**
[pytests_nightly_ci_memory_errors_80gb-device_sub-packages-bionemo-evo2-tests-bionemo-evo2-test_evo2_notslow_br_bnm2712_memory_error_on_nightly_a_20250903T2236_5f4ce5d5.log](https://github.com/user-attachments/files/22129350/pytests_nightly_ci_memory_errors_80gb-device_sub-packages-bionemo-evo2-tests-bionemo-evo2-test_evo2_notslow_br_bnm2712_memory_error_on_nightly_a_20250903T2236_5f4ce5d5.log)



<img width="645" height="65" alt="image" src="https://github.com/user-attachments/assets/bbfb7659-5abb-4528-920f-da85c34e3a7c" />


<img width="635" height="155" alt="image" src="https://github.com/user-attachments/assets/890ffd2c-61a2-4303-a065-e0c833336f8a" />


<!-- Mark the relevant option with an [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

### CI Pipeline Configuration

Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage

<!--- How does a user interact with the changed code -->

```python
# TODO: Add code snippet
```

### Pre-submit Checklist

<!--- Ensure all items are completed before submitting -->

- [wip] I have tested these changes locally
- [na] I have updated the documentation accordingly
- [na] I have added/updated tests as needed
- [wip] All existing tests pass successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable maximum sequence length when loading models/tokenizers, applied to inference limits and thresholds.
  * Additional inference options enabled for improved runtime performance, including faster decode paths and decode-time optimizations.

* **Tests**
  * Per-test GPU memory gating to skip runs when resources are insufficient, driven by test-aware memory requirements.
  * Tests compute per-test sequence-length caps, enable fast decode paths where applicable, and record tokens/sec for performance tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->