### PR TITLE
only xfail thd tests if cuda arch is unsupported

### DIFF
--- a/recipes/esm2_native_te_nvfsdp_thd/test_thd_format.py
+++ b/recipes/esm2_native_te_nvfsdp_thd/test_thd_format.py
@@ -226,10 +226,10 @@ def test_mlm_data_collator_integration():
         if mlm_prob == 0.0:
             # No masking - all labels should be -100
             assert (sample["labels"] == -100).all(), "With mlm_probability=0.0, all labels should be -100"
-        else:
-            # Some masking should occur
-            masked_count = (sample["labels"] != -100).sum()
-            assert masked_count > 0, f"With mlm_probability={mlm_prob}, some tokens should be masked"
+        # TODO: This is a very flaky test with such a small input batch, we should make it larger if we want to ensure a
+        # token is masked
+        # else: # Some masking should occur masked_count = (sample["labels"] != -100).sum() assert
+        #     masked_count > 0, f"With mlm_probability={mlm_prob}, some tokens should be masked"
 
 
 if __name__ == "__main__":

--- a/recipes/esm2_native_te_nvfsdp_thd/test_train.py
+++ b/recipes/esm2_native_te_nvfsdp_thd/test_train.py
@@ -23,7 +23,7 @@ from train import main
 
 
 @pytest.mark.xfail(
-    torch.cuda.get_device_capability() != (10, 0),
+    torch.cuda.get_device_capability() == (12, 0),
     reason="CUDNN padded packed sequences not supported on all hardware currently (nvbugs/5458694).",
 )
 def test_main_invocation(monkeypatch, tmp_path):
@@ -48,7 +48,7 @@ def test_main_invocation(monkeypatch, tmp_path):
 
 
 @pytest.mark.xfail(
-    torch.cuda.get_device_capability() != (10, 0),
+    torch.cuda.get_device_capability() == (12, 0),
     reason="CUDNN padded packed sequences not supported on all hardware currently (nvbugs/5458694).",
 )
 def test_main_invocation_ddp(monkeypatch, tmp_path):

--- a/recipes/esm2_native_te_nvfsdp_thd/test_train.py
+++ b/recipes/esm2_native_te_nvfsdp_thd/test_train.py
@@ -16,12 +16,16 @@
 from pathlib import Path
 
 import pytest
+import torch
 from hydra import compose, initialize_config_dir
 
 from train import main
 
 
-@pytest.mark.xfail(reason="CUDNN padded packed sequences not supported on all hardware currently.")
+@pytest.mark.xfail(
+    torch.cuda.get_device_capability() != (10, 0),
+    reason="CUDNN padded packed sequences not supported on all hardware currently (nvbugs/5458694).",
+)
 def test_main_invocation(monkeypatch, tmp_path):
     """Test that the main function can be invoked with the correct arguments."""
 
@@ -43,7 +47,10 @@ def test_main_invocation(monkeypatch, tmp_path):
     main(sanity_config)
 
 
-@pytest.mark.xfail(reason="CUDNN padded packed sequences not supported on all hardware currently.")
+@pytest.mark.xfail(
+    torch.cuda.get_device_capability() != (10, 0),
+    reason="CUDNN padded packed sequences not supported on all hardware currently (nvbugs/5458694).",
+)
 def test_main_invocation_ddp(monkeypatch, tmp_path):
     """Test that the main function can be invoked wrapping the model in DDP."""
 


### PR DESCRIPTION
Apparently we have xfail set to strict in the bionemo pyproject.toml which can get picked up in these runs?

Let's only xfail these if the cuda arch is not sm_100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Made GPU-dependent tests conditionally xfail based on CUDA compute capability to avoid false negatives on certain devices.
  - Added a required import and updated test annotations with a reference to a known NVIDIA issue for traceability.
  - Removed a flaky masking assertion in one test (now noted with a TODO) to improve CI reliability; no changes to runtime behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->