### PR TITLE
Add wandb mode arg

### DIFF
--- a/recipes/geneformer_native_te_nvfsdp_fp8/AGENT_DOCUMENTATION.md
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/AGENT_DOCUMENTATION.md
@@ -122,9 +122,15 @@ training:
   num_workers: 4                        # DataLoader workers
   mlm_probability: 0.15                 # Mask probability
   use_fp8: true                         # Enable FP8 precision
-  wandb_init_args:
-    name: "geneformer-4b-te"           # Experiment name
+```
+
+### WandB Configuration
+
+```yaml
+wandb_init_args:
+    name: "geneformer-4b-te"            # Experiment name
     project: "bionemo-recipes"          # Project name
+    mode: "offline"                     # Run data management
 ```
 
 ### Data Configuration

--- a/recipes/geneformer_native_te_nvfsdp_fp8/README.md
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/README.md
@@ -226,7 +226,7 @@ We support full integration with weights and biases. To use this please supply t
 export WANDB_API_KEY=<yourapikey>
 ```
 
-and supply the hydra config section `training.wandb_init_args` with your experiment name and project.
+and supply the hydra config section `wandb_init_args` with your experiment name and project.
 
 ### Dataset
 

--- a/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/106m.yaml
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/106m.yaml
@@ -18,13 +18,14 @@ training:
   num_train_steps: 100 # this setting defines the number of training steps
   num_workers: 4 # this setting defines the number of workers for the dataloader
   mlm_probability: 0.15 # this setting defines the probability of masking tokens in the input
-  wandb_init_args: # These arguments are for managing the weights and biases experiment.
-    name: "geneformer-l0-106m" # this setting defines the name of the experiment
-    project: "bionemo-recipes-l0-106m" # this setting defines the project name
-    mode: "offline"
   checkpoint_dir: "checkpoints/l0-106m"
   save_every_n_steps: 50
   resume_from_checkpoint: true
+
+wandb_init_args: # These arguments are for managing the weights and biases experiment.
+  name: "geneformer-l0-106m" # this setting defines the name of the experiment
+  project: "bionemo-recipes-l0-106m" # this setting defines the project name
+  mode: "offline"
 
 # Data configuration
 data:

--- a/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/106m.yaml
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/106m.yaml
@@ -21,10 +21,11 @@ training:
   wandb_init_args: # These arguments are for managing the weights and biases experiment.
     name: "geneformer-l0-106m" # this setting defines the name of the experiment
     project: "bionemo-recipes-l0-106m" # this setting defines the project name
+    mode: "offline"
   checkpoint_dir: "checkpoints/l0-106m"
   save_every_n_steps: 50
   resume_from_checkpoint: true
 
 # Data configuration
 data:
-  path: "genecorpus_500_samples.parquet"  # A sanity dataset saved to the repo that holds 500 samples.
+  path: "genecorpus_500_samples.parquet" # A sanity dataset saved to the repo that holds 500 samples.

--- a/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/10m.yaml
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/10m.yaml
@@ -21,10 +21,11 @@ training:
   wandb_init_args: # These arguments are for managing the weights and biases experiment.
     name: "geneformer-10m" # this setting defines the name of the experiment
     project: "bionemo-recipes-10m" # this setting defines the project name
+    mode: "offline"
   checkpoint_dir: "checkpoints/10m"
   save_every_n_steps: 50
   resume_from_checkpoint: true
 
 # Data configuration
 data:
-  path: "genecorpus_500_samples.parquet"  # A sanity dataset saved to the repo that holds 500 samples.
+  path: "genecorpus_500_samples.parquet" # A sanity dataset saved to the repo that holds 500 samples.

--- a/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/10m.yaml
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/10m.yaml
@@ -18,13 +18,14 @@ training:
   num_train_steps: 100 # this setting defines the number of training steps
   num_workers: 4 # this setting defines the number of workers for the dataloader
   mlm_probability: 0.15 # this setting defines the probability of masking tokens in the input
-  wandb_init_args: # These arguments are for managing the weights and biases experiment.
-    name: "geneformer-10m" # this setting defines the name of the experiment
-    project: "bionemo-recipes-10m" # this setting defines the project name
-    mode: "offline"
   checkpoint_dir: "checkpoints/10m"
   save_every_n_steps: 50
   resume_from_checkpoint: true
+
+wandb_init_args: # These arguments are for managing the weights and biases experiment.
+  name: "geneformer-10m" # this setting defines the name of the experiment
+  project: "bionemo-recipes-10m" # this setting defines the project name
+  mode: "offline"
 
 # Data configuration
 data:

--- a/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/4b.yaml
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/4b.yaml
@@ -18,13 +18,14 @@ training:
   num_train_steps: 100 # this setting defines the number of training steps
   num_workers: 4 # this setting defines the number of workers for the dataloader
   mlm_probability: 0.15 # this setting defines the probability of masking tokens in the input
-  wandb_init_args: # These arguments are for managing the weights and biases experiment.
-    name: "geneformer-l0-4b" # this setting defines the name of the experiment
-    project: "bionemo-recipes-l0-4b" # this setting defines the project name
-    mode: "offline"
   checkpoint_dir: "checkpoints/4b"
   save_every_n_steps: 50
   resume_from_checkpoint: true
+
+wandb_init_args: # These arguments are for managing the weights and biases experiment.
+  name: "geneformer-l0-4b" # this setting defines the name of the experiment
+  project: "bionemo-recipes-l0-4b" # this setting defines the project name
+  mode: "offline"
 
 # Data configuration
 data:

--- a/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/4b.yaml
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/4b.yaml
@@ -21,10 +21,11 @@ training:
   wandb_init_args: # These arguments are for managing the weights and biases experiment.
     name: "geneformer-l0-4b" # this setting defines the name of the experiment
     project: "bionemo-recipes-l0-4b" # this setting defines the project name
+    mode: "offline"
   checkpoint_dir: "checkpoints/4b"
   save_every_n_steps: 50
   resume_from_checkpoint: true
 
 # Data configuration
 data:
-  path: "genecorpus_500_samples.parquet"  # A sanity dataset saved to the repo that holds 500 samples.
+  path: "genecorpus_500_samples.parquet" # A sanity dataset saved to the repo that holds 500 samples.

--- a/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/defaults.yaml
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/defaults.yaml
@@ -45,10 +45,11 @@ training:
   wandb_init_args: # These arguments are for managing the weights and biases experiment.
     name: "geneformer-???" # this setting defines the name of the experiment
     project: "bionemo-recipes-???" # this setting defines the project name
+    mode: "offline"
   checkpoint_dir: ???
   save_every_n_steps: 50
   resume_from_checkpoint: true
 
 # Data configuration
 data:
-  path: "genecorpus_500_samples.parquet"  # A sanity dataset saved to the repo that holds 500 samples.
+  path: "genecorpus_500_samples.parquet" # A sanity dataset saved to the repo that holds 500 samples.

--- a/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/defaults.yaml
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/defaults.yaml
@@ -42,13 +42,14 @@ training:
     fp8_format: "hybrid"
     amax_history_len: 16 # this setting defines the number of steps to store the amax values for the fp8 training. Why was mine so low?
     amax_compute_algo: "max"
-  wandb_init_args: # These arguments are for managing the weights and biases experiment.
-    name: "geneformer-???" # this setting defines the name of the experiment
-    project: "bionemo-recipes-???" # this setting defines the project name
-    mode: "offline"
   checkpoint_dir: ???
   save_every_n_steps: 50
   resume_from_checkpoint: true
+
+wandb_init_args: # These arguments are for managing the weights and biases experiment.
+  name: "geneformer-???" # this setting defines the name of the experiment
+  project: "bionemo-recipes-???" # this setting defines the project name
+  mode: "offline"
 
 # Data configuration
 data:

--- a/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/l0_sanity.yaml
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/l0_sanity.yaml
@@ -18,13 +18,14 @@ training:
   num_train_steps: 100 # this setting defines the number of training steps
   num_workers: 4 # this setting defines the number of workers for the dataloader
   mlm_probability: 0.15 # this setting defines the probability of masking tokens in the input
-  wandb_init_args: # These arguments are for managing the weights and biases experiment.
-    name: "geneformer-l0-sanity" # this setting defines the name of the experiment
-    project: "bionemo-recipes-l0-sanity" # this setting defines the project name
-    mode: "offline"
   checkpoint_dir: "checkpoints/l0-sanity"
   save_every_n_steps: 50
   resume_from_checkpoint: true
+
+wandb_init_args: # These arguments are for managing the weights and biases experiment.
+  name: "geneformer-l0-sanity" # this setting defines the name of the experiment
+  project: "bionemo-recipes-l0-sanity" # this setting defines the project name
+  mode: "offline"
 
 # Data configuration
 data:

--- a/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/l0_sanity.yaml
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/hydra_config/l0_sanity.yaml
@@ -21,10 +21,11 @@ training:
   wandb_init_args: # These arguments are for managing the weights and biases experiment.
     name: "geneformer-l0-sanity" # this setting defines the name of the experiment
     project: "bionemo-recipes-l0-sanity" # this setting defines the project name
+    mode: "offline"
   checkpoint_dir: "checkpoints/l0-sanity"
   save_every_n_steps: 50
   resume_from_checkpoint: true
 
 # Data configuration
 data:
-  path: "genecorpus_500_samples.parquet"  # A sanity dataset saved to the repo that holds 500 samples.
+  path: "genecorpus_500_samples.parquet" # A sanity dataset saved to the repo that holds 500 samples.

--- a/recipes/geneformer_native_te_nvfsdp_fp8/train.py
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/train.py
@@ -115,9 +115,9 @@ def main(cfg: DictConfig) -> None:
     # Initialize wandb only on the main process
     if dist_config.is_main_process():
         wandb.init(
-            project=cfg.training.wandb_init_args.project,
-            name=cfg.training.wandb_init_args.name,
-            mode=cfg.training.wandb_init_args.mode,
+            project=cfg.wandb_init_args.project,
+            name=cfg.wandb_init_args.name,
+            mode=cfg.wandb_init_args.mode,
             config={
                 "batch_size": cfg.model.micro_batch_size,
                 "learning_rate": cfg.training.optimizer_kwargs.lr,

--- a/recipes/geneformer_native_te_nvfsdp_fp8/train.py
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/train.py
@@ -117,6 +117,7 @@ def main(cfg: DictConfig) -> None:
         wandb.init(
             project=cfg.training.wandb_init_args.project,
             name=cfg.training.wandb_init_args.name,
+            mode=cfg.training.wandb_init_args.mode,
             config={
                 "batch_size": cfg.model.micro_batch_size,
                 "learning_rate": cfg.training.optimizer_kwargs.lr,


### PR DESCRIPTION
Add wandb mode arg to geneformer configs.

This is needed so that we can collect the wandb logs as `online` in CI testing.
I defaulted to `offline` since that's what the esm2 models use for default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for offline experiment logging with Weights & Biases; runs can be created offline and synced later.
  - Training now respects a configured logging mode so offline logging is applied by default.

- **Documentation**
  - Updated docs to reflect the new logging configuration key and show offline usage examples.

- **Chores**
  - Minor formatting and comment whitespace cleanup in config/docs; no behavioral or data-path changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->