### PR TITLE
Add wandb logging to recipe amplify model

### DIFF
--- a/recipes/amplify_accelerate_te_fp8/callbacks.py
+++ b/recipes/amplify_accelerate_te_fp8/callbacks.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 from transformers.trainer_callback import TrainerCallback, TrainerControl, TrainerState
 from transformers.training_args import TrainingArguments
 
@@ -32,3 +34,19 @@ class StopAfterNStepsCallback(TrainerCallback):
         """Interrupt training after a specified number of steps."""
         if state.global_step >= self.max_steps:
             control.should_training_stop = True
+
+
+class StepTimingCallback(TrainerCallback):
+    def __init__(self):
+        self.step_start_time = None
+
+    def on_step_begin(self, args, state, control, **kwargs):
+        """Called at the beginning of each training step."""
+        self.step_start_time = time.perf_counter()
+
+    def on_log(self, args, state, control, logs=None, **kwargs):
+        """Called when metrics are logged."""
+        if self.step_start_time is not None and logs is not None:
+            current_time = time.perf_counter()
+            step_time = current_time - self.step_start_time
+            logs["train/step_time"] = step_time

--- a/recipes/amplify_accelerate_te_fp8/callbacks.py
+++ b/recipes/amplify_accelerate_te_fp8/callbacks.py
@@ -37,7 +37,10 @@ class StopAfterNStepsCallback(TrainerCallback):
 
 
 class StepTimingCallback(TrainerCallback):
+    """Callback to log the time taken for each step."""
+
     def __init__(self):
+        """Initialize the callback."""
         self.step_start_time = None
 
     def on_step_begin(self, args, state, control, **kwargs):

--- a/recipes/amplify_accelerate_te_fp8/hydra_config/L0_sanity.yaml
+++ b/recipes/amplify_accelerate_te_fp8/hydra_config/L0_sanity.yaml
@@ -13,3 +13,8 @@ trainer:
   logging_steps: 1
   report_to: "none"
   dataloader_num_workers: 0
+
+wandb_init_args: # These arguments are for managing the weights and biases experiment.
+  name: "L0_sanity" # this setting defines the name of the experiment
+  project: "bionemo-recipes-amplify_accelerate_te_fp8" # this setting defines the project name
+  mode: "online"

--- a/recipes/amplify_accelerate_te_fp8/hydra_config/L0_sanity.yaml
+++ b/recipes/amplify_accelerate_te_fp8/hydra_config/L0_sanity.yaml
@@ -15,6 +15,6 @@ trainer:
   dataloader_num_workers: 0
 
 wandb_init_args: # These arguments are for managing the weights and biases experiment.
-  name: "L0_sanity" # this setting defines the name of the experiment
-  project: "bionemo-recipes-amplify_accelerate_te_fp8" # this setting defines the project name
+  name: "L0_sanity_testdir" # this setting defines the name of the experiment
+  project: "bnmo_testdir" # this setting defines the project name
   mode: "online"

--- a/recipes/amplify_accelerate_te_fp8/hydra_config/L1_350M_partial_conv.yaml
+++ b/recipes/amplify_accelerate_te_fp8/hydra_config/L1_350M_partial_conv.yaml
@@ -10,3 +10,8 @@ trainer:
   report_to: "wandb"
   per_device_train_batch_size: 128
   per_device_eval_batch_size: 256
+
+wandb_init_args: # These arguments are for managing the weights and biases experiment.
+  name: "L1_350M_partial_conv" # this setting defines the name of the experiment
+  project: "bionemo-recipes-amplify_accelerate_te_fp8" # this setting defines the project name
+  mode: "online"

--- a/recipes/amplify_accelerate_te_fp8/train.py
+++ b/recipes/amplify_accelerate_te_fp8/train.py
@@ -19,12 +19,13 @@ from pathlib import Path
 import hydra
 import torch
 import transformers
+import wandb
 from omegaconf import DictConfig
 from transformers import AutoConfig, AutoModelForMaskedLM
 from transformers.trainer import Trainer
 from transformers.training_args import TrainingArguments
 
-from callbacks import StopAfterNStepsCallback
+from callbacks import StopAfterNStepsCallback, StepTimingCallback
 from dataset import create_datasets_and_collator
 from metrics import compute_metrics
 
@@ -35,6 +36,14 @@ logger = logging.getLogger(__name__)
 @hydra.main(config_path="hydra_config", config_name="L0_sanity", version_base="1.2")
 def main(args: DictConfig):
     """Entrypoint."""
+    # add wandb logging on main process
+    if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+        wandb.init(
+            project=args.wandb_init_args.project,
+            name=args.wandb_init_args.name,
+            config=OmegaConf.to_container(args, resolve=True, throw_on_missing=True),
+            mode=getattr(args.wandb_init_args, 'mode', 'online'),
+        )
     config = AutoConfig.from_pretrained(args.model_tag, trust_remote_code=True)
     config.max_length = args.max_seq_length
 
@@ -50,7 +59,10 @@ def main(args: DictConfig):
         data_size=args.data_size,
     )
 
-    training_args = TrainingArguments(**args.trainer)
+    training_args = TrainingArguments(
+        **args.trainer,
+        report_to="wandb" if wandb.run is not None else None,
+    )
 
     trainer = Trainer(
         model=model,
@@ -59,7 +71,10 @@ def main(args: DictConfig):
         eval_dataset=eval_dataset,
         compute_metrics=compute_metrics,
         data_collator=data_collator,
-        callbacks=[StopAfterNStepsCallback(args.stop_after_n_steps)],
+        callbacks=[
+            StopAfterNStepsCallback(args.stop_after_n_steps),
+            StepTimingCallback(),
+        ],
     )
 
     logger.info("ACCELERATE STATE:\n%s\n", trainer.accelerator.state)
@@ -78,6 +93,9 @@ def main(args: DictConfig):
 
     if training_args.do_eval:
         trainer.evaluate()
+
+    if wandb.run is not None:
+        wandb.finish()
 
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         torch.distributed.destroy_process_group()

--- a/recipes/amplify_accelerate_te_fp8/train.py
+++ b/recipes/amplify_accelerate_te_fp8/train.py
@@ -38,12 +38,7 @@ def main(args: DictConfig):
     """Entrypoint."""
     # add wandb logging on main process
     if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
-        wandb.init(
-            project=args.wandb_init_args.project,
-            name=args.wandb_init_args.name,
-            config=OmegaConf.to_container(args, resolve=True, throw_on_missing=True),
-            mode=getattr(args.wandb_init_args, "mode", "online"),
-        )
+        wandb.init(config=OmegaConf.to_container(args, resolve=True, throw_on_missing=True), **args.wandb_init_args)
     config = AutoConfig.from_pretrained(args.model_tag, trust_remote_code=True)
     config.max_length = args.max_seq_length
 

--- a/recipes/amplify_accelerate_te_fp8/train.py
+++ b/recipes/amplify_accelerate_te_fp8/train.py
@@ -20,7 +20,7 @@ import hydra
 import torch
 import transformers
 import wandb
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 from transformers import AutoConfig, AutoModelForMaskedLM
 from transformers.trainer import Trainer
 from transformers.training_args import TrainingArguments

--- a/recipes/amplify_accelerate_te_fp8/train.py
+++ b/recipes/amplify_accelerate_te_fp8/train.py
@@ -25,7 +25,7 @@ from transformers import AutoConfig, AutoModelForMaskedLM
 from transformers.trainer import Trainer
 from transformers.training_args import TrainingArguments
 
-from callbacks import StopAfterNStepsCallback, StepTimingCallback
+from callbacks import StepTimingCallback, StopAfterNStepsCallback
 from dataset import create_datasets_and_collator
 from metrics import compute_metrics
 
@@ -42,7 +42,7 @@ def main(args: DictConfig):
             project=args.wandb_init_args.project,
             name=args.wandb_init_args.name,
             config=OmegaConf.to_container(args, resolve=True, throw_on_missing=True),
-            mode=getattr(args.wandb_init_args, 'mode', 'online'),
+            mode=getattr(args.wandb_init_args, "mode", "online"),
         )
     config = AutoConfig.from_pretrained(args.model_tag, trust_remote_code=True)
     config.max_length = args.max_seq_length
@@ -59,10 +59,7 @@ def main(args: DictConfig):
         data_size=args.data_size,
     )
 
-    training_args = TrainingArguments(
-        **args.trainer,
-        report_to="wandb" if wandb.run is not None else None,
-    )
+    training_args = TrainingArguments(**args.trainer)
 
     trainer = Trainer(
         model=model,


### PR DESCRIPTION
Add wandb logging to recipe amplify model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Weights & Biases logging with configurable project, run name, and mode.
  * Trainer reports metrics to Weights & Biases when enabled.
  * Added per-step timing metric ("train/step_time") to training logs for performance visibility.

* **Chores**
  * Added configuration presets for Weights & Biases initialization.
  * Ensured proper startup/shutdown of experiment tracking in distributed runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->