### PR TITLE
switch to 25.08 for unit tests

### DIFF
--- a/.devcontainer/recipes/Dockerfile
+++ b/.devcontainer/recipes/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:25.06-py3
+FROM nvcr.io/nvidia/pytorch:25.08-py3
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/workspace/requirements.txt \
     PIP_CONSTRAINT= pip install -r /workspace/requirements.txt

--- a/.github/workflows/unit-tests-recipes.yml
+++ b/.github/workflows/unit-tests-recipes.yml
@@ -93,8 +93,8 @@ jobs:
           # Currently, AMPLIFY is the only folder that needs a custom base image, since we have to support both TE and
           # xformers-based models for golden value testing. The rest of the models use the default pytorch image.
 
-          # This uses a squashed version of the pytorch:25.06-py3 image, generated with `docker-squash
-          # nvcr.io/nvidia/pytorch:25.06-py3 -t svcbionemo023/bionemo-framework:pytorch25.06-py3-squashed --output
+          # This uses a squashed version of the pytorch:25.08-py3 image, generated with `docker-squash
+          # nvcr.io/nvidia/pytorch:25.08-py3 -t svcbionemo023/bionemo-framework:pytorch25.08-py3-squashed --output
           # type=registry,compression=zstd,force-compression=true,oci-mediatypes=true,compression-level=15` and pushed
           # to the dockerhub registry. Our github actions are able to cache image pulls from dockerhub but not nvcr, so
           # hopefully this cuts down slightly on CI time at the expense of having a slightly in-directed image location.
@@ -107,8 +107,8 @@ jobs:
                 if . == "bionemo-recipes/models/amplify" then
                   "svcbionemo023/bionemo-framework:amplify-model-devcontainer-082025"
                 else
-                  "nvcr.io/nvidia/pytorch:25.08-py3"
-                  # "svcbionemo023/bionemo-framework:pytorch25.06-py3-squashed-zstd"
+                  # "nvcr.io/nvidia/pytorch:25.08-py3"
+                  "svcbionemo023/bionemo-framework:pytorch25.08-py3-squashed-zstd"
                 end
               )
             })

--- a/.github/workflows/unit-tests-recipes.yml
+++ b/.github/workflows/unit-tests-recipes.yml
@@ -107,7 +107,8 @@ jobs:
                 if . == "bionemo-recipes/models/amplify" then
                   "svcbionemo023/bionemo-framework:amplify-model-devcontainer-082025"
                 else
-                  "svcbionemo023/bionemo-framework:pytorch25.06-py3-squashed-zstd"
+                  "nvcr.io/nvidia/pytorch:25.08-py3"
+                  # "svcbionemo023/bionemo-framework:pytorch25.06-py3-squashed-zstd"
                 end
               )
             })

--- a/bionemo-recipes/models/esm2/Dockerfile
+++ b/bionemo-recipes/models/esm2/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:25.06-py3
+FROM nvcr.io/nvidia/pytorch:25.08-py3
 WORKDIR /workspace/bionemo
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/bionemo-recipes/recipes/README.md
+++ b/bionemo-recipes/recipes/README.md
@@ -86,7 +86,7 @@ recipes/{recipe_name}/
 Your `Dockerfile` should create a complete, reproducible training environment:
 
 ```dockerfile
-FROM nvcr.io/nvidia/pytorch:25.06-py3
+FROM nvcr.io/nvidia/pytorch:25.08-py3
 
 # Install dependencies with caching for faster builds
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/bionemo-recipes/recipes/amplify_accelerate_te_fp8/Dockerfile
+++ b/bionemo-recipes/recipes/amplify_accelerate_te_fp8/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:25.06-py3
+FROM nvcr.io/nvidia/pytorch:25.08-py3
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/bionemo-recipes/recipes/esm2_accelerate_te/Dockerfile
+++ b/bionemo-recipes/recipes/esm2_accelerate_te/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:25.06-py3
+FROM nvcr.io/nvidia/pytorch:25.08-py3
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/bionemo-recipes/recipes/esm2_native_te/Dockerfile
+++ b/bionemo-recipes/recipes/esm2_native_te/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:25.06-py3
+FROM nvcr.io/nvidia/pytorch:25.08-py3
 
 RUN --mount=type=secret,id=netrc,target=/root/.netrc \
     --mount=type=cache,target=/root/.cache/pip \

--- a/bionemo-recipes/recipes/esm2_native_te_mfsdp_thd/Dockerfile
+++ b/bionemo-recipes/recipes/esm2_native_te_mfsdp_thd/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-# FROM nvcr.io/nvidia/pytorch:25.06-py3
+# FROM nvcr.io/nvidia/pytorch:25.08-py3
 FROM gitlab-master.nvidia.com:5005/dl/transformerengine/transformerengine:te_ci-pytorch-py3-devel
 
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/bionemo-recipes/recipes/geneformer_native_te_mfsdp_fp8/Dockerfile
+++ b/bionemo-recipes/recipes/geneformer_native_te_mfsdp_fp8/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:25.06-py3
+FROM nvcr.io/nvidia/pytorch:25.08-py3
 
 RUN apt-get update && apt-get install -y git
 

--- a/bionemo-recipes/recipes/vit/Dockerfile
+++ b/bionemo-recipes/recipes/vit/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:25.06-py3
+FROM nvcr.io/nvidia/pytorch:25.08-py3
 
 RUN --mount=type=secret,id=netrc,target=/root/.netrc \
     --mount=type=cache,target=/root/.cache/pip \

--- a/ci/scripts/recipes_local_test.py
+++ b/ci/scripts/recipes_local_test.py
@@ -48,14 +48,14 @@ CUSTOM_CONTAINERS = {
     "models/amplify": "svcbionemo023/bionemo-framework:amplify-model-devcontainer-082025",
 }
 
-# DEFAULT_CONTAINER = "nvcr.io/nvidia/pytorch:25.06-py3"
+# DEFAULT_CONTAINER = "nvcr.io/nvidia/pytorch:25.08-py3"
 
-# This is a squashed version of the pytorch:25.06-py3 image, generated with
-# docker-squash nvcr.io/nvidia/pytorch:25.06-py3 -t svcbionemo023/bionemo-framework:pytorch25.06-py3-squashed
+# This is a squashed version of the pytorch:25.08-py3 image, generated with
+# docker-squash nvcr.io/nvidia/pytorch:25.08-py3 -t svcbionemo023/bionemo-framework:pytorch25.08-py3-squashed
 # --output type=registry,compression=zstd,force-compression=true,oci-mediatypes=true,compression-level=15
 # and pushed to the dockerhub registry. Our github actions are able to cache image pulls from dockerhub but not nvcr, so
 # hopefully this cuts down slightly on CI time at the expense of having a slightly in-directed image location.
-DEFAULT_CONTAINER = "svcbionemo023/bionemo-framework:pytorch25.06-py3-squashed"
+DEFAULT_CONTAINER = "svcbionemo023/bionemo-framework:pytorch25.08-py3-squashed"
 
 
 def get_git_root() -> str:


### PR DESCRIPTION
Updates bionemo-recipes to use the pytorch 25.08 base image, including pushing a squashed version to our dockerhub for faster image pulls in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated CI unit-test environment for non-amplify recipes to use a newer PyTorch container, aligning with upstream images and improving reliability.
  - Refreshed base images for select recipe Dockerfiles (ESM2 accelerate/native TE and ViT) to the latest PyTorch tag for better compatibility with recent dependencies.
  - Updated local testing defaults to the newer container image for consistency across CI and local runs.
  - No impact on application behavior; changes are limited to build/test infrastructure. Expect more predictable and potentially faster builds/tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->