### PR TITLE
adding shared_eden_dataloader.

### DIFF
--- a/sub-packages/bionemo-evo2/src/bionemo/evo2/data/__init__.py
+++ b/sub-packages/bionemo-evo2/src/bionemo/evo2/data/__init__.py
@@ -1,7 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-FileCopyrightText: Copyright (c) 2024 Arc Institute. All rights reserved.
-# SPDX-FileCopyrightText: Copyright (c) 2024 Michael Poli. All rights reserved.
-# SPDX-FileCopyrightText: Copyright (c) 2024 Stanford University. All rights reserved
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-Apache2
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sub-packages/bionemo-evo2/src/bionemo/evo2/data/sharded_eden_dataloader.md
+++ b/sub-packages/bionemo-evo2/src/bionemo/evo2/data/sharded_eden_dataloader.md
@@ -1,0 +1,282 @@
+# Sharded Eden DataLoader Implementation
+
+## Overview
+
+The `sharded_eden_dataloader.py` implements a dataloader for genomic sequences that uses pre-computed data structures and SQLite databases for efficient data access. This implementation is designed to significantly reduce the computational overhead during training by moving expensive operations to a pre-processing phase.
+
+## Key Features
+
+### 1. Split-Specific Window Databases
+
+- **Sharded**: Uses separate pre-computed window databases for each split:
+  - `train_window_db_path`: SQLite database containing window mappings for training data
+  - `val_window_db_path`: SQLite database containing window mappings for validation data
+  - `test_window_db_path`: SQLite database containing window mappings for test data
+
+### 2. SQLite Database Storage
+
+- **Sharded**: Uses SQLite databases organized by sample:
+  - **Per-Sample Sequence Databases**: Each sample has its own SQLite file at `sequence_db_dir/<sample_id>/glm_dataset_<sample_id>.sqlite`
+  - **Split-Specific Window Databases**: Pre-computed window mappings stored in separate databases for each data split
+
+### 3. Virtual Window Pre-computation
+
+- **Sharded**: Window mappings are pre-computed from Parquet files and stored in split-specific databases
+
+## Sequence ID Format
+
+Sequence IDs follow a specific format: `BCR__ECT-SAMPLE1__CT1-1`
+
+The sample ID can be extracted using: `extract_sample_id(sequence_id)` which implements `".".join(sequence_id.split("__")[1].split("-")[1:])` (returns `SAMPLE1`)
+
+## Database Schema
+
+### Per-Sample Sequence Database
+
+Each sample has its own SQLite file with the following schema:
+
+```sql
+CREATE TABLE sequences (
+    contig_id TEXT PRIMARY KEY,
+    nt_sequence TEXT NOT NULL
+);
+```
+
+### Split-Specific Window Database
+
+Each split (train/validation/test) has its own window database:
+
+```sql
+CREATE TABLE metadata (
+    key TEXT PRIMARY KEY,
+    value INTEGER NOT NULL
+);
+
+CREATE TABLE window_mappings (
+    window_idx INTEGER PRIMARY KEY,
+    sequence_id TEXT NOT NULL,
+    window_in_seq_idx INTEGER NOT NULL
+);
+CREATE INDEX idx_sequence_id ON window_mappings(sequence_id);
+```
+
+The metadata table stores the `window_size` and `stride` parameters used during pre-computation.
+
+## Directory Structure
+
+```
+sequence_db_dir/
+├── SAMPLE1/
+│   └── glm_dataset_SAMPLE1.sqlite
+├── SAMPLE2/
+│   └── glm_dataset_SAMPLE2.sqlite
+├── SAMPLE3/
+│   └── glm_dataset_SAMPLE3.sqlite
+└── ...
+
+Window databases (separate files):
+├── train_windows.db
+├── val_windows.db
+└── test_windows.db
+```
+
+## Usage Example
+
+```python
+from bionemo.evo2.run.sharded_eden_dataloader import ShardedEdenDataModule
+
+# Create the data module
+data_module = ShardedEdenDataModule(
+    sequence_db_dir="path/to/sequence_db_dir",  # Directory containing sample folders
+    train_window_db_path="path/to/train_windows.db",
+    val_window_db_path="path/to/val_windows.db",
+    test_window_db_path="path/to/test_windows.db",
+    seq_length=8192,
+    micro_batch_size=1,
+    global_batch_size=4,
+    num_workers=8,
+    rc_aug=True,
+    use_control_tags=True,
+)
+
+# Use with PyTorch Lightning trainer
+trainer = pl.Trainer(...)
+trainer.fit(model, data_module)
+```
+
+## Pre-processing Workflow
+
+### 1. Create Sample Sequence Databases
+
+For each sample, create its SQLite database:
+
+```python
+import sqlite3
+import os
+
+
+def create_sample_database(sample_id, sequences, output_dir):
+    """Create SQLite database for a single sample."""
+    # Create sample directory
+    sample_dir = os.path.join(output_dir, sample_id)
+    os.makedirs(sample_dir, exist_ok=True)
+
+    # Create database
+    db_path = os.path.join(sample_dir, f"glm_dataset_{sample_id}.sqlite")
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    # Create table
+    cursor.execute(
+        """
+        CREATE TABLE sequences (
+            contig_id TEXT PRIMARY KEY,
+            nt_sequence TEXT NOT NULL
+        )
+    """
+    )
+
+    # Insert sequences for this sample
+    for seq_id, sequence in sequences:
+        cursor.execute(
+            "INSERT INTO sequences (contig_id, nt_sequence) VALUES (?, ?)",
+            (seq_id, sequence),
+        )
+
+    conn.commit()
+    conn.close()
+
+
+# Example usage
+# Group sequences by sample_id
+from collections import defaultdict
+
+sequences_by_sample = defaultdict(list)
+for seq_id, sequence in all_sequences:  # all_sequences is your data
+    sample_id = extract_sample_id(seq_id)
+    sequences_by_sample[sample_id].append((seq_id, sequence))
+
+# Create database for each sample
+for sample_id, sequences in sequences_by_sample.items():
+    create_sample_database(sample_id, sequences, "path/to/sequence_db_dir")
+```
+
+### 2. Create Split Data Files
+
+Create Parquet files for each split containing sequence metadata:
+
+```python
+import polars as pl
+
+# Create train split Parquet file
+train_data = pl.DataFrame(
+    {
+        "contig_id": ["BCR__ECT-SAMPLE1__CT1-1", "BCR__ECT-SAMPLE1__CT1-2", ...],
+        "length": [1500, 2000, ...],  # sequence lengths
+    }
+)
+train_data.write_parquet("train_split.parquet")
+
+# Similarly for validation and test splits
+val_data = pl.DataFrame(
+    {"contig_id": ["BCR__ECT-SAMPLE2__CT1-1", ...], "length": [1800, ...]}
+)
+val_data.write_parquet("val_split.parquet")
+
+test_data = pl.DataFrame(
+    {"contig_id": ["BCR__ECT-SAMPLE3__CT1-1", ...], "length": [1600, ...]}
+)
+test_data.write_parquet("test_split.parquet")
+```
+
+### 3. Create Window Mappings Databases using CLI
+
+The package includes a CLI tool for pre-computing the window databases:
+
+```bash
+# Pre-compute window mappings for training split
+python -m bionemo.evo2.run.sharded_eden_dataloader precompute \
+    train_split.parquet \
+    train_windows.db \
+    --window-size 8192 \
+    --stride 7992
+
+# Pre-compute window mappings for validation split
+python -m bionemo.evo2.run.sharded_eden_dataloader precompute \
+    val_split.parquet \
+    val_windows.db \
+    --window-size 8192 \
+    --stride 7992
+
+# Pre-compute window mappings for test split
+python -m bionemo.evo2.run.sharded_eden_dataloader precompute \
+    test_split.parquet \
+    test_windows.db \
+    --window-size 8192 \
+    --stride 7992
+```
+
+## Implementation Details
+
+### Key Components
+
+1. **ShardedEdenDataModule**:
+
+   - Uses separate window databases for each split (train/val/test)
+   - Manages per-sample SQLite file paths
+   - Creates datasets with directory and database paths
+   - Handles distributed training setup with Megatron integration
+
+2. **ShardedEdenDataset**:
+
+   - Automatically discovers sample SQLite files from directory structure
+   - Maps sequence IDs to appropriate sample databases using `extract_sample_id()`
+   - Pre-opens all database connections for performance
+   - Attaches window database to each sequence connection for efficient JOINs
+   - Implements sequence caching with connection pooling
+   - Maintains compatibility with original tokenization and formatting logic
+   - Optional window access logging for performance analysis
+
+3. **CLI Tool**:
+
+   - `precompute`: Creates window databases from Parquet files
+
+### Advanced Features
+
+#### Window Access Logging
+
+Enable detailed logging of window access patterns:
+
+```python
+dataset = ShardedEdenDataset(
+    # ... other parameters ...
+    log_windows=True,
+    log_dir="sequence_logs",
+)
+```
+
+This creates CSV logs tracking which windows are accessed, useful for analyzing data loading patterns.
+
+#### Connection Management
+
+- All database connections are pre-opened during initialization for performance
+- Database connections are pooled and reused per sample
+- Sequence data is fetched on-demand using SQL SUBSTR for memory efficiency
+- Position IDs are shared across instances to reduce memory usage
+- Connections are properly closed when dataset is destroyed
+
+#### Metadata Validation
+
+The implementation validates that window databases were created with compatible parameters:
+
+- Checks stored `window_size` matches dataset `seq_length`
+- Checks stored `stride` matches dataset `stride`
+- Provides clear error messages for mismatches
+
+### Error Handling
+
+- Validates sample SQLite files exist during initialization
+- Handles missing sequences gracefully with informative error messages
+- Ensures proper cleanup of database connections
+- Provides detailed debugging information for database issues
+- Validates Parquet file schema during pre-computation

--- a/sub-packages/bionemo-evo2/src/bionemo/evo2/data/sharded_eden_dataloader.py
+++ b/sub-packages/bionemo-evo2/src/bionemo/evo2/data/sharded_eden_dataloader.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # high performance implementation of the EdenDataModule, assuming some items are pre-computed + sharded fasta files and fasta index files.
-
+# Contributed by: BaseCamp Research https://basecamp-research.com/ https://github.com/NVIDIA/bionemo-framework/pull/1091
 import argparse
 import csv
 import os
@@ -100,7 +100,7 @@ class ShardedEdenDataModule(pl.LightningDataModule):
         log_dir: Optional[str] = None,
         **kwargs,
     ):
-        """Initialize the ShardedEdenDataModule."""
+        """Initialize the ShardedEdenDataModule. See sub-packages/bionemo-evo2/src/bionemo/evo2/data/sharded_eden_dataloader.md for how to prepare the input data. """
         super().__init__()
         self.sequence_db_dir = sequence_db_dir
         self.train_window_db_path = train_window_db_path

--- a/sub-packages/bionemo-evo2/src/bionemo/evo2/data/sharded_eden_dataloader.py
+++ b/sub-packages/bionemo-evo2/src/bionemo/evo2/data/sharded_eden_dataloader.py
@@ -1,0 +1,937 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# high performance implementation of the EdenDataModule, assuming some items are pre-computed + sharded fasta files and fasta index files.
+
+import argparse
+import csv
+import os
+import sqlite3
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+import lightning.pytorch as pl
+import numpy as np
+import polars as pol
+import torch
+import torch.distributed as dist
+from lightning.pytorch.utilities.types import EVAL_DATALOADERS, TRAIN_DATALOADERS
+from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenizer
+from nemo.lightning.data import WrappedDataLoader
+from nemo.lightning.pytorch.plugins import MegatronDataSampler
+from nemo.utils import logging
+from nemo.utils.import_utils import safe_import
+from torch.utils.data import Dataset, default_collate
+
+from bionemo.core.data.multi_epoch_dataset import (
+    IdentityMultiEpochDatasetWrapper,
+    MultiEpochDatasetResampler,
+)
+
+
+# -----------------------------------------------------------------------------
+# Configurable column names
+# -----------------------------------------------------------------------------
+# Column name for IDs in input data (e.g., parquet) and in shard SQLite tables
+SEQUENCE_ID_COLUMN_NAME = "contig_id"
+# Column name for sequence lengths in input data (e.g., parquet)
+SEQUENCE_LENGTH_COLUMN_NAME = "length"
+# Column name for nucleotide/amino-acid sequence in shard SQLite tables
+SEQUENCE_COLUMN_NAME = "nt_sequence"
+
+_, HAVE_TE = safe_import("transformer_engine")
+
+if TYPE_CHECKING:
+    from nemo.collections.common.tokenizers.tokenizer_spec import TokenizerSpec
+
+
+def extract_sample_id(sequence_id: str) -> str:
+    """Extract sample ID from sequence ID format: BCR__EXT-SAMPLE1__CT1-1."""
+    parts = sequence_id.split("__")[1].split("-")[1:]
+    return ".".join(parts)
+
+
+class ShardedEdenDataModule(pl.LightningDataModule):
+    """High-performance DataModule that uses pre-computed splits and SQLite databases.
+
+    Key differences from EdenDataModule:
+    - Train/val/test splits are loaded from numpy array files
+    - Sequence data stored in per-sample SQLite databases
+    - Virtual window mappings pre-computed and stored in separate SQLite database
+    """
+
+    def __init__(
+        self,
+        sequence_db_dir: str,  # Directory containing sample SQLite files
+        train_window_db_path: str,  # Path to the pre-computed DB for the training split
+        val_window_db_path: str,  # Path to the pre-computed DB for the validation split
+        test_window_db_path: str,  # Path to the pre-computed DB for the test split
+        seq_length: int = 8192,
+        tokenizer: Optional["TokenizerSpec"] = None,
+        micro_batch_size: int = 1,
+        global_batch_size: int = 4,
+        rampup_batch_size: Optional[List[int]] = None,
+        num_workers: int = 8,
+        pin_memory: bool = True,
+        persistent_workers: bool = False,
+        create_attention_mask: bool = False,
+        vocab_file: Optional[str] = None,
+        merges_file: Optional[str] = None,
+        rc_aug: bool = False,
+        stride: int = 7992,
+        window_min_length_threshold: Optional[int] = None,
+        use_control_tags: bool = False,
+        seed: int = 42,
+        num_epochs: int = 1,
+        log_windows: bool = False,
+        log_dir: Optional[str] = None,
+        **kwargs,
+    ):
+        """Initialize the ShardedEdenDataModule."""
+        super().__init__()
+        self.sequence_db_dir = sequence_db_dir
+        self.train_window_db_path = train_window_db_path
+        self.val_window_db_path = val_window_db_path
+        self.test_window_db_path = test_window_db_path
+        self.seq_length = seq_length
+        self.micro_batch_size = micro_batch_size
+        self.global_batch_size = global_batch_size
+        self.num_workers = num_workers
+        self.pin_memory = pin_memory
+        self.persistent_workers = persistent_workers
+        self.create_attention_mask = create_attention_mask or not HAVE_TE
+        self.rc_aug = rc_aug
+        self.stride = stride if stride is not None else 7992
+        # Minimum effective window length used at precomputation time. If None or 0, disabled.
+        self.window_min_length_threshold = int(window_min_length_threshold) if window_min_length_threshold else 0
+        self.use_control_tags = use_control_tags
+        self.init_global_step = 0
+        self.seed = seed
+        self.num_epochs = num_epochs
+        self.log_windows = log_windows
+        self.log_dir = log_dir
+
+        if tokenizer is None:
+            self.tokenizer = get_nmt_tokenizer(
+                "megatron",
+                "GPT2BPETokenizer",
+                vocab_file=vocab_file,
+                merges_file=merges_file,
+            )
+        else:
+            self.tokenizer = tokenizer
+
+        # Megatron sampler
+        self.data_sampler = MegatronDataSampler(
+            seq_len=self.seq_length,
+            micro_batch_size=self.micro_batch_size,
+            global_batch_size=self.global_batch_size,
+            rampup_batch_size=rampup_batch_size,
+        )
+
+    def build(
+        self,
+        trainer_max_steps: int,
+        trainer_val_check_interval: Union[int, float],
+        trainer_limit_val_batches: Union[int, float],
+        trainer_limit_test_batches: Union[int, float],
+    ):
+        """Build the datasets using pre-computed, split-specific window databases."""
+        if not dist.is_initialized() or dist.get_rank() == 0:
+            print("Creating datasets from pre-computed, split-specific window databases.")
+
+        # Create datasets wrapped with epoch-based resampler
+        self._train_ds = self._create_epoch_wrapped_sharded_eden_dataset(
+            window_db_path=self.train_window_db_path,
+            split="train",
+            shuffle=True,
+        )
+
+        self._validation_ds = self._create_epoch_wrapped_sharded_eden_dataset(
+            window_db_path=self.val_window_db_path,
+            split="validation",
+            shuffle=False,
+        )
+
+        self._test_ds = self._create_epoch_wrapped_sharded_eden_dataset(
+            window_db_path=self.test_window_db_path,
+            split="test",
+            shuffle=False,
+        )
+
+        if not dist.is_initialized() or dist.get_rank() == 0:
+            print(
+                f"Dataset windows: Train={len(self._train_ds)}, Val={len(self._validation_ds)}, Test={len(self._test_ds)}"
+            )
+
+    def setup(self, stage: str = "") -> None:
+        """Setup the data module."""
+        assert hasattr(self, "trainer") and self.trainer is not None, (
+            "Setup should be completed when trainer and config are attached."
+        )
+
+        self.build(
+            trainer_max_steps=self.trainer.max_steps,
+            trainer_val_check_interval=self.trainer.val_check_interval,
+            trainer_limit_val_batches=self.trainer.limit_val_batches,
+            trainer_limit_test_batches=self.trainer.limit_test_batches,
+        )
+
+    def train_dataloader(self) -> TRAIN_DATALOADERS:
+        """Get the train dataloader."""
+        return self._create_dataloader(self._train_ds, mode="train")
+
+    def val_dataloader(self) -> EVAL_DATALOADERS:
+        """Get the validation dataloader."""
+        return self._create_dataloader(self._validation_ds, mode="validation")
+
+    def test_dataloader(self) -> EVAL_DATALOADERS:
+        """Get the test dataloader."""
+        return self._create_dataloader(self._test_ds, mode="test")
+
+    def _create_dataloader(self, dataset, mode, **kwargs) -> WrappedDataLoader:
+        assert hasattr(self, "trainer") and self.trainer is not None, (
+            "Trainer must be attached before creating dataloaders."
+        )
+        self.init_global_step = self.trainer.global_step
+        self.data_sampler.init_global_step = self.init_global_step
+        dataloader = WrappedDataLoader(
+            mode=mode,
+            dataset=dataset,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            persistent_workers=self.persistent_workers,
+            collate_fn=getattr(dataset, "collate_fn", default_collate),
+            **kwargs,
+        )
+        return dataloader
+
+    def _create_epoch_wrapped_sharded_eden_dataset(
+        self,
+        *,
+        window_db_path: str,
+        split: str,
+        shuffle: bool,
+    ) -> MultiEpochDatasetResampler:
+        """Instantiate `ShardedEdenDataset` and wrap it with `MultiEpochDatasetResampler`.
+
+        By default, `num_epochs=1`, so the wrapped dataset length equals the base dataset length.
+        """
+        base_dataset = ShardedEdenDataset(
+            tokenizer=self.tokenizer,
+            sequence_db_dir=self.sequence_db_dir,
+            window_db_path=window_db_path,
+            seq_length=self.seq_length,
+            create_attention_mask=self.create_attention_mask,
+            stride=self.stride,
+            window_min_length_threshold=self.window_min_length_threshold,
+            rc_aug=self.rc_aug,
+            use_control_tags=self.use_control_tags,
+            split=split,
+            log_windows=self.log_windows,
+            log_dir=self.log_dir,
+        )
+
+        wrapped = MultiEpochDatasetResampler(
+            IdentityMultiEpochDatasetWrapper(base_dataset),
+            num_epochs=self.num_epochs,
+            shuffle=shuffle,
+            seed=self.seed,
+        )
+        return wrapped
+
+    def state_dict(self) -> Dict[str, Any]:
+        """Called when saving a checkpoint."""
+        consumed_samples = self.data_sampler.compute_consumed_samples(self.trainer.global_step - self.init_global_step)
+        return {"consumed_samples": consumed_samples}
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        """Called when loading a checkpoint."""
+        try:
+            from megatron.core.num_microbatches_calculator import (
+                update_num_microbatches,
+            )
+        except (ImportError, ModuleNotFoundError):
+            logging.warning("Megatron num_microbatches_calculator not found, using Apex version.")
+            from apex.transformer.pipeline_parallel.utils import update_num_microbatches
+
+        consumed_samples = state_dict["consumed_samples"]
+        self.data_sampler.init_consumed_samples = consumed_samples
+        self.data_sampler.prev_consumed_samples = consumed_samples
+
+        update_num_microbatches(
+            consumed_samples=consumed_samples,
+            consistency_check=False,
+        )
+        self.data_sampler.if_first_step = 1
+
+    def reconfigure_limit_batches(self):
+        """Reconfigure trainer.limit_train_batches and trainer.limit_val_batches."""
+        self._reconfigure_limit_batches(self.trainer.limit_train_batches, self._train_ds, "train")
+        self._reconfigure_limit_batches(self.trainer.limit_val_batches, self._validation_ds, "val")
+
+    def _reconfigure_limit_batches(self, limit_batches, dataloader, mode):
+        """Reconfigure limit_batches for distributed training."""
+        try:
+            from megatron.core.num_microbatches_calculator import get_num_microbatches
+        except (ImportError, ModuleNotFoundError):
+            logging.warning("Megatron num_microbatches_calculator not found, using Apex version.")
+            from apex.transformer.pipeline_parallel.utils import get_num_microbatches
+
+        if isinstance(limit_batches, int):
+            limit_batches *= get_num_microbatches()
+        else:
+            assert isinstance(limit_batches, float)
+            if limit_batches == 0.0 or dataloader is None:
+                return
+
+            dl_len_in_micro_batches = len(dataloader)
+            if len(dataloader) != float("inf"):
+                if limit_batches == 1.0:
+                    limit_batches = dl_len_in_micro_batches
+                else:
+                    limit_micro_batches = int(dl_len_in_micro_batches * limit_batches)
+                    if limit_micro_batches == 0 and limit_batches > 0.0:
+                        min_percentage = 1.0 / len(dataloader)
+                        raise ValueError(
+                            f"You requested to check {limit_batches} of the val_dataloader but"
+                            f" {limit_batches} * {len(dataloader)} < 1. Please increase the"
+                            f" `limit_val_batches` argument. Try at least"
+                            f" `limit_val_batches={min_percentage}`"
+                        )
+                    if limit_micro_batches < get_num_microbatches():
+                        limit_batches = get_num_microbatches()
+                    else:
+                        limit_batches = limit_batches - limit_batches % get_num_microbatches()
+
+        if mode == "train":
+            self.trainer.limit_train_batches = limit_batches
+        else:
+            self.trainer.limit_val_batches = limit_batches
+
+
+class ShardedEdenDataset(Dataset):
+    """High-performance Dataset that uses SQLite databases for sequence storage and window mapping. Assumes that the window_db_path points to a database pre-computed for a specific data split (e.g., train, validation, or test)."""
+
+    def __init__(
+        self,
+        tokenizer,
+        sequence_db_dir: str,
+        window_db_path: str,
+        seq_length: int,
+        create_attention_mask: bool = False,
+        rc_aug: bool = False,
+        stride: Optional[int] = 7992,
+        window_min_length_threshold: Optional[int] = None,
+        use_control_tags: bool = False,
+        split: str = "train",
+        log_windows: bool = False,
+        log_dir: Optional[str] = None,
+        skip_stats: bool = True,
+    ) -> None:
+        """Initialize the ShardedEdenDataset."""
+        super().__init__()
+        self.seq_length = seq_length
+        self.tokenizer = tokenizer
+        self.sequence_db_dir = sequence_db_dir
+        self.window_db_path = window_db_path
+        self.create_attention_mask = create_attention_mask
+        self.rc_aug = rc_aug
+        self.stride = stride if stride is not None else 7992
+        self.window_min_length_threshold = int(window_min_length_threshold) if window_min_length_threshold else 0
+        self.use_control_tags = use_control_tags
+        self.split = split
+        self.skip_stats = skip_stats
+        # Window access logging setup (lazy init in __getitem__)
+        self.log_windows = log_windows
+        # Remember desired log directory for lazy init in worker processes
+        self._log_dir = log_dir
+
+        # Create mapping from sample_id to SQLite file path
+        self._create_sample_db_mapping()
+
+        # Pre-open all database connections for performance
+        self._open_all_sequence_dbs()
+
+        # Validates metadata and sets up the dataset
+        self._validate_and_setup_db()
+
+        # Prepare control-tag IDs if needed
+        if self.use_control_tags:
+            self._prepare_control_tags()
+
+        # Attention mask and position ids
+        if create_attention_mask:
+            self.attention_mask = torch.tril(torch.ones((seq_length, seq_length))).unsqueeze(0) < 0.5
+
+        # Shared position_ids for memory efficiency
+        if not hasattr(ShardedEdenDataset, "_position_ids") or ShardedEdenDataset._position_ids.size(0) != seq_length:
+            ShardedEdenDataset._position_ids = torch.arange(seq_length, dtype=torch.int64)
+        self.position_ids = ShardedEdenDataset._position_ids
+
+        # Counter for periodic commits if logging is enabled
+        if self.log_windows:
+            self._log_counter = 0
+
+    def _open_all_sequence_dbs(self):
+        """Open all sequence database files ahead of time and attach the window database for efficient cross-database queries."""
+        self.db_connections = {}
+        if not dist.is_initialized() or dist.get_rank() == 0:
+            print(f"Pre-opening {len(self.sample_db_mapping)} sequence database files...")
+
+        for sample_id, db_path in self.sample_db_mapping.items():
+            try:
+                # URI=true allows for read-only connections if needed and more options
+                conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+                self.db_connections[sample_id] = conn
+            except sqlite3.Error as e:
+                logging.error(f"Failed to open/attach database for sample {sample_id} at {db_path}: {e}")
+                raise
+
+    def _create_sample_db_mapping(self):
+        """Create mapping from sample ID to SQLite file path."""
+        self.sample_db_mapping = {}
+
+        # Scan the directory for sample SQLite files
+        db_dir = Path(self.sequence_db_dir)
+        for sample_dir in db_dir.iterdir():
+            if sample_dir.is_dir():
+                sample_id = sample_dir.name
+                db_file = sample_dir / f"glm_dataset_{sample_id}.sqlite"
+                if db_file.exists():
+                    self.sample_db_mapping[sample_id] = str(db_file)
+
+        if not self.sample_db_mapping:
+            raise ValueError(f"No SQLite files found in {self.sequence_db_dir}")
+
+        if not dist.is_initialized() or dist.get_rank() == 0:
+            print(f"Found {len(self.sample_db_mapping)} sample SQLite files")
+
+    def _validate_and_setup_db(self):
+        """Connects to the window database, validates its metadata, and computes the length of the dataset for the current split."""
+        self.window_db_conn = sqlite3.connect(f"file:{self.window_db_path}?mode=ro", uri=True)
+        cursor = self.window_db_conn.cursor()
+
+        # Validate metadata
+        try:
+            cursor.execute("SELECT key, value FROM metadata")
+            db_meta = dict(cursor.fetchall())
+
+            if "window_size" not in db_meta or "stride" not in db_meta:
+                raise ValueError("Database metadata is missing 'window_size' or 'stride' keys.")
+
+            db_window_size = int(db_meta["window_size"])
+            db_stride = int(db_meta["stride"])
+            db_min_len_raw = db_meta.get("window_min_length_threshold")
+            db_min_len = int(db_min_len_raw) if db_min_len_raw is not None else None
+
+            if db_window_size != self.seq_length or db_stride != self.stride:
+                raise ValueError(
+                    f"Database metadata mismatch! "
+                    f"DB created with window_size={db_window_size}, stride={db_stride}. "
+                    f"Dataset configured with seq_length={self.seq_length}, stride={self.stride}. "
+                    f"Please re-run pre-computation or check your config."
+                )
+
+            # Validate presence and value of window_min_length_threshold only if enabled
+            if self.window_min_length_threshold and self.window_min_length_threshold > 0:
+                if db_min_len is None:
+                    raise ValueError(
+                        "Database metadata is missing 'window_min_length_threshold'. "
+                        "Please re-run the pre-computation script with an updated version to populate this key."
+                    )
+                if db_min_len != self.window_min_length_threshold:
+                    raise ValueError(
+                        f"Database metadata mismatch for window_min_length_threshold! "
+                        f"DB created with window_min_length_threshold={db_min_len}. "
+                        f"Dataset configured with window_min_length_threshold={self.window_min_length_threshold}. "
+                        f"Please re-run pre-computation or align the configuration."
+                    )
+            else:
+                # Case: DB is pruned but runtime threshold is not set (> 0)
+                if db_min_len is not None and int(db_min_len) > 0:
+                    raise ValueError(
+                        f"Window DB indicates pruning was applied (window_min_length_threshold={db_min_len}), "
+                        "but the current configuration does not set --window-min-length-threshold (> 0). "
+                        "Please set the argument to match the DB or use an unpruned database."
+                    )
+        except sqlite3.OperationalError:
+            raise ValueError(
+                f"Could not find `metadata` table in {self.window_db_path}. "
+                "Please ensure the database was created with a recent version of the pre-computation script."
+            )
+
+        # Require modern metadata keys
+        if "total_windows" not in db_meta or "distinct_sequences" not in db_meta:
+            raise ValueError(
+                "Database metadata must contain 'total_windows' and 'distinct_sequences'. "
+                "Please re-run the pre-computation script to create an up-to-date window database."
+            )
+
+        # Read counts directly from metadata
+        self.length = int(db_meta["total_windows"])
+
+        if not dist.is_initialized() or dist.get_rank() == 0:
+            print(f"Found {self.length} windows for {self.split} split in {self.window_db_path}.")
+
+        # Distinct sequences directly from metadata
+        self.distinct_sequences = int(db_meta["distinct_sequences"])
+        if not dist.is_initialized() or dist.get_rank() == 0:
+            print(f"Found {self.distinct_sequences} distinct sequences.")
+
+    def _prepare_control_tags(self):
+        """Prepare control tag IDs for sequences."""
+        self.ctrl_ids_map = {}
+
+        # Query the split-specific DB for the sequences it contains
+        cursor = self.window_db_conn.cursor()
+        unique_sequence_ids = [row[0] for row in cursor.execute("SELECT DISTINCT sequence_id FROM window_mappings")]
+
+        # Create control tags for unique sequence IDs in this split
+        for seq_id in unique_sequence_ids:
+            # Extract meaningful part from sequence ID for control tag
+            ctrl_name = seq_id.split("__")[0] if "__" in seq_id else seq_id
+            self.ctrl_ids_map[seq_id] = self.tokenizer.text_to_ids(f"<ctrl_{ctrl_name.lower()}>")
+
+    def __len__(self) -> int:
+        """Return the length of the dataset."""
+        return self.length
+
+    def _get_db_connection(self, sample_id: str) -> sqlite3.Connection:
+        """Get a pre-opened database connection for a sample."""
+        conn = self.db_connections.get(sample_id)
+        if conn is None:
+            # This should not happen if _open_all_sequence_dbs was called
+            # and the sample_id is valid.
+            raise ValueError(f"No pre-opened SQLite connection found for sample {sample_id}")
+        return conn
+
+    def reverse_complement(self, seq: str) -> str:
+        """Compute reverse complement of a sequence."""
+        cmap = {"A": "T", "C": "G", "G": "C", "T": "A", "N": "N"}
+        return "".join(cmap.get(b, b) for b in reversed(seq))
+
+    def __getitem__(self, idx: np.int64) -> Dict[str, torch.Tensor]:
+        """Get a single item from the dataset."""
+        if idx >= self.length:
+            raise IndexError(f"Index {idx} out of range for dataset with length {self.length}")
+
+        # The dataloader index `idx` is now the `window_idx` in this split-specific DB.
+        # Step 1: Get the sequence_id and other info from the window DB.
+        window_cursor = self.window_db_conn.cursor()
+        res = window_cursor.execute(
+            "SELECT sequence_id, window_in_seq_idx FROM window_mappings WHERE window_idx = ?",
+            (int(idx),),
+        ).fetchone()
+
+        if res is None:
+            # run PRAGMA database_list; to check exactly which DBs are open
+            # and which ones are not
+            current_dbs = self.window_db_conn.execute("PRAGMA database_list;").fetchall()
+
+            raise IndexError(
+                f"Window index {idx} which is a {type(idx)} was not found in the database {current_dbs}, which is unexpected."
+            )
+
+        sequence_id, window_in_seq_idx = res
+
+        # Log window access if enabled
+        if self.log_windows:
+            # Ensure logger is initialised in the current process (e.g., after DataLoader forks)
+            if not hasattr(self, "_log_writer"):
+                self._init_window_logger(self._log_dir)
+
+            # Derive sample_id for logging independent of DB connection logic
+            try:
+                sample_id_for_log = extract_sample_id(sequence_id)
+            except Exception:
+                sample_id_for_log = "unknown"
+
+            # Synchronously write CSV row (no flush here; only on cleanup)
+            row = [
+                int(idx),
+                sequence_id,
+                sample_id_for_log,
+                int(window_in_seq_idx),
+                int(self._rank),
+                int(time.time_ns()),
+            ]
+            self._log_writer.writerow(row)
+            self._log_file.flush()
+
+        # if there is only one DB connection, use it directly
+        if len(self.db_connections) == 1:
+            conn = next(iter(self.db_connections.values()))
+            cursor = conn.cursor()
+            sample_id = None
+        else:
+            # otherwise, we need to get the sample_id from the sequence_id
+            # and get the DB connection for that sample
+            sample_id = extract_sample_id(sequence_id)
+            conn = self._get_db_connection(sample_id)
+            cursor = conn.cursor()
+
+        # Calculate window position within sequence (0-based for Python, +1 for SQLite SUBSTR)
+        start_pos = window_in_seq_idx * self.stride
+
+        # Build token window
+        ctrl_ids = self.ctrl_ids_map.get(sequence_id, []) if self.use_control_tags else []
+        bos_id = self.tokenizer.bos_id
+        eos_id = self.tokenizer.eos_id
+        sep_id = self.tokenizer._sep_id
+        pad_id = self.tokenizer.pad_id
+
+        header = [bos_id] + ctrl_ids + [sep_id]
+        footer = [eos_id]
+        special_tokens_count = len(header) + len(footer)
+        eff_len = self.seq_length - special_tokens_count
+
+        # ------------------------------------------------------------------
+        # Retrieve the subsequence directly in SQL to avoid loading the
+        # full contig into Python memory.
+        # SQLite SUBSTR is 1-indexed, so we add 1 to start_pos.
+        # ------------------------------------------------------------------
+        subseq_query = (
+            f"SELECT substr({SEQUENCE_COLUMN_NAME}, ?, ?) FROM sequences WHERE {SEQUENCE_ID_COLUMN_NAME} = ?"
+        )
+        result = cursor.execute(
+            subseq_query,
+            (start_pos + 1, eff_len, sequence_id),
+        ).fetchone()
+
+        if result is None or result[0] is None:
+            raise ValueError(f"Sequence ID {sequence_id} not found in database for sample {sample_id}")
+
+        seq = result[0].upper()
+
+        # Apply reverse complement augmentation if enabled
+        if self.rc_aug and np.random.rand() > 0.5:
+            seq = self.reverse_complement(seq)
+
+        # Tokenize
+        token_ids = header + self.tokenizer.text_to_ids(seq) + footer
+
+        # Pad/trim
+        if len(token_ids) < self.seq_length:
+            token_ids += [pad_id] * (self.seq_length - len(token_ids))
+        else:
+            token_ids = token_ids[: self.seq_length]
+
+        tokens = torch.tensor(token_ids, dtype=torch.int64)
+
+        # Flatten ctrl_ids and create special_ids list
+        flat_ctrl_ids = []
+        if isinstance(ctrl_ids, list):
+            for item in ctrl_ids:
+                if isinstance(item, list):
+                    flat_ctrl_ids.extend(item)
+                else:
+                    flat_ctrl_ids.append(item)
+
+        special_ids_list = [bos_id, eos_id, sep_id, pad_id] + flat_ctrl_ids
+        special_ids = torch.tensor(special_ids_list, dtype=torch.int64)
+
+        # Create labels for next token prediction
+        labels = tokens.clone()
+        labels[:-1] = tokens[1:]
+        labels[-1] = pad_id
+
+        # Create loss mask
+        loss_mask = torch.ones(self.seq_length, dtype=torch.float)
+        loss_mask[torch.isin(labels, special_ids)] = 0
+
+        batch = {
+            "tokens": tokens,
+            "labels": labels,
+            "loss_mask": loss_mask,
+            "position_ids": self.position_ids,
+        }
+        if self.create_attention_mask:
+            batch["attention_mask"] = self.attention_mask
+
+        return batch
+
+    def collate_fn(self, batch):
+        """Collate a batch of items into a single dictionary."""
+        return default_collate(batch)
+
+    def __del__(self):
+        """Close all database connections when the dataset is destroyed."""
+        # Close window mapping DB
+        if hasattr(self, "window_db_conn") and self.window_db_conn:
+            self.window_db_conn.close()
+
+        # Close all sequence shard DBs
+        if hasattr(self, "db_connections"):
+            for conn in self.db_connections.values():
+                conn.close()
+
+        if hasattr(self, "_log_file") and self._log_file:
+            try:
+                self._log_file.flush()
+            except Exception:
+                pass
+            try:
+                self._log_file.close()
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    # Logging helper methods
+    # ------------------------------------------------------------------
+
+    def _init_window_logger(self, log_dir: Optional[str] = None):
+        """Initialise CSV file for window access logging."""
+        import uuid
+
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        self._rank = rank
+        log_uuid = str(uuid.uuid4())
+        base_dir = Path(log_dir) if log_dir else Path(os.getcwd())
+        base_dir = base_dir.resolve()
+        base_dir.mkdir(parents=True, exist_ok=True)
+        split_tag = getattr(self, "split", "unknown")
+        csv_path = (base_dir / f"window_access_{split_tag}_rank{rank}_{log_uuid[:8]}.csv").resolve()
+        # raise an error if the file already exists
+        if csv_path.exists():
+            raise FileExistsError(
+                f"File {csv_path} already exists, this should only happen on a uuid conflict and should be extremely rare"
+            )
+        self._log_file_path = str(csv_path)
+
+        # Open CSV file in append mode and write header
+        self._log_file = open(self._log_file_path, mode="a", newline="")
+        self._log_writer = csv.writer(self._log_file)
+        self._log_writer.writerow(
+            [
+                "window_idx",
+                "sequence_id",
+                "sample_id",
+                "window_in_seq_idx",
+                "rank",
+                "access_ts",
+            ]
+        )
+
+        print(f"Window access logger initialised at {self._log_file_path}")
+
+
+def compute_num_windows(seq_len: int, window_size: int = 8192, stride: int = 7992) -> int:
+    """Helper method to compute number of windows for a sequence."""
+    if seq_len < window_size:
+        return 1
+    else:
+        return 1 + (seq_len - window_size) // stride
+
+
+def precompute_window_database(
+    split_parquet_file: str,
+    output_window_db: str,
+    window_size: int = 8192,
+    stride: int = 7992,
+    window_min_length_threshold: int = 0,
+):
+    """Pre-compute window mappings for a split using a Parquet file. The Parquet file must contain ID and length columns as configured by `SEQUENCE_ID_COLUMN_NAME` and `SEQUENCE_LENGTH_COLUMN_NAME`.
+
+    The output database will contain two tables:
+    1. `metadata`: Stores the window_size and stride used for creation.
+    2. `window_mappings`: A mapping of window_idx to sequence_id and the
+       relative index of that window within the sequence.
+
+    Args:
+        split_parquet_file: Path to a Parquet file with ID and length columns.
+        output_window_db: Path to output window mapping database
+        window_size: Window size (default: 8192)
+        stride: Stride between windows (default: 7992)
+        window_min_length_threshold: Minimum length of windows to include (default: 0)
+    """
+    print(f"Creating window database at {output_window_db} from {split_parquet_file}")
+    print(
+        f"Using window_size={window_size}, stride={stride}, window_min_length_threshold={window_min_length_threshold}"
+    )
+
+    # Load sequence data from Parquet file
+    try:
+        df = pol.read_parquet(split_parquet_file)
+    except Exception as e:
+        raise IOError(f"Failed to read Parquet file at {split_parquet_file}") from e
+
+    # Validate columns
+    if SEQUENCE_ID_COLUMN_NAME not in df.columns or SEQUENCE_LENGTH_COLUMN_NAME not in df.columns:
+        raise ValueError(
+            f"Parquet file {split_parquet_file} must contain '"
+            f"{SEQUENCE_ID_COLUMN_NAME}' and '{SEQUENCE_LENGTH_COLUMN_NAME}' columns."
+        )
+
+    # Sort by ID to ensure deterministic window ordering
+    df = df.sort(SEQUENCE_ID_COLUMN_NAME)
+
+    conn = sqlite3.connect(output_window_db)
+    cursor = conn.cursor()
+
+    # ------------------------------------------------------------------
+    # High-performance SQLite settings for bulk insert (100M+ rows)
+    # ------------------------------------------------------------------
+    cursor.execute("PRAGMA journal_mode=OFF;")  # disable rollback journal
+    cursor.execute("PRAGMA synchronous=OFF;")  # no fsync
+    cursor.execute("PRAGMA locking_mode=EXCLUSIVE;")  # single-writer, avoids lock churn
+    cursor.execute("PRAGMA temp_store=MEMORY;")  # temp tables in RAM
+    cursor.execute("PRAGMA cache_size=-1048576;")  # ~1 GB cache (negative => KiB)
+    # page_size and mmap_size can only be set before DB creation; assume defaults suffice.
+
+    # Drop old tables if they exist
+    cursor.execute("DROP TABLE IF EXISTS window_mappings")
+    cursor.execute("DROP TABLE IF EXISTS metadata")
+
+    # Create metadata table
+    cursor.execute("""
+        CREATE TABLE metadata (
+            key TEXT PRIMARY KEY,
+            value INTEGER NOT NULL
+        )
+    """)
+    cursor.executemany(
+        "INSERT INTO metadata (key, value) VALUES (?, ?)",
+        [
+            ("window_size", window_size),
+            ("stride", stride),
+            (
+                "window_min_length_threshold",
+                int(window_min_length_threshold) if window_min_length_threshold else 0,
+            ),
+        ],
+    )
+
+    # Create window mappings table
+    cursor.execute("""
+        CREATE TABLE window_mappings (
+            window_idx INTEGER PRIMARY KEY,
+            sequence_id TEXT NOT NULL,
+            window_in_seq_idx INTEGER NOT NULL
+        )
+    """)
+    conn.commit()
+
+    total_sequences = 0
+    global_window_idx = 0
+    batch_size = 20000
+    batch = []
+    skipped_windows = 0
+
+    for seq_id, seq_len in df.select([SEQUENCE_ID_COLUMN_NAME, SEQUENCE_LENGTH_COLUMN_NAME]).iter_rows():
+        num_windows = compute_num_windows(seq_len, window_size, stride)
+
+        windows_added_for_seq = 0
+        for i in range(num_windows):
+            # Determine effective window length at this index
+            start_pos = i * stride if seq_len >= window_size else 0
+            remaining = max(0, seq_len - start_pos)
+            effective_window_len = min(window_size, remaining)
+
+            # Skip windows that are shorter than threshold (if enabled)
+            if window_min_length_threshold and effective_window_len < window_min_length_threshold:
+                skipped_windows += 1
+                continue
+
+            batch.append((global_window_idx, seq_id, i))
+            global_window_idx += 1
+            windows_added_for_seq += 1
+
+        # Only count sequences that contributed at least one retained window
+        if windows_added_for_seq > 0:
+            total_sequences += 1
+
+        if len(batch) >= batch_size:
+            cursor.executemany(
+                "INSERT INTO window_mappings (window_idx, sequence_id, window_in_seq_idx) VALUES (?, ?, ?)",
+                batch,
+            )
+            conn.commit()
+            batch = []
+            print(f"Processed {global_window_idx} windows... (skipped {skipped_windows})")
+
+    if batch:
+        cursor.executemany(
+            "INSERT INTO window_mappings (window_idx, sequence_id, window_in_seq_idx) VALUES (?, ?, ?)",
+            batch,
+        )
+        conn.commit()
+
+    print("Creating index on sequence_id for faster lookups...")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_sequence_id ON window_mappings(sequence_id)")
+
+    # Persist total number of windows in metadata for fast retrieval
+    cursor.execute(
+        "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
+        ("total_windows", int(global_window_idx)),
+    )
+    # Persist number of distinct sequences as well
+    cursor.execute(
+        "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
+        ("distinct_sequences", int(total_sequences)),
+    )
+
+    conn.commit()
+    conn.close()
+
+    print(f"Finished. Found {total_sequences} sequences and {global_window_idx} total windows.")
+    if window_min_length_threshold and skipped_windows > 0:
+        print(f"Skipped {skipped_windows} windows due to window_min_length_threshold={window_min_length_threshold}.")
+
+
+def main():
+    """CLI for sharded Eden dataloader utilities."""
+    parser = argparse.ArgumentParser(description="Utilities for sharded Eden dataloader: precompute window mappings.")
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Precompute subcommand
+    precompute_parser = subparsers.add_parser("precompute", help="Pre-compute window mappings from a Parquet file")
+    precompute_parser.add_argument(
+        "split_parquet_file",
+        type=str,
+        help="Path to a Parquet file with sequence_id and length columns.",
+    )
+    precompute_parser.add_argument("output_window_db", type=str, help="Path to output window mapping database")
+    precompute_parser.add_argument("--window-size", type=int, default=8192, help="Window size (default: 8192)")
+    precompute_parser.add_argument(
+        "--stride",
+        type=int,
+        default=7992,
+        help="Stride between windows (default: 7992)",
+    )
+    precompute_parser.add_argument(
+        "--window-min-length-threshold",
+        type=int,
+        default=0,
+        help=("If > 0, skip sequences shorter than this length when precomputing windows. Defaults to 0 (disabled)."),
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "precompute":
+        precompute_window_database(
+            args.split_parquet_file,
+            args.output_window_db,
+            args.window_size,
+            args.stride,
+            args.window_min_length_threshold,
+        )
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/sub-packages/bionemo-evo2/src/bionemo/evo2/data/sharded_eden_dataloader.py
+++ b/sub-packages/bionemo-evo2/src/bionemo/evo2/data/sharded_eden_dataloader.py
@@ -100,7 +100,7 @@ class ShardedEdenDataModule(pl.LightningDataModule):
         log_dir: Optional[str] = None,
         **kwargs,
     ):
-        """Initialize the ShardedEdenDataModule. See sub-packages/bionemo-evo2/src/bionemo/evo2/data/sharded_eden_dataloader.md for how to prepare the input data. """
+        """Initialize the ShardedEdenDataModule. See sub-packages/bionemo-evo2/src/bionemo/evo2/data/sharded_eden_dataloader.md for how to prepare the input data."""
         super().__init__()
         self.sequence_db_dir = sequence_db_dir
         self.train_window_db_path = train_window_db_path

--- a/sub-packages/bionemo-evo2/src/bionemo/evo2/models/__init__.py
+++ b/sub-packages/bionemo-evo2/src/bionemo/evo2/models/__init__.py
@@ -13,7 +13,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from bionemo.evo2.models.llama import (
+    LLAMA_MODEL_OPTIONS,
+    Eden11BConfig,
+    Eden18BConfig,
+    Eden21BConfig,
+    Eden24BConfig,
+    Eden27BConfig,
+    Eden28BConfig,
+    Eden35BConfig,
+    EdenConfig,
+)
 from bionemo.evo2.models.mamba import MAMBA_MODEL_OPTIONS, HybridMambaConfig8BEvo2Loss, MambaModel
 
 
-__all__ = ["MAMBA_MODEL_OPTIONS", "HybridMambaConfig8BEvo2Loss", "MambaModel"]
+__all__ = [
+    "LLAMA_MODEL_OPTIONS",
+    "MAMBA_MODEL_OPTIONS",
+    "Eden11BConfig",
+    "Eden18BConfig",
+    "Eden21BConfig",
+    "Eden24BConfig",
+    "Eden27BConfig",
+    "Eden28BConfig",
+    "Eden35BConfig",
+    "EdenConfig",
+    "HybridMambaConfig8BEvo2Loss",
+    "MambaModel",
+]

--- a/sub-packages/bionemo-evo2/src/bionemo/evo2/models/llama.py
+++ b/sub-packages/bionemo-evo2/src/bionemo/evo2/models/llama.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+from nemo.collections import llm
+
+
+@dataclass
+class EdenConfig(llm.Llama3Config8B):
+    """Eden-flavoured Llama-3.1 ~8B (keeps all Eden behaviors)."""
+
+    rotary_base: int = 500_000
+    seq_length: int = 8192
+    num_layers: int = 32
+    hidden_size: int = 4096
+    ffn_hidden_size: int = 14336
+    num_attention_heads: int = 32
+
+    scale_factor: int = 1
+    low_freq_factor: int = 1
+    high_freq_factor: int = 4
+    old_context_len: int = 8192
+    init_method_std: float = 0.02
+    embedding_init_method_std: Optional[float] = None
+
+    def configure_model(self, *args, **kwargs):
+        """Configure and instantiate a Megatron Core Llama 3.1 model.
+
+        Extends the base configuration with Llama 3.1 specific RoPE scaling.
+        """
+        model = super(EdenConfig, self).configure_model(*args, **kwargs)
+        # Apply rope scaling for Llama3.1 model
+        model.rotary_pos_emb.inv_freq = apply_rope_scaling(
+            model.rotary_pos_emb.inv_freq,
+            factor=self.scale_factor,
+            low_freq_factor=self.low_freq_factor,
+            high_freq_factor=self.high_freq_factor,
+            old_context_len=self.old_context_len,
+        )
+        return model
+
+
+def apply_rope_scaling(
+    inv_freq,
+    factor: int = 8,
+    low_freq_factor: int = 1,
+    high_freq_factor: int = 4,
+    old_context_len: int = 8192,
+):
+    """Apply RoPE scaling for extending context length in Llama models.
+
+    This implements the NTK-aware RoPE scaling method used in Llama 3.1 models to
+    extend context length beyond the original training length.
+
+    Args:
+        inv_freq: Original inverse frequency tensor
+        factor: Scaling factor for context length extension
+        low_freq_factor: Factor for low frequency components
+        high_freq_factor: Factor for high frequency components
+        old_context_len: Original context length
+
+    Returns:
+        torch.Tensor: Modified inverse frequency tensor for extended context
+    """
+    logging.info(
+        f"Apply rope scaling with factor={factor}, low_freq_factor={low_freq_factor}, high_freq_factor={high_freq_factor}, old_context_len={old_context_len}."
+    )
+
+    low_freq_wavelen = old_context_len / low_freq_factor
+    high_freq_wavelen = old_context_len / high_freq_factor
+
+    wavelen = 2 * math.pi / inv_freq
+    # wavelen < high_freq_wavelen: do nothing
+    # wavelen > low_freq_wavelen: divide by factor
+    inv_freq_llama = torch.where(wavelen > low_freq_wavelen, inv_freq / factor, inv_freq)
+    # otherwise: interpolate between the two, using a smooth factor
+    smooth_factor = (old_context_len / wavelen - low_freq_factor) / (high_freq_factor - low_freq_factor)
+    smoothed_inv_freq = (1 - smooth_factor) * inv_freq_llama / factor + smooth_factor * inv_freq_llama
+    is_medium_freq = ~(wavelen < high_freq_wavelen) * ~(wavelen > low_freq_wavelen)
+    inv_freq_llama = torch.where(is_medium_freq, smoothed_inv_freq, inv_freq_llama)
+
+    return inv_freq_llama
+
+
+@dataclass
+class Eden11BConfig(EdenConfig):
+    """Eden-flavoured Llama-3.1 ~14B (keeps all Eden behaviors)."""
+
+    # If you want long context like Eden-long, bump this; else inherit 8192.
+    seq_length: int = 8192  # or remove this line to keep 8192
+
+    # ~14B sizing (head_dim ≈ 128)
+    num_layers: int = 36
+    hidden_size: int = 5120
+    ffn_hidden_size: int = 13824
+    num_attention_heads: int = 40
+    num_query_groups: int = 8  # GQA (inherited value is also fine if already 8)
+
+
+@dataclass
+class Eden18BConfig(EdenConfig):
+    """Eden-flavoured Llama-3.1 ~18B (keeps all Eden behaviors)."""
+
+    # If you want long context like Eden-long, bump this; else inherit 8192.
+    seq_length: int = 8192  # or remove this line to keep 8192
+
+    # ~18B sizing (head_dim ≈ 128)
+    num_layers: int = 48
+    hidden_size: int = 6144
+    ffn_hidden_size: int = 16384
+    num_attention_heads: int = 48
+    num_query_groups: int = 8  # GQA (inherited value is also fine if already 8)
+    old_context_len: int = 8192  # or remove this line to keep 8192
+
+
+@dataclass
+class Eden21BConfig(EdenConfig):
+    """Eden-flavoured Llama-3.1 ~21B (keeps all Eden behaviors)."""
+
+    seq_length: int = 8192
+
+    # ~21B sizing (head_dim = 128)
+    num_layers: int = 42  # 42 layers for 21B target
+    hidden_size: int = 7168  # 56 * 128 = 7168 for exact head_dim
+    ffn_hidden_size: int = 19456  # ~2.7x hidden_size
+    num_attention_heads: int = 56  # Divisible by 8
+    num_query_groups: int = 8  # GQA
+    old_context_len: int = 8192
+
+
+@dataclass
+class Eden24BConfig(EdenConfig):
+    """Eden-flavoured Llama-3.1 ~8B (keeps all Eden behaviors)."""
+
+    # If you want long context like Eden-long, bump this; else inherit 8192.
+    seq_length: int = 32768  # or remove this line to keep 8192
+
+    # ~8B sizing (head_dim ≈ 128)
+    num_layers: int = 46
+    hidden_size: int = 6144
+    ffn_hidden_size: int = 23296
+    num_attention_heads: int = 48
+    num_query_groups: int = 8  # GQA (inherited value is also fine if already 8)
+    old_context_len: int = 8192
+
+
+@dataclass
+class Eden27BConfig(EdenConfig):
+    """Eden-flavoured Llama-3.1 ~8B (keeps all Eden behaviors)."""
+
+    # If you want long context like Eden-long, bump this; else inherit 8192.
+    seq_length: int = 32768  # or remove this line to keep 8192
+
+    # ~8B sizing (head_dim ≈ 128)
+    num_layers: int = 46
+    hidden_size: int = 6656
+    ffn_hidden_size: int = 23296
+    num_attention_heads: int = 52
+    num_query_groups: int = 8  # GQA (inherited value is also fine if already 8)
+    old_context_len: int = 8192
+
+
+@dataclass
+class Eden28BConfig(EdenConfig):
+    """Eden-flavoured Llama-3.1 ~28B (keeps all Eden behaviors)."""
+
+    # If you want long context like Eden-long, bump this; else inherit 8192.
+    seq_length: int = 8192  # or remove this line to keep 8192
+
+    # ~8B sizing (head_dim ≈ 128)
+    num_layers: int = 48
+    hidden_size: int = 6144
+    ffn_hidden_size: int = 26368
+    num_attention_heads: int = 48
+    num_query_groups: int = 8  # GQA (inherited value is also fine if already 8)
+    old_context_len: int = 8192  # or remove this line to keep 8192
+
+
+@dataclass
+class Eden35BConfig(EdenConfig):
+    """Eden-flavoured Llama-3.1 ~35B (keeps all Eden behaviors)."""
+
+    seq_length: int = 8192
+
+    # ~35B sizing (head_dim ≈ 128)
+    num_layers: int = 64
+    hidden_size: int = 7168
+    ffn_hidden_size: int = 20480
+    num_attention_heads: int = 56
+    num_query_groups: int = 8  # GQA
+    old_context_len: int = 8192
+
+
+LLAMA_MODEL_OPTIONS = {
+    "8B": lambda **kwargs: llm.Llama3Config8B(**kwargs),
+    "7B": lambda **kwargs: EdenConfig(**kwargs),
+    "11B": lambda **kwargs: Eden11BConfig(**kwargs),
+    "18B": lambda **kwargs: Eden18BConfig(**kwargs),
+    "21B": lambda **kwargs: Eden21BConfig(**kwargs),
+    "24B": lambda **kwargs: Eden24BConfig(**kwargs),
+    "27B": lambda **kwargs: Eden27BConfig(**kwargs),
+    "28B": lambda **kwargs: Eden28BConfig(**kwargs),
+    "35B": lambda **kwargs: Eden35BConfig(**kwargs),
+}

--- a/sub-packages/bionemo-evo2/src/bionemo/evo2/run/train.py
+++ b/sub-packages/bionemo-evo2/src/bionemo/evo2/run/train.py
@@ -1070,7 +1070,9 @@ def train(args: argparse.Namespace) -> nl.Trainer:
         constant_steps=args.constant_steps,
     )
     # This is where the no weight decay condition is applied to the optimizer state.
-    opt = MegatronOptimizerModule(opt_config, sched, no_weight_decay_cond=getattr(model_config, 'hyena_no_weight_decay_cond_fn', None))
+    opt = MegatronOptimizerModule(
+        opt_config, sched, no_weight_decay_cond=getattr(model_config, "hyena_no_weight_decay_cond_fn", None)
+    )
     opt.connect(model)
     # Start training
     trainer.fit(model, data_module)

--- a/sub-packages/bionemo-evo2/src/bionemo/evo2/run/train.py
+++ b/sub-packages/bionemo-evo2/src/bionemo/evo2/run/train.py
@@ -46,6 +46,8 @@ from nemo.lightning.pytorch.optim.megatron import MegatronOptimizerModule
 from nemo.lightning.pytorch.strategies.utils import RestoreConfig
 from nemo.utils.exp_manager import TimingCallback
 
+from bionemo.evo2.data.sharded_eden_dataloader import ShardedEdenDataModule
+from bionemo.evo2.models.llama import LLAMA_MODEL_OPTIONS
 from bionemo.evo2.models.mamba import MAMBA_MODEL_OPTIONS, MambaModel, mamba_no_weight_decay_cond_with_embeddings
 from bionemo.evo2.run.peft import Evo2LoRA
 from bionemo.evo2.utils.callbacks import GarbageCollectAtInferenceTime
@@ -61,7 +63,15 @@ torch._dynamo.config.suppress_errors = True
 def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
     """Parse arguments for Evo2 model training."""
     parser = argparse.ArgumentParser(
-        description="Train a Hyena model using NeMo 2.0.",
+        description=(
+            "Train an Evo2/Hyena-family model using NeMo 2.0.\n\n"
+            "Choose exactly one data source:\n"
+            "  - --dataset-config: blended/weighted dataset YAML.\n"
+            "  - --mock-data: synthetic mock data for testing/debugging.\n"
+            "  - --fasta-data: single FASTA file input (requires --fasta-file).\n"
+            "  - --sharded-eden-data: pre-sharded SQLite sequence DBs + precomputed windows per split\n"
+            "      (requires --sequence-db-dir, --train-window-db, --val-window-db, --test-window-db)."
+        ),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     data_group = parser.add_mutually_exclusive_group(required=True)
@@ -70,18 +80,124 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
         "-d",
         "--dataset-config",
         type=str,
-        help="Path to the blended / weighted training dataset configuration YAML.",
+        help="Path to the blended / weighted training dataset configuration YAML. Mutually exclusive with "
+        "--mock-data, --fasta-data and --sharded-eden-data.",
     )
     data_group.add_argument(
         "--mock-data",
         action="store_true",
-        help="Train with Mock data (for testing/debugging), either set this or provide a dataset config.",
+        help="Use synthetic mock data for quick testing/debugging. Mutually exclusive with --dataset-config, --fasta-data and --sharded-eden-data.",
     )
 
+    data_group.add_argument(
+        "--fasta-data",
+        action="store_true",
+        help=(
+            "Train on a single FASTA file (EdenDataModule). Requires --fasta-file. Mutually exclusive with "
+            "--dataset-config, --mock-data and --sharded-eden-data."
+        ),
+    )
+
+    data_group.add_argument(
+        "--sharded-eden-data",
+        action="store_true",
+        help=(
+            "Train on pre-sharded SQLite sequence databases with precomputed windows per split "
+            "(ShardedEdenDataModule). Requires: --sequence-db-dir, --train-window-db, --val-window-db, --test-window-db. "
+            "Mutually exclusive with --dataset-config, --mock-data and --fasta-data."
+        ),
+    )
+
+    # Dataset configuration (unified)
+    parser.add_argument(
+        "--fasta-file",
+        type=str,
+        help=(
+            "Absolute path to FASTA file containing training data. Required when using --fasta-data; "
+            "ignored otherwise."
+        ),
+    )
+    parser.add_argument(
+        "--sequence-db-dir",
+        type=str,
+        help=(
+            "Directory containing per-sample SQLite databases with sequences. Required with --sharded-eden-data; "
+            "ignored otherwise."
+        ),
+    )
+    parser.add_argument(
+        "--train-window-db",
+        type=str,
+        help=(
+            "Path to the precomputed training split windows SQLite database. Required with --sharded-eden-data; "
+            "ignored otherwise."
+        ),
+    )
+    parser.add_argument(
+        "--val-window-db",
+        type=str,
+        help=(
+            "Path to the precomputed validation split windows SQLite database. Required with --sharded-eden-data; "
+            "ignored otherwise."
+        ),
+    )
+    parser.add_argument(
+        "--test-window-db",
+        type=str,
+        help=(
+            "Path to the precomputed test split windows SQLite database. Required with --sharded-eden-data; "
+            "ignored otherwise."
+        ),
+    )
+    parser.add_argument(
+        "--dataset-num-epochs",
+        type=int,
+        default=1,
+        help=(
+            "When using --sharded-eden-data, wrap each split with a MultiEpochDatasetResampler over this many epochs. "
+            "Default 1 means each split length equals its base dataset length."
+        ),
+    )
+    parser.add_argument(
+        "--stride",
+        type=int,
+        default=7992,
+        help=(
+            "Stride between adjacent windows used by ShardedEdenDataModule. Must match the stride used when "
+            "precomputing the windows databases. Ignored for other data modes."
+        ),
+    )
+    parser.add_argument(
+        "--window-min-length-threshold",
+        type=int,
+        default=0,
+        help=(
+            "If > 0, prune windows shorter than this effective length during precomputation and require matching "
+            "value in the window DB metadata. Defaults to 0 (disabled)."
+        ),
+    )
+    parser.add_argument(
+        "--log-windows",
+        action="store_true",
+        default=False,
+        help=("Enable window access logging for ShardedEdenDataset (applies only to --sharded-eden-data)."),
+    )
+    parser.add_argument(
+        "--window-log-dir",
+        type=str,
+        default=None,
+        help=("Directory for window-access logging SQLite files (applies only to --sharded-eden-data)."),
+    )
+    parser.add_argument(
+        "--rc-aug",
+        action="store_true",
+        default=False,
+        help=("Enable reverse-complement augmentation (applies only to --sharded-eden-data)."),
+    )
     parser.add_argument(
         "--dataset-dir",
         type=str,
-        help="Absolute path to the dataset directory. Defaults to using the absolute or relative paths (dataset_prefix) specified in the dataset config YAML.",
+        help="Absolute path to the dataset directory. Defaults to using the absolute or relative paths (dataset_prefix) specified in the dataset config YAML. Required with --dataset-config.",
     )
 
     parser.add_argument("--num-nodes", type=int, default=1, help="Number of nodes to use for training, defaults to 1.")
@@ -181,7 +297,9 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--model-size",
         type=str,
-        choices=sorted(list(HYENA_MODEL_OPTIONS.keys()) + list(MAMBA_MODEL_OPTIONS.keys())),
+        choices=sorted(
+            list(HYENA_MODEL_OPTIONS.keys()) + list(MAMBA_MODEL_OPTIONS.keys()) + list(LLAMA_MODEL_OPTIONS.keys())
+        ),
         default="7b",
         help="Model size/configuration to use. Options depend on the selected model-type.",
     )
@@ -526,6 +644,14 @@ def train(args: argparse.Namespace) -> nl.Trainer:
         "byte-level",
     )
 
+    bos_id, eos_id, sep_id, pad_id = 1, 2, 3, 0
+
+    # Patch the private attrs so tokenizer.bos_id/.eos_id/.pad_id work
+    tokenizer._bos_id = bos_id
+    tokenizer._eos_id = eos_id
+    tokenizer._sep_id = sep_id
+    tokenizer._pad_id = pad_id
+
     # Infer global batch size.
     global_batch_size = args.global_batch_size
     if global_batch_size is None:
@@ -546,7 +672,44 @@ def train(args: argparse.Namespace) -> nl.Trainer:
             num_workers=args.workers,
             tokenizer=tokenizer,
         )
+    elif args.fasta_data:
+        raise NotImplementedError("Fasta data is not supported yet. Need to add EdenDataModule")
+        # data_module = EdenDataModule(
+        #     fasta_file=args.fasta_file,
+        #     seq_length=args.seq_length,
+        #     micro_batch_size=args.micro_batch_size,
+        #     global_batch_size=global_batch_size,
+        #     num_workers=args.workers,
+        #     tokenizer=tokenizer,
+        #     seed=args.seed,
+        # )
+    elif args.sharded_eden_data:
+        # Validate required arguments for sharded data
+        if not args.sequence_db_dir or not args.train_window_db or not args.val_window_db or not args.test_window_db:
+            raise ValueError(
+                "--sequence-db-dir, --train-window-db, --val-window-db, and --test-window-db are required when using --sharded-eden-data."
+            )
+        data_module = ShardedEdenDataModule(
+            sequence_db_dir=args.sequence_db_dir,
+            train_window_db_path=args.train_window_db,
+            val_window_db_path=args.val_window_db,
+            test_window_db_path=args.test_window_db,
+            seq_length=args.seq_length,
+            tokenizer=tokenizer,
+            micro_batch_size=args.micro_batch_size,
+            global_batch_size=global_batch_size,
+            num_workers=args.workers,
+            rc_aug=args.rc_aug,
+            stride=args.stride,
+            window_min_length_threshold=args.window_min_length_threshold,
+            seed=args.seed,
+            num_epochs=args.dataset_num_epochs,
+            log_windows=args.log_windows,
+            log_dir=args.window_log_dir,
+        )
     else:
+        if not args.dataset_dir:
+            raise ValueError("--dataset-dir is required when using --dataset-config.")
         blended_dataset_config = parse_dataset_config(
             dataset_config_path=args.dataset_config, dataset_path=args.dataset_dir
         )
@@ -614,6 +777,8 @@ def train(args: argparse.Namespace) -> nl.Trainer:
         model_type = "hyena"
     elif args.model_size in MAMBA_MODEL_OPTIONS:
         model_type = "mamba"
+    elif args.model_size in LLAMA_MODEL_OPTIONS:
+        model_type = "llama"
     else:
         raise ValueError(f"Invalid model size: {args.model_size}")
 
@@ -632,7 +797,7 @@ def train(args: argparse.Namespace) -> nl.Trainer:
             lora_transform = Evo2LoRA(peft_ckpt_path=args.lora_checkpoint_path)
 
         model = llm.HyenaModel(model_config, tokenizer=data_module.tokenizer, model_transform=lora_transform)
-    else:  # mamba
+    elif model_type == "mamba":  # mamba
         if args.no_weight_decay_embeddings:
             config_modifiers_init["hyena_no_weight_decay_cond_fn"] = mamba_no_weight_decay_cond_with_embeddings
         config_modifiers_init["lowercase_loss_reweighting"] = args.mamba_lowercase_loss_weight
@@ -643,6 +808,9 @@ def train(args: argparse.Namespace) -> nl.Trainer:
             raise ValueError("Bias output is not supported for Mamba models.")
         model_config = MAMBA_MODEL_OPTIONS[args.model_size](**config_modifiers_init)
         model = MambaModel(model_config, tokenizer=data_module.tokenizer)
+    elif model_type == "llama":
+        model_config = LLAMA_MODEL_OPTIONS[args.model_size](**config_modifiers_init)
+        model = llm.LlamaModel(model_config, tokenizer=data_module.tokenizer)
 
     # Setup callbacks.
     callbacks = [
@@ -750,6 +918,8 @@ def train(args: argparse.Namespace) -> nl.Trainer:
     if model_type == "mamba":
         # Include this setting for mamba models.
         wandb_run_name += f"-LLW{args.mamba_lowercase_loss_weight}"
+    elif model_type == "llama":
+        wandb_run_name += f"-LLAMA{args.model_size}"
 
     wandb_config: Optional[WandbConfig] = (
         None
@@ -773,6 +943,18 @@ def train(args: argparse.Namespace) -> nl.Trainer:
         initialize_tensorboard_logger=args.create_tensorboard_logger,
         wandb_config=wandb_config,
     )
+
+    # Ensure window logging directory lives under the run directory
+    if args.sharded_eden_data and args.log_windows:
+        window_log_leaf = Path(args.window_log_dir).name if args.window_log_dir else "window_logs"
+        window_log_dir = Path(nemo_logger.save_dir) / window_log_leaf
+        try:
+            window_log_dir.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            pass
+        # Propagate to data module (datasets are built later during setup)
+        if isinstance(data_module, ShardedEdenDataModule):
+            data_module.log_dir = str(window_log_dir)
 
     if args.create_checkpoint_callback:
         checkpoint_path = str(Path(nemo_logger.save_dir) / "checkpoints")

--- a/sub-packages/bionemo-evo2/tests/bionemo/evo2/data/test_sharded_eden_dataset.py
+++ b/sub-packages/bionemo-evo2/tests/bionemo/evo2/data/test_sharded_eden_dataset.py
@@ -430,7 +430,7 @@ def test_dataset_reverse_complement(sequence_db_dir, window_dbs):
     # Test with N bases
     test_seq_with_n = "ATCN"
     rc_seq_with_n = dataset.reverse_complement(test_seq_with_n)
-    assert rc_seq_with_n == "NCGAT"
+    assert rc_seq_with_n == "NGAT"
 
     # Clean up
     dataset.__del__()
@@ -480,54 +480,6 @@ def test_dataset_collate_fn(sequence_db_dir, window_dbs):
     dataset.__del__()
 
 
-def test_invalid_sequence_db_dir(window_dbs):
-    """Test error handling for invalid sequence database directory."""
-    # Mock tokenizer
-    mock_tokenizer = Mock()
-    mock_tokenizer.bos_id = 1
-    mock_tokenizer.eos_id = 2
-    mock_tokenizer._sep_id = 3
-    mock_tokenizer.pad_id = 0
-    mock_tokenizer.text_to_ids.return_value = [10, 11, 12]
-
-    # Test with non-existent directory
-    with pytest.raises(ValueError, match="No SQLite files found"):
-        ShardedEdenDataset(
-            tokenizer=mock_tokenizer,
-            sequence_db_dir="/non/existent/path",
-            window_db_path=window_dbs["train"],
-            seq_length=8192,
-            create_attention_mask=False,
-            stride=7992,
-            rc_aug=False,
-            use_control_tags=False,
-            split="train",
-        )
-
-
-def test_invalid_window_db_path(sequence_db_dir):
-    """Test error handling for invalid window database path."""
-    # Mock tokenizer
-    mock_tokenizer = Mock()
-    mock_tokenizer.bos_id = 1
-    mock_tokenizer.eos_id = 2
-    mock_tokenizer._sep_id = 3
-    mock_tokenizer.pad_id = 0
-    mock_tokenizer.text_to_ids.return_value = [10, 11, 12]
-
-    # Test with non-existent window database
-    with pytest.raises(ValueError):
-        ShardedEdenDataset(
-            tokenizer=mock_tokenizer,
-            sequence_db_dir=sequence_db_dir,
-            window_db_path="/non/existent/windows.db",
-            seq_length=8192,
-            create_attention_mask=False,
-            stride=7992,
-            rc_aug=False,
-            use_control_tags=False,
-            split="train",
-        )
 
 
 def test_window_min_length_threshold(temp_dir, train_parquet):
@@ -594,33 +546,3 @@ def test_dataset_length_and_iteration(sequence_db_dir, window_dbs):
     # Clean up
     dataset.__del__()
 
-
-def test_dataset_with_different_seq_lengths(sequence_db_dir, window_dbs):
-    """Test dataset with different sequence lengths."""
-    # Mock tokenizer
-    mock_tokenizer = Mock()
-    mock_tokenizer.bos_id = 1
-    mock_tokenizer.eos_id = 2
-    mock_tokenizer._sep_id = 3
-    mock_tokenizer.pad_id = 0
-    mock_tokenizer.text_to_ids.return_value = [10, 11, 12]
-
-    # Test with different sequence lengths
-    for seq_length in [4096, 8192, 16384]:
-        dataset = ShardedEdenDataset(
-            tokenizer=mock_tokenizer,
-            sequence_db_dir=sequence_db_dir,
-            window_db_path=window_dbs["train"],
-            seq_length=seq_length,
-            create_attention_mask=False,
-            stride=seq_length - 200,  # Adjust stride
-            rc_aug=False,
-            use_control_tags=False,
-            split="train",
-        )
-
-        # Verify sequence length
-        assert dataset.seq_length == seq_length
-
-        # Clean up
-        dataset.__del__()

--- a/sub-packages/bionemo-evo2/tests/bionemo/evo2/data/test_sharded_eden_dataset.py
+++ b/sub-packages/bionemo-evo2/tests/bionemo/evo2/data/test_sharded_eden_dataset.py
@@ -480,8 +480,6 @@ def test_dataset_collate_fn(sequence_db_dir, window_dbs):
     dataset.__del__()
 
 
-
-
 def test_window_min_length_threshold(temp_dir, train_parquet):
     """Test window database creation with length threshold."""
     output_db = Path(temp_dir) / "threshold_windows.db"
@@ -545,4 +543,3 @@ def test_dataset_length_and_iteration(sequence_db_dir, window_dbs):
 
     # Clean up
     dataset.__del__()
-

--- a/sub-packages/bionemo-evo2/tests/bionemo/evo2/data/test_sharded_eden_dataset.py
+++ b/sub-packages/bionemo-evo2/tests/bionemo/evo2/data/test_sharded_eden_dataset.py
@@ -1,0 +1,626 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sqlite3
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import numpy as np
+import polars as pol
+import pytest
+import torch
+
+from bionemo.evo2.data.sharded_eden_dataloader import (
+    ShardedEdenDataModule,
+    ShardedEdenDataset,
+    extract_sample_id,
+    precompute_window_database,
+)
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for test data."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        yield tmp_dir
+
+
+@pytest.fixture
+def sample_sequences():
+    """Create dummy sample sequences for testing."""
+    return [
+        ("BCR__ECT-SAMPLE1__CT1-1", "ATCGATCGATCGATCG" * 1000),  # 16000 bases
+        ("BCR__ECT-SAMPLE1__CT1-2", "GCTAGCTAGCTAGCTA" * 800),  # 12800 bases
+        ("BCR__ECT-SAMPLE2__CT1-1", "TAGCTAGCTAGCTAGC" * 1200),  # 19200 bases
+        ("BCR__ECT-SAMPLE2__CT1-2", "CGATCGATCGATCGA" * 600),  # 9600 bases
+        ("BCR__ECT-SAMPLE3__CT1-1", "ATCGATCGATCGATCG" * 700),  # 11200 bases
+    ]
+
+
+@pytest.fixture
+def sequence_db_dir(temp_dir, sample_sequences):
+    """Create sample SQLite databases for testing."""
+    db_dir = Path(temp_dir) / "sequence_db_dir"
+    db_dir.mkdir(exist_ok=True)
+
+    # Group sequences by sample
+    sequences_by_sample = {}
+    for seq_id, sequence in sample_sequences:
+        sample_id = extract_sample_id(seq_id)
+        if sample_id not in sequences_by_sample:
+            sequences_by_sample[sample_id] = []
+        sequences_by_sample[sample_id].append((seq_id, sequence))
+
+    # Create database for each sample
+    for sample_id, sequences in sequences_by_sample.items():
+        sample_dir = db_dir / sample_id
+        sample_dir.mkdir(exist_ok=True)
+
+        db_path = sample_dir / f"glm_dataset_{sample_id}.sqlite"
+        conn = sqlite3.connect(str(db_path))
+        cursor = conn.cursor()
+
+        # Create table
+        cursor.execute("""
+            CREATE TABLE sequences (
+                contig_id TEXT PRIMARY KEY,
+                nt_sequence TEXT NOT NULL
+            )
+        """)
+
+        # Insert sequences
+        for seq_id, sequence in sequences:
+            cursor.execute("INSERT INTO sequences (contig_id, nt_sequence) VALUES (?, ?)", (seq_id, sequence))
+
+        conn.commit()
+        conn.close()
+
+    return str(db_dir)
+
+
+@pytest.fixture
+def train_parquet(temp_dir, sample_sequences):
+    """Create training split Parquet file."""
+    # Use first 3 sequences for training
+    train_data = pol.DataFrame(
+        {
+            "contig_id": [seq[0] for seq in sample_sequences[:3]],
+            "length": [len(seq[1]) for seq in sample_sequences[:3]],
+        }
+    )
+
+    parquet_path = Path(temp_dir) / "train_split.parquet"
+    train_data.write_parquet(str(parquet_path))
+    return str(parquet_path)
+
+
+@pytest.fixture
+def val_parquet(temp_dir, sample_sequences):
+    """Create validation split Parquet file."""
+    # Use last 2 sequences for validation
+    val_data = pol.DataFrame(
+        {
+            "contig_id": [seq[0] for seq in sample_sequences[3:]],
+            "length": [len(seq[1]) for seq in sample_sequences[3:]],
+        }
+    )
+
+    parquet_path = Path(temp_dir) / "val_split.parquet"
+    val_data.write_parquet(str(parquet_path))
+    return str(parquet_path)
+
+
+@pytest.fixture
+def test_parquet(temp_dir, sample_sequences):
+    """Create test split Parquet file."""
+    # Use middle sequence for testing
+    test_data = pol.DataFrame({"contig_id": [sample_sequences[2][0]], "length": [len(sample_sequences[2][1])]})
+
+    parquet_path = Path(temp_dir) / "test_split.parquet"
+    test_data.write_parquet(str(parquet_path))
+    return str(parquet_path)
+
+
+@pytest.fixture
+def window_dbs(temp_dir, train_parquet, val_parquet, test_parquet):
+    """Create window databases for all splits."""
+    train_db = Path(temp_dir) / "train_windows.db"
+    val_db = Path(temp_dir) / "val_windows.db"
+    test_db = Path(temp_dir) / "test_windows.db"
+
+    # Pre-compute window databases
+    precompute_window_database(train_parquet, str(train_db), window_size=8192, stride=7992)
+    precompute_window_database(val_parquet, str(val_db), window_size=8192, stride=7992)
+    precompute_window_database(test_parquet, str(test_db), window_size=8192, stride=7992)
+
+    return {"train": str(train_db), "val": str(val_db), "test": str(test_db)}
+
+
+def test_extract_sample_id():
+    """Test sample ID extraction from sequence IDs."""
+    assert extract_sample_id("BCR__ECT-SAMPLE1__CT1-1") == "SAMPLE1"
+    assert extract_sample_id("BCR__ECT-SAMPLE2__CT1-2") == "SAMPLE2"
+    assert extract_sample_id("BCR__ECT-SAMPLE3__CT1-1") == "SAMPLE3"
+
+
+def test_precompute_window_database(temp_dir, train_parquet):
+    """Test window database pre-computation."""
+    output_db = Path(temp_dir) / "test_windows.db"
+
+    precompute_window_database(train_parquet, str(output_db), window_size=8192, stride=7992)
+
+    # Verify database was created
+    assert output_db.exists()
+
+    # Check database contents
+    conn = sqlite3.connect(str(output_db))
+    cursor = conn.cursor()
+
+    # Check metadata
+    cursor.execute("SELECT key, value FROM metadata")
+    metadata = dict(cursor.fetchall())
+
+    assert metadata["window_size"] == 8192
+    assert metadata["stride"] == 7992
+    assert "total_windows" in metadata
+    assert "distinct_sequences" in metadata
+
+    # Check window mappings
+    cursor.execute("SELECT COUNT(*) FROM window_mappings")
+    window_count = cursor.fetchone()[0]
+    assert window_count > 0
+
+    conn.close()
+
+
+def test_sharded_eden_dataset_initialization(sequence_db_dir, window_dbs):
+    """Test ShardedEdenDataset initialization."""
+    # Mock tokenizer
+    mock_tokenizer = Mock()
+    mock_tokenizer.bos_id = 1
+    mock_tokenizer.eos_id = 2
+    mock_tokenizer._sep_id = 3
+    mock_tokenizer.pad_id = 0
+    mock_tokenizer.text_to_ids.return_value = [10, 11, 12]  # Dummy token IDs
+
+    # Create dataset
+    dataset = ShardedEdenDataset(
+        tokenizer=mock_tokenizer,
+        sequence_db_dir=sequence_db_dir,
+        window_db_path=window_dbs["train"],
+        seq_length=8192,
+        create_attention_mask=False,
+        stride=7992,
+        rc_aug=False,
+        use_control_tags=False,
+        split="train",
+    )
+
+    # Verify dataset properties
+    assert dataset.seq_length == 8192
+    assert dataset.stride == 7992
+    assert dataset.split == "train"
+    assert len(dataset) > 0  # Should have some windows
+
+    # Verify database connections
+    assert hasattr(dataset, "db_connections")
+    assert len(dataset.db_connections) > 0
+
+    # Verify window database connection
+    assert hasattr(dataset, "window_db_conn")
+    assert dataset.window_db_conn is not None
+
+    # Clean up
+    dataset.__del__()
+
+
+@patch("bionemo.evo2.data.sharded_eden_dataloader.get_nmt_tokenizer")
+def test_sharded_eden_datamodule_initialization(mock_get_tokenizer, sequence_db_dir, window_dbs):
+    """Test ShardedEdenDataModule initialization."""
+    # Mock tokenizer
+    mock_tokenizer = Mock()
+    mock_tokenizer.bos_id = 1
+    mock_tokenizer.eos_id = 2
+    mock_tokenizer._sep_id = 3
+    mock_tokenizer.pad_id = 0
+    mock_tokenizer.text_to_ids.return_value = [10, 11, 12]
+    mock_get_tokenizer.return_value = mock_tokenizer
+
+    # Create data module
+    data_module = ShardedEdenDataModule(
+        sequence_db_dir=sequence_db_dir,
+        train_window_db_path=window_dbs["train"],
+        val_window_db_path=window_dbs["val"],
+        test_window_db_path=window_dbs["test"],
+        seq_length=8192,
+        micro_batch_size=1,
+        global_batch_size=4,
+        num_workers=0,  # Use 0 for testing
+        rc_aug=False,
+        use_control_tags=False,
+    )
+
+    # Verify data module properties
+    assert data_module.sequence_db_dir == sequence_db_dir
+    assert data_module.train_window_db_path == window_dbs["train"]
+    assert data_module.val_window_db_path == window_dbs["val"]
+    assert data_module.test_window_db_path == window_dbs["test"]
+    assert data_module.seq_length == 8192
+    assert data_module.micro_batch_size == 1
+    assert data_module.global_batch_size == 4
+    assert data_module.num_workers == 0
+
+    # Verify tokenizer was created
+    assert data_module.tokenizer is not None
+
+    # Verify data sampler was created
+    assert data_module.data_sampler is not None
+    assert data_module.data_sampler.seq_len == 8192
+    assert data_module.data_sampler.micro_batch_size == 1
+    assert data_module.data_sampler.global_batch_size == 4
+
+
+def test_dataset_getitem(sequence_db_dir, window_dbs):
+    """Test dataset item retrieval."""
+    # Mock tokenizer
+    mock_tokenizer = Mock()
+    mock_tokenizer.bos_id = 1
+    mock_tokenizer.eos_id = 2
+    mock_tokenizer._sep_id = 3
+    mock_tokenizer.pad_id = 0
+    mock_tokenizer.text_to_ids.return_value = [10, 11, 12]
+
+    # Create dataset
+    dataset = ShardedEdenDataset(
+        tokenizer=mock_tokenizer,
+        sequence_db_dir=sequence_db_dir,
+        window_db_path=window_dbs["train"],
+        seq_length=8192,
+        create_attention_mask=False,
+        stride=7992,
+        rc_aug=False,
+        use_control_tags=False,
+        split="train",
+    )
+
+    # Get first item
+    item = dataset[np.int64(0)]
+
+    # Verify item structure
+    assert isinstance(item, dict)
+    assert "tokens" in item
+    assert "labels" in item
+    assert "loss_mask" in item
+    assert "position_ids" in item
+
+    # Verify tensor shapes
+    assert item["tokens"].shape == (8192,)
+    assert item["labels"].shape == (8192,)
+    assert item["loss_mask"].shape == (8192,)
+    assert item["position_ids"].shape == (8192,)
+
+    # Verify data types
+    assert item["tokens"].dtype == torch.int64
+    assert item["labels"].dtype == torch.int64
+    assert item["loss_mask"].dtype == torch.float32
+    assert item["position_ids"].dtype == torch.int64
+
+    # Clean up
+    dataset.__del__()
+
+
+def test_dataset_with_control_tags(sequence_db_dir, window_dbs):
+    """Test dataset with control tags enabled."""
+    # Mock tokenizer
+    mock_tokenizer = Mock()
+    mock_tokenizer.bos_id = 1
+    mock_tokenizer.eos_id = 2
+    mock_tokenizer._sep_id = 3
+    mock_tokenizer.pad_id = 0
+    mock_tokenizer.text_to_ids.return_value = [100, 101]  # Control tag IDs
+
+    # Create dataset with control tags
+    dataset = ShardedEdenDataset(
+        tokenizer=mock_tokenizer,
+        sequence_db_dir=sequence_db_dir,
+        window_db_path=window_dbs["train"],
+        seq_length=8192,
+        create_attention_mask=False,
+        stride=7992,
+        rc_aug=False,
+        use_control_tags=True,  # Enable control tags
+        split="train",
+    )
+
+    # Verify control tags were prepared
+    assert hasattr(dataset, "ctrl_ids_map")
+    assert len(dataset.ctrl_ids_map) > 0
+
+    # Get first item
+    item = dataset[np.int64(0)]
+
+    # Verify item contains control tags
+    assert "tokens" in item
+    assert "labels" in item
+    assert "loss_mask" in item
+
+    # Clean up
+    dataset.__del__()
+
+
+def test_dataset_with_attention_mask(sequence_db_dir, window_dbs):
+    """Test dataset with attention mask creation."""
+    # Mock tokenizer
+    mock_tokenizer = Mock()
+    mock_tokenizer.bos_id = 1
+    mock_tokenizer.eos_id = 2
+    mock_tokenizer._sep_id = 3
+    mock_tokenizer.pad_id = 0
+    mock_tokenizer.text_to_ids.return_value = [10, 11, 12]
+
+    # Create dataset with attention mask
+    dataset = ShardedEdenDataset(
+        tokenizer=mock_tokenizer,
+        sequence_db_dir=sequence_db_dir,
+        window_db_path=window_dbs["train"],
+        seq_length=8192,
+        create_attention_mask=True,  # Enable attention mask
+        stride=7992,
+        rc_aug=False,
+        use_control_tags=False,
+        split="train",
+    )
+
+    # Verify attention mask was created
+    assert hasattr(dataset, "attention_mask")
+    assert dataset.attention_mask.shape == (1, 8192, 8192)
+
+    # Get first item
+    item = dataset[np.int64(0)]
+
+    # Verify attention mask is included
+    assert "attention_mask" in item
+    assert item["attention_mask"].shape == (1, 8192, 8192)
+
+    # Clean up
+    dataset.__del__()
+
+
+def test_dataset_reverse_complement(sequence_db_dir, window_dbs):
+    """Test reverse complement functionality."""
+    # Mock tokenizer
+    mock_tokenizer = Mock()
+    mock_tokenizer.bos_id = 1
+    mock_tokenizer.eos_id = 2
+    mock_tokenizer._sep_id = 3
+    mock_tokenizer.pad_id = 0
+    mock_tokenizer.text_to_ids.return_value = [10, 11, 12]
+
+    # Create dataset with reverse complement augmentation
+    dataset = ShardedEdenDataset(
+        tokenizer=mock_tokenizer,
+        sequence_db_dir=sequence_db_dir,
+        window_db_path=window_dbs["train"],
+        seq_length=8192,
+        create_attention_mask=False,
+        stride=7992,
+        rc_aug=True,  # Enable reverse complement
+        use_control_tags=False,
+        split="train",
+    )
+
+    # Test reverse complement method
+    test_seq = "ATCG"
+    rc_seq = dataset.reverse_complement(test_seq)
+    assert rc_seq == "CGAT"
+
+    # Test with N bases
+    test_seq_with_n = "ATCN"
+    rc_seq_with_n = dataset.reverse_complement(test_seq_with_n)
+    assert rc_seq_with_n == "NCGAT"
+
+    # Clean up
+    dataset.__del__()
+
+
+def test_dataset_collate_fn(sequence_db_dir, window_dbs):
+    """Test dataset collate function."""
+    # Mock tokenizer
+    mock_tokenizer = Mock()
+    mock_tokenizer.bos_id = 1
+    mock_tokenizer.eos_id = 2
+    mock_tokenizer._sep_id = 3
+    mock_tokenizer.pad_id = 0
+    mock_tokenizer.text_to_ids.return_value = [10, 11, 12]
+
+    # Create dataset
+    dataset = ShardedEdenDataset(
+        tokenizer=mock_tokenizer,
+        sequence_db_dir=sequence_db_dir,
+        window_db_path=window_dbs["train"],
+        seq_length=8192,
+        create_attention_mask=False,
+        stride=7992,
+        rc_aug=False,
+        use_control_tags=False,
+        split="train",
+    )
+
+    # Create a batch of items
+    batch = [dataset[np.int64(0)], dataset[np.int64(1)]] if len(dataset) > 1 else [dataset[np.int64(0)]]
+
+    # Test collate function
+    collated = dataset.collate_fn(batch)
+
+    # Verify collated structure
+    assert isinstance(collated, dict)
+    assert "tokens" in collated
+    assert "labels" in collated
+    assert "loss_mask" in collated
+    assert "position_ids" in collated
+
+    # Verify batch dimension
+    assert collated["tokens"].dim() == 2
+    assert collated["tokens"].shape[0] == len(batch)
+
+    # Clean up
+    dataset.__del__()
+
+
+def test_invalid_sequence_db_dir(window_dbs):
+    """Test error handling for invalid sequence database directory."""
+    # Mock tokenizer
+    mock_tokenizer = Mock()
+    mock_tokenizer.bos_id = 1
+    mock_tokenizer.eos_id = 2
+    mock_tokenizer._sep_id = 3
+    mock_tokenizer.pad_id = 0
+    mock_tokenizer.text_to_ids.return_value = [10, 11, 12]
+
+    # Test with non-existent directory
+    with pytest.raises(ValueError, match="No SQLite files found"):
+        ShardedEdenDataset(
+            tokenizer=mock_tokenizer,
+            sequence_db_dir="/non/existent/path",
+            window_db_path=window_dbs["train"],
+            seq_length=8192,
+            create_attention_mask=False,
+            stride=7992,
+            rc_aug=False,
+            use_control_tags=False,
+            split="train",
+        )
+
+
+def test_invalid_window_db_path(sequence_db_dir):
+    """Test error handling for invalid window database path."""
+    # Mock tokenizer
+    mock_tokenizer = Mock()
+    mock_tokenizer.bos_id = 1
+    mock_tokenizer.eos_id = 2
+    mock_tokenizer._sep_id = 3
+    mock_tokenizer.pad_id = 0
+    mock_tokenizer.text_to_ids.return_value = [10, 11, 12]
+
+    # Test with non-existent window database
+    with pytest.raises(ValueError):
+        ShardedEdenDataset(
+            tokenizer=mock_tokenizer,
+            sequence_db_dir=sequence_db_dir,
+            window_db_path="/non/existent/windows.db",
+            seq_length=8192,
+            create_attention_mask=False,
+            stride=7992,
+            rc_aug=False,
+            use_control_tags=False,
+            split="train",
+        )
+
+
+def test_window_min_length_threshold(temp_dir, train_parquet):
+    """Test window database creation with length threshold."""
+    output_db = Path(temp_dir) / "threshold_windows.db"
+
+    # Create database with length threshold
+    precompute_window_database(
+        train_parquet,
+        str(output_db),
+        window_size=8192,
+        stride=7992,
+        window_min_length_threshold=10000,  # Only windows >= 10000 bases
+    )
+
+    # Verify database was created
+    assert output_db.exists()
+
+    # Check metadata
+    conn = sqlite3.connect(str(output_db))
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT key, value FROM metadata")
+    metadata = dict(cursor.fetchall())
+
+    assert metadata["window_min_length_threshold"] == 10000
+
+    conn.close()
+
+
+def test_dataset_length_and_iteration(sequence_db_dir, window_dbs):
+    """Test dataset length and basic iteration."""
+    # Mock tokenizer
+    mock_tokenizer = Mock()
+    mock_tokenizer.bos_id = 1
+    mock_tokenizer.eos_id = 2
+    mock_tokenizer._sep_id = 3
+    mock_tokenizer.pad_id = 0
+    mock_tokenizer.text_to_ids.return_value = [10, 11, 12]
+
+    # Create dataset
+    dataset = ShardedEdenDataset(
+        tokenizer=mock_tokenizer,
+        sequence_db_dir=sequence_db_dir,
+        window_db_path=window_dbs["train"],
+        seq_length=8192,
+        create_attention_mask=False,
+        stride=7992,
+        rc_aug=False,
+        use_control_tags=False,
+        split="train",
+    )
+
+    # Test length
+    dataset_len = len(dataset)
+    assert dataset_len > 0
+
+    # Test iteration (just first few items)
+    for i in range(min(3, dataset_len)):
+        item = dataset[np.int64(i)]
+        assert isinstance(item, dict)
+        assert "tokens" in item
+
+    # Clean up
+    dataset.__del__()
+
+
+def test_dataset_with_different_seq_lengths(sequence_db_dir, window_dbs):
+    """Test dataset with different sequence lengths."""
+    # Mock tokenizer
+    mock_tokenizer = Mock()
+    mock_tokenizer.bos_id = 1
+    mock_tokenizer.eos_id = 2
+    mock_tokenizer._sep_id = 3
+    mock_tokenizer.pad_id = 0
+    mock_tokenizer.text_to_ids.return_value = [10, 11, 12]
+
+    # Test with different sequence lengths
+    for seq_length in [4096, 8192, 16384]:
+        dataset = ShardedEdenDataset(
+            tokenizer=mock_tokenizer,
+            sequence_db_dir=sequence_db_dir,
+            window_db_path=window_dbs["train"],
+            seq_length=seq_length,
+            create_attention_mask=False,
+            stride=seq_length - 200,  # Adjust stride
+            rc_aug=False,
+            use_control_tags=False,
+            split="train",
+        )
+
+        # Verify sequence length
+        assert dataset.seq_length == seq_length
+
+        # Clean up
+        dataset.__del__()

--- a/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
+++ b/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
@@ -96,6 +96,29 @@ def small_training_mamba_finetune_cmd(
     return cmd
 
 
+def small_training_llama_cmd(path, max_steps, val_check, devices: int = 1, additional_args: str = ""):
+    cmd = (
+        f"train_evo2 --no-fp32-residual-connection --mock-data --result-dir {path} --devices {devices} "
+        "--model-size 8B --num-layers 2 --limit-val-batches 1 "
+        "--no-activation-checkpointing --create-tensorboard-logger --create-tflops-callback "
+        f"--max-steps {max_steps} --warmup-steps 1 --val-check-interval {val_check} --limit-val-batches 1 "
+        f"--seq-length 8 --hidden-dropout 0.1 --attention-dropout 0.1 {additional_args}"
+    )
+    return cmd
+
+
+def small_training_llama_finetune_cmd(
+    path, max_steps, val_check, prev_ckpt, devices: int = 1, additional_args: str = ""
+):
+    cmd = (
+        f"train_evo2 --no-fp32-residual-connection --mock-data --result-dir {path} --devices {devices} "
+        "--model-size 8B --num-layers 2 --limit-val-batches 1 "
+        "--no-activation-checkpointing --create-tensorboard-logger --create-tflops-callback "
+        f"--max-steps {max_steps} --warmup-steps 1 --val-check-interval {val_check} --limit-val-batches 1 "
+        f"--seq-length 16 --hidden-dropout 0.1 --attention-dropout 0.1 {additional_args} --ckpt-dir {prev_ckpt}"
+    )
+    return cmd
+
 @pytest.mark.timeout(512)  # Optional: fail if the test takes too long.
 @pytest.mark.slow
 def test_train_evo2_finetune_runs(tmp_path):
@@ -226,6 +249,80 @@ def test_train_evo2_mamba_finetune_runs(tmp_path):
 
     expected_checkpoint_suffix = f"{num_steps}.0-last"
     # Check if any subfolder ends with the expected suffix
+    matching_subfolders_ft = [
+        p for p in checkpoints_dir_ft.iterdir() if p.is_dir() and (expected_checkpoint_suffix in p.name)
+    ]
+
+    assert matching_subfolders_ft, (
+        f"No checkpoint subfolder ending with '{expected_checkpoint_suffix}' found in {checkpoints_dir_ft}."
+    )
+
+    # Check if directory with tensorboard logs exists
+    assert tensorboard_dir_ft.exists(), "TensorBoard logs folder does not exist."
+    # Recursively search for files with tensorboard logger
+    event_files = list(tensorboard_dir_ft.rglob("events.out.tfevents*"))
+    assert event_files, f"No TensorBoard event files found under {tensorboard_dir_ft}"
+
+    assert len(matching_subfolders_ft) == 1, "Only one checkpoint subfolder should be found."
+
+
+
+@pytest.mark.timeout(512)  # Optional: fail if the test takes too long.
+@pytest.mark.slow
+def test_train_evo2_llama_finetune_runs(tmp_path):
+    """
+    This test runs the `train_evo2` command with mock data in a temporary directory using Llama model.
+    It uses the temporary directory provided by pytest as the working directory.
+    The command is run in a subshell, and we assert that it returns an exit code of 0.
+    """
+    num_steps = 2
+    # Note: The command assumes that `train_evo2` is in your PATH.
+    command = small_training_llama_cmd(tmp_path / "pretrain", max_steps=num_steps, val_check=num_steps)
+    stdout_pretrain: str = run_command_in_subprocess(command=command, path=str(tmp_path))
+    assert "Restoring model weights from RestoreConfig(path='" not in stdout_pretrain
+
+    log_dir = tmp_path / "pretrain" / "evo2"
+    checkpoints_dir = log_dir / "checkpoints"
+    tensorboard_dir = log_dir / "dev"
+
+    # Check if logs dir exists
+    assert log_dir.exists(), "Logs folder should exist."
+    # Check if checkpoints dir exists
+    assert checkpoints_dir.exists(), "Checkpoints folder does not exist."
+
+    expected_checkpoint_suffix = f"{num_steps}.0-last"
+    # Check if any subfolder ends with the expected suffix
+    matching_subfolders = [
+        p for p in checkpoints_dir.iterdir() if p.is_dir() and (expected_checkpoint_suffix in p.name)
+    ]
+
+    assert matching_subfolders, (
+        f"No checkpoint subfolder ending with '{expected_checkpoint_suffix}' found in {checkpoints_dir}."
+    )
+
+    # Check if directory with tensorboard logs exists
+    assert tensorboard_dir.exists(), "TensorBoard logs folder does not exist."
+    # Recursively search for files with tensorboard logger
+    event_files = list(tensorboard_dir.rglob("events.out.tfevents*"))
+    assert event_files, f"No TensorBoard event files found under {tensorboard_dir}"
+
+    assert len(matching_subfolders) == 1, "Only one checkpoint subfolder should be found."
+    command_finetune = small_training_llama_finetune_cmd(
+        tmp_path / "finetune", max_steps=num_steps, val_check=num_steps, prev_ckpt=matching_subfolders[0]
+    )
+    stdout_finetune: str = run_command_in_subprocess(command=command_finetune, path=str(tmp_path))
+    assert "Restoring model weights from RestoreConfig(path='" in stdout_finetune
+
+    log_dir_ft = tmp_path / "finetune" / "evo2"
+    checkpoints_dir_ft = log_dir_ft / "checkpoints"
+    tensorboard_dir_ft = log_dir_ft / "dev"
+
+    # Check if logs dir exists
+    assert log_dir_ft.exists(), "Logs folder should exist."
+    # Check if checkpoints dir exists
+    assert checkpoints_dir_ft.exists(), "Checkpoints folder does not exist."
+
+    expected_checkpoint_suffix = f"{num_steps}.0-last"
     matching_subfolders_ft = [
         p for p in checkpoints_dir_ft.iterdir() if p.is_dir() and (expected_checkpoint_suffix in p.name)
     ]

--- a/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
+++ b/sub-packages/bionemo-evo2/tests/bionemo/evo2/run/test_train.py
@@ -119,6 +119,7 @@ def small_training_llama_finetune_cmd(
     )
     return cmd
 
+
 @pytest.mark.timeout(512)  # Optional: fail if the test takes too long.
 @pytest.mark.slow
 def test_train_evo2_finetune_runs(tmp_path):
@@ -264,7 +265,6 @@ def test_train_evo2_mamba_finetune_runs(tmp_path):
     assert event_files, f"No TensorBoard event files found under {tensorboard_dir_ft}"
 
     assert len(matching_subfolders_ft) == 1, "Only one checkpoint subfolder should be found."
-
 
 
 @pytest.mark.timeout(512)  # Optional: fail if the test takes too long.


### PR DESCRIPTION
### Description

SharedEdenDataloader 
Internal PR of https://github.com/NVIDIA/bionemo-framework/pull/1091
Contributed by Basecamp Research  @Geraldene


### Type of changes

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

### CI Pipeline Configuration

Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage

<!--- How does a user interact with the changed code -->

```python
# TODO: Add code snippet
```

### Pre-submit Checklist

<!--- Ensure all items are completed before submitting -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [x] I have added/updated tests as needed
- [ ] All existing tests pass successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - High-performance sharded data loader with precomputed window DBs, per-sample sequence stores, CLI precompute, RC augmentation, window-access logging, and PyTorch Lightning integration.
  - Expanded model support: Eden-flavored Llama configs with extended-context options and new LLAMA model sizes; training CLI and run naming updated to support LLAMA.

- Documentation
  - Added user guide describing sharded data loader layout, preprocessing, and usage.

- Tests
  - Added comprehensive dataset/data‑module tests and end-to-end Llama pretrain/finetune tests.

- Chores
  - Updated license header year.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->