### PR TITLE
Add wandb logic to recipes esm2_accelerate

### DIFF
--- a/recipes/esm2_accelerate/callbacks.py
+++ b/recipes/esm2_accelerate/callbacks.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 from transformers.trainer_callback import TrainerCallback, TrainerControl, TrainerState
 from transformers.training_args import TrainingArguments
 
@@ -32,3 +34,22 @@ class StopAfterNStepsCallback(TrainerCallback):
         """Interrupt training after a specified number of steps."""
         if state.global_step >= self.max_steps:
             control.should_training_stop = True
+
+
+class StepTimingCallback(TrainerCallback):
+    """Callback to log the time taken for each step."""
+
+    def __init__(self):
+        """Initialize the callback."""
+        self.step_start_time = None
+
+    def on_step_begin(self, args, state, control, **kwargs):
+        """Called at the beginning of each training step."""
+        self.step_start_time = time.perf_counter()
+
+    def on_log(self, args, state, control, logs=None, **kwargs):
+        """Called when metrics are logged."""
+        if self.step_start_time is not None and logs is not None:
+            current_time = time.perf_counter()
+            step_time = current_time - self.step_start_time
+            logs["train/step_time"] = step_time

--- a/recipes/esm2_accelerate/hydra_config/L0_sanity.yaml
+++ b/recipes/esm2_accelerate/hydra_config/L0_sanity.yaml
@@ -12,3 +12,8 @@ trainer:
   logging_steps: 1
   report_to: "none"
   dataloader_num_workers: 0
+
+wandb_init_args: # These arguments are for managing the weights and biases experiment.
+  name: "L0_sanity" # this setting defines the name of the experiment
+  project: "bionemo-recipes-esm2_accelerate" # this setting defines the project name
+  mode: "online"

--- a/recipes/esm2_accelerate/train.py
+++ b/recipes/esm2_accelerate/train.py
@@ -38,12 +38,7 @@ def main(args: DictConfig):
     """Entrypoint."""
     # add wandb logging on main process
     if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
-        wandb.init(
-            project=args.wandb_init_args.project,
-            name=args.wandb_init_args.name,
-            config=OmegaConf.to_container(args, resolve=True, throw_on_missing=True),
-            mode=getattr(args.wandb_init_args, "mode", "online"),
-        )
+        wandb.init(config=OmegaConf.to_container(args, resolve=True, throw_on_missing=True), **args.wandb_init_args)
     config = AutoConfig.from_pretrained(args.model_tag, trust_remote_code=True)
     config.max_seq_length = args.max_seq_length
     config.micro_batch_size = args.trainer.per_device_train_batch_size


### PR DESCRIPTION
Add wandb logic to esm2_accelerate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Integrated Weights & Biases experiment tracking with configurable run settings.
  - Added automatic logging of training step duration (train/step_time) for performance monitoring.

- Chores
  - Updated the L0_sanity configuration to include default Weights & Biases project, run name, and mode.
  - Ensured clean shutdown of tracking and distributed processes after training to avoid lingering runs or sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->