### PR TITLE
Fix infer_evo2 argparse error.

### DIFF
--- a/sub-packages/bionemo-evo2/src/bionemo/evo2/run/infer.py
+++ b/sub-packages/bionemo-evo2/src/bionemo/evo2/run/infer.py
@@ -86,14 +86,12 @@ def parse_args():
     )
     ap.add_argument(
         "--fp8",
-        type=bool,
         action="store_true",
         default=False,
         help="Whether to use vortex style FP8. Defaults to False.",
     )
     ap.add_argument(
         "--flash-decode",
-        type=bool,
         action="store_true",
         default=False,
         help="Whether to use flash decode. Defaults to True.",


### PR DESCRIPTION
### Description

Fix an issue with argparse with evo2 inference. For example the following command fails before this PR:
```
infer_evo2 --ckpt-dir  $(download_bionemo_data evo2/1b-8k-bf16:1.0) --prompt AAA
```

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

### CI Pipeline Configuration

Configure CI behavior by applying the relevant labels:

- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage

```python
infer_evo2 --ckpt-dir  $(download_bionemo_data evo2/1b-8k-bf16:1.0) --prompt AAA
```

### Pre-submit Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified command-line flag handling for performance options. The --fp8 and --flash-decode flags remain boolean toggles enabled only when specified, with unchanged defaults and behavior. No changes to outputs, workflows, or compatibility. No action required for existing users or scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->