### PR TITLE
uses image with zstd compression

### DIFF
--- a/ci/scripts/recipes_local_test.py
+++ b/ci/scripts/recipes_local_test.py
@@ -55,7 +55,7 @@ CUSTOM_CONTAINERS = {
 # --output type=registry,compression=zstd,force-compression=true,oci-mediatypes=true,compression-level=15
 # and pushed to the dockerhub registry. Our github actions are able to cache image pulls from dockerhub but not nvcr, so
 # hopefully this cuts down slightly on CI time at the expense of having a slightly in-directed image location.
-DEFAULT_CONTAINER = "svcbionemo023/bionemo-framework:pytorch25.06-py3-squashed"
+DEFAULT_CONTAINER = "svcbionemo023/bionemo-framework:pytorch25.06-py3-squashed-zstd"
 
 
 def get_git_root() -> str:


### PR DESCRIPTION
Uses an image verified to use zstd compression, which will hopefully give faster builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the default container image tag used by CI/local test runs.
- Tests
  - No changes to test behavior or execution flow; workflows continue to run as before.
  - Fallback behavior for selecting a container remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->