### PR TITLE
Log step_time in recipes geneformer

### DIFF
--- a/recipes/geneformer_native_te_nvfsdp_fp8/train.py
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/train.py
@@ -116,9 +116,6 @@ def main(cfg: DictConfig) -> None:
     # Initialize wandb only on the main process
     if dist_config.is_main_process():
         wandb.init(
-            project=cfg.wandb_init_args.project,
-            name=cfg.wandb_init_args.name,
-            mode=cfg.wandb_init_args.mode,
             config={
                 "batch_size": cfg.model.micro_batch_size,
                 "learning_rate": cfg.training.optimizer_kwargs.lr,
@@ -127,6 +124,7 @@ def main(cfg: DictConfig) -> None:
                 "use_fp8": cfg.training.use_fp8,
                 "world_size": dist_config.world_size,
             },
+            **cfg.wandb_init_args,
         )
 
     bert_model_config = TEBertConfig(**cfg.model, torch_dtype=torch.bfloat16)

--- a/recipes/geneformer_native_te_nvfsdp_fp8/train.py
+++ b/recipes/geneformer_native_te_nvfsdp_fp8/train.py
@@ -258,7 +258,7 @@ def main(cfg: DictConfig) -> None:
             step_time = current_time - previous_step_time
             previous_step_time = current_time
             logger.info(
-                f"Step {step} loss: {loss.item()}, grad_norm: {total_norm}, lr: {optimizer.param_groups[0]['lr']}"
+                f"Step {step} loss: {loss.item()}, grad_norm: {total_norm}, lr: {optimizer.param_groups[0]['lr']}, step_time: {step_time:.3f}s"
             )
             wandb.log(
                 {


### PR DESCRIPTION
Add logic to track `step_time` and save it to wandb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-step training time is now recorded and displayed: a "train/step_time" metric is logged each step and step_time appears in console/train log lines for real-time iteration timing.

* **Chores**
  * WandB initialization now derives arguments from the training configuration (uses configured init args).  

* **Other**
  * No public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->