### PR TITLE
nit: fix amplify config

### DIFF
--- a/recipes/esm2_accelerate/hydra_config/L0_sanity_amplify.yaml
+++ b/recipes/esm2_accelerate/hydra_config/L0_sanity_amplify.yaml
@@ -1,5 +1,5 @@
 defaults:
-  - defaults
+  - defaults_amplify
   - _self_
 
 model_tag: "nvidia/AMPLIFY_120M"


### PR DESCRIPTION
Update amplify L0 test config to use the amplify LR schedule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the default configuration for the ESM2 Accelerate recipe to use the amplify profile, so runs without overrides will now pick up the amplify defaults.
  - Other parameters (training steps, dataset, trainer) remain unchanged aside from the selected defaults profile.
  - This change is limited to the ESM2 Accelerate recipe and does not affect other recipes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->