### PR TITLE
pin torch version in amplify

### DIFF
--- a/models/amplify/pyproject.toml
+++ b/models/amplify/pyproject.toml
@@ -19,8 +19,8 @@ dependencies = [
     "nvidia_resiliency_ext",
     "omegaconf",
     "pytest",
-    "torch",
-    # "transformer_engine[pytorch]",
+    "torch==2.6.0a0+ecf3bae40a.nv25.01",
+    "transformer_engine[pytorch]",
     "transformers",
     "xformers",
 ]


### PR DESCRIPTION
For some reason a dependency seems to be requesting a torch update in the AMPLIFY model tests, which we can't do in the older torch 2.6.0 base container (to continue to support the legacy xformers version of the original AMPLIFY model). This pins the torch version in these tests to make sure we don't update via pip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated core ML runtime to a pinned Torch pre-release version.
  - Enabled Transformer Engine (PyTorch) dependency.
  - Note: You may need to reinstall/update dependencies after pulling this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->