### PR TITLE
add mxfp8 padding and tests for esm-2

### DIFF
--- a/bionemo-recipes/models/esm2/src/esm/collator.py
+++ b/bionemo-recipes/models/esm2/src/esm/collator.py
@@ -18,6 +18,7 @@
 This should eventually get moved to a separate package, or possibly upstreamed into `transformers`.
 """
 
+import logging
 from dataclasses import dataclass
 from typing import Any
 
@@ -25,28 +26,45 @@ import torch
 from transformers import DataCollatorForLanguageModeling, DefaultDataCollator, PreTrainedTokenizerBase
 
 
+logger = logging.getLogger(__name__)
+
+
 class MLMDataCollatorWithFlattening:
-    """Combines a DataCollatorForLanguageModeling and a DataCollatorWithFlattening.
+    """Data collator that combines MLM masking with sequence packing for Flash Attention.
 
     This data collator enables efficient training on variable-length sequences by:
-    1. First flattening multiple sequences into a single packed tensor (no padding)
+    1. First flattening multiple sequences into a single packed tensor (no padding between sequences)
     2. Then applying MLM masking to the flattened sequence
-    3. Providing Flash Attention metadata (cu_seq_lens) for sequence boundary awareness.
-        Note. cu_seq_lens stands for cumulative sequence lengths.
+    3. Providing Flash Attention metadata (cu_seq_lens) for sequence boundary awareness
+    4. Optionally padding the total sequence length to be divisible by a specified number
 
     The result is a THD-format batch optimized for Flash Attention with sequence packing,
     eliminating the need for traditional attention masks while maintaining proper sequence
     boundaries during attention computation.
 
-    Attributes:
-        mlm_collator (DataCollatorForLanguageModeling): Handles MLM token masking.
-        flattening_collator (DataCollatorWithFlattening): Handles sequence packing and
-            Flash Attention metadata generation.
+    **Padding to Multiple**: When `pad_to_multiple_of` is specified, the collator ensures
+    that the total number of tokens across all sequences is divisible by the given number.
+    This is accomplished by appending a mock sequence to the end of the packed batch with
+    padding tokens and corresponding labels set to -100. This feature is useful for
+    optimizing memory alignment and computational efficiency on specific hardware.
+
+    **Tensor Support**: Currently only supports PyTorch tensors (return_tensors="pt").
+    Other tensor formats are not implemented.
+
+    Args:
+        tokenizer (PreTrainedTokenizerBase): The tokenizer to use for masking tokens.
+        mlm (bool): Whether to use masked language modeling. Defaults to True.
+        mlm_probability (float | None): Probability of masking tokens. Defaults to 0.15.
+        mask_replace_prob (float): Probability of replacing masked tokens with [MASK]. Defaults to 0.8.
+        random_replace_prob (float): Probability of replacing masked tokens with random tokens. Defaults to 0.1.
+        tf_experimental_compile (bool): Whether to use TensorFlow experimental compilation. Defaults to False.
+        return_tensors (str): Format for returned tensors. Only "pt" (PyTorch) is supported. Defaults to "pt".
+        seed (int | None): Random seed for reproducible masking. Defaults to None.
+        pad_to_multiple_of (int | None): If set, pads the total sequence length to be divisible
+            by this number by adding a mock sequence at the end. Defaults to None.
 
     Example:
-        >>> from transformers import AutoTokenizer, DataCollatorForLanguageModeling
-        >>> from transformers.data.data_collator import DataCollatorWithFlattening
-        >>>
+        >>> from transformers import AutoTokenizer
         >>> tokenizer = AutoTokenizer.from_pretrained("facebook/esm2_t6_8M_UR50D")
         >>>
         >>> # Input: Variable-length protein sequences
@@ -54,30 +72,30 @@ class MLMDataCollatorWithFlattening:
         ...     {"input_ids": [0, 5, 6, 7, 2]},      # CLS + amino acids + EOS (5 tokens)
         ...     {"input_ids": [0, 8, 9, 10, 11, 2]}, # CLS + amino acids + EOS (6 tokens)
         ...     {"input_ids": [0, 12, 13, 2]},       # CLS + amino acids + EOS (4 tokens)
-        ... ]
+        ... ]  # Total: 15 tokens
         >>>
-        >>> # Create the collator
+        >>> # Create collator with padding to multiple of 8
         >>> collator = MLMDataCollatorWithFlattening(
         ...     tokenizer=tokenizer,
         ...     mlm_probability=0.15,
+        ...     pad_to_multiple_of=8,  # Pad 15 -> 16 tokens
+        ...     seed=42
         ... )
         >>>
         >>> # Process batch
         >>> batch = collator(sequences)
         >>>
-        >>> # Output: Flattened and masked sequences
-        >>> print(batch['input_ids'])
-        >>> # tensor([[ 0,  5,  6,  7,  2,  0,  8,  9, 10, 11,  2,  0, 12, 16,  2]])
-        >>> #                                                      ↑ masked token
-        >>>
-        >>> print(batch['labels'])
-        >>> # tensor([[-100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, 13, -100]])
-        >>> #                                                                                        ↑ original token
-        >>>
-        >>> print(batch['cu_seq_lens_q'])
-        >>> # tensor([ 0,  5, 11, 15], dtype=torch.int32)  # Sequence boundaries: [0:5], [5:11], [11:15]
-        >>>
-        >>> # Ready for Flash Attention without attention masks!
+        >>> # Output: Flattened, masked, and padded sequences
+        >>> print(batch['input_ids'].shape)    # torch.Size([1, 16])
+        >>> print(batch['labels'].shape)       # torch.Size([1, 16])
+        >>> print(batch['cu_seq_lens_q'])      # tensor([0, 5, 11, 15, 16], dtype=torch.int32)
+        >>>                                    # Note: Extra entry for mock padding sequence
+        >>> # Ready for Flash Attention without traditional attention masks!
+
+    Note:
+        The output is in THD (Total, Height, Depth) format with batch_size=1 and
+        sequence_length=total_tokens, optimized for Flash Attention's variable-length
+        sequence processing capabilities.
     """
 
     def __init__(
@@ -88,34 +106,45 @@ class MLMDataCollatorWithFlattening:
         mlm_probability: float | None = 0.15,
         mask_replace_prob: float = 0.8,
         random_replace_prob: float = 0.1,
-        pad_to_multiple_of: int | None = None,
-        label_pad: int = -100,
         tf_experimental_compile: bool = False,
         return_tensors: str = "pt",
         seed: int | None = None,
+        pad_to_multiple_of: int | None = None,
     ):
-        """Initialize the MLMDataCollatorWithFlattening."""
+        """Initialize the MLMDataCollatorWithFlattening.
+
+        Args:
+            tokenizer (PreTrainedTokenizerBase): The tokenizer to use for masking tokens.
+            mlm (bool): Whether to use masked language modeling. Defaults to True.
+            mlm_probability (float | None): Probability of masking tokens. Defaults to 0.15.
+            mask_replace_prob (float): Probability of replacing masked tokens with [MASK]. Defaults to 0.8.
+            random_replace_prob (float): Probability of replacing masked tokens with random tokens. Defaults to 0.1.
+            tf_experimental_compile (bool): Whether to use TensorFlow experimental compilation. Defaults to False.
+            return_tensors (str): Format for returned tensors. Only "pt" (PyTorch) is supported. Defaults to "pt".
+            seed (int | None): Random seed for reproducible masking. Defaults to None.
+            pad_to_multiple_of (int | None): If set, pads the total sequence length to be divisible
+                by this number by adding a mock sequence at the end. Defaults to None.
+        """
         self.mlm_collator = DataCollatorForLanguageModeling(
             tokenizer=tokenizer,
             mlm=mlm,
             mlm_probability=mlm_probability,
             mask_replace_prob=mask_replace_prob,
             random_replace_prob=random_replace_prob,
-            pad_to_multiple_of=pad_to_multiple_of,
             tf_experimental_compile=tf_experimental_compile,
             return_tensors=return_tensors,
             seed=seed,
         )
         self.return_tensors = return_tensors
         self.pad_to_multiple_of = pad_to_multiple_of
-        self.label_pad = label_pad
 
     def __call__(self, features, return_tensors=None):
         """Process a batch of variable-length sequences for Flash Attention with MLM.
 
-        This method performs a two-step process:
+        This method performs the following steps:
         1. Flattens multiple sequences into a single packed tensor with Flash Attention metadata
         2. Applies MLM masking to the flattened sequence while preserving special tokens
+        3. Optionally pads to a multiple of a specified number for hardware optimization
 
         Args:
             features (List[Dict[str, List[int]]]): List of tokenized sequences, each containing
@@ -125,45 +154,48 @@ class MLMDataCollatorWithFlattening:
                     {"input_ids": [0, 8, 9, 10, 11, 2]}, # Protein sequence 2
                     {"input_ids": [0, 12, 13, 2]}        # Protein sequence 3
                 ]
-            return_tensors (str, optional): Format for returned tensors ('pt' for PyTorch).
-                Defaults to None (uses collator default).
+            return_tensors (str, optional): Format for returned tensors. Only "pt" (PyTorch)
+                is supported. Defaults to None (uses collator default).
 
         Returns:
             Dict[str, torch.Tensor]: Batch dictionary containing:
                 - input_ids (torch.Tensor): Flattened and MLM-masked token sequences.
-                  Shape: [1, total_tokens] where total_tokens = sum of all sequence lengths.
+                  Shape: [1, total_tokens] where total_tokens = sum of all sequence lengths
+                  (plus padding if pad_to_multiple_of is specified).
                 - labels (torch.Tensor): MLM labels with -100 for non-masked tokens and
                   original token IDs for masked positions. Same shape as input_ids.
-                - position_ids (torch.Tensor): Position indices that reset at sequence boundaries.
-                  Shape: [1, total_tokens].
                 - cu_seq_lens_q (torch.IntTensor): Cumulative sequence lengths for queries.
-                  Shape: [num_sequences + 1]. Example: [0, 5, 11, 15].
+                  Shape: [num_sequences + 1] or [num_sequences + 2] if padding is added.
+                  Example: [0, 5, 11, 15] or [0, 5, 11, 15, 16] with padding.
                 - cu_seq_lens_k (torch.IntTensor): Cumulative sequence lengths for keys.
                   Same as cu_seq_lens_q for self-attention.
                 - max_length_q (int): Maximum sequence length in the batch.
                 - max_length_k (int): Same as max_length_q for self-attention.
+                - attention_mask (torch.Tensor): Attention mask with 1s for actual tokens
+                  and 0s for padding tokens (if any).
+
+        Raises:
+            NotImplementedError: If return_tensors is not "pt".
 
         Example:
             >>> # Input features
             >>> features = [
             ...     {"input_ids": [0, 5, 6, 7, 2]},      # 5 tokens
             ...     {"input_ids": [0, 8, 9, 10, 11, 2]}, # 6 tokens
-            ...     {"input_ids": [0, 12, 13, 2]}        # 4 tokens
             ... ]
             >>>
             >>> batch = collator(features)
             >>>
             >>> # Output shapes and values
-            >>> batch['input_ids'].shape          # torch.Size([1, 15])
-            >>> batch['labels'].shape             # torch.Size([1, 15])
-            >>> batch['cu_seq_lens_q']            # tensor([0, 5, 11, 15], dtype=torch.int32)
-            >>>
-            >>> # Flash Attention can now process this without attention masks!
+            >>> batch['input_ids'].shape          # torch.Size([1, 11]) or larger if padded
+            >>> batch['labels'].shape             # torch.Size([1, 11]) or larger if padded
+            >>> batch['cu_seq_lens_q']            # tensor([0, 5, 11], dtype=torch.int32) or larger
 
         Note:
             The output is in THD (Total, Height, Depth) format with batch_size=1 and
             sequence_length=total_tokens, optimized for Flash Attention's variable-length
-            sequence processing capabilities.
+            sequence processing capabilities. When pad_to_multiple_of is used, an additional
+            mock sequence is appended to reach the desired total length.
         """
         if return_tensors is None:
             return_tensors = self.return_tensors
@@ -179,11 +211,17 @@ class MLMDataCollatorWithFlattening:
         )
 
         if self.pad_to_multiple_of is not None:
+            # Ensure token_pad is an integer, defaulting to 1 if pad_token_id is None or invalid
+            pad_token_id = self.mlm_collator.tokenizer.pad_token_id
+            if not isinstance(pad_token_id, int):
+                logger.warning(f"tokenizer.pad_token_id is not an integer, using 1 instead: {pad_token_id}")
+                pad_token_id = 1
+
             batch = _pt_pad_to_multiple_of(
                 batch,
                 self.pad_to_multiple_of,
-                token_pad=self.mlm_collator.tokenizer.pad_token_id,
-                label_pad=self.label_pad,
+                token_pad=pad_token_id,
+                label_pad=-100,
             )
 
         return batch
@@ -199,9 +237,10 @@ class DataCollatorWithFlattening(DefaultDataCollator):
     pad_to_multiple_of: int | None = None
     token_pad: int = 1
     label_pad: int = -100
+    return_tensors: str = "pt"
 
     def __call__(self, features: list[dict[str, list[int]]], return_tensors: str | None = None) -> dict[str, Any]:
-        """Collate a batch of variable-length sequences for Flash Attention with MLM.
+        """Collate a batch of variable-length sequences for Flash Attention with sequence packing.
 
         Args:
             features: List of tokenized sequences, each containing 'input_ids' and optionally 'labels'.
@@ -219,7 +258,11 @@ class DataCollatorWithFlattening(DefaultDataCollator):
                   Same as cu_seq_lens_q for self-attention.
                 - max_length_q (int): Maximum sequence length in the batch.
                 - max_length_k (int): Same as max_length_q for self-attention.
+                - attention_mask (torch.Tensor): Attention mask with 1s for non-padding tokens and 0s for padding tokens.
         """
+        if not features:
+            raise ValueError("features must be a non-empty list")
+
         if return_tensors is None:
             return_tensors = self.return_tensors
 
@@ -250,7 +293,7 @@ def _pt_flatten_collate(features: list[dict[str, list[int]]]):
     batch["cu_seq_lens_q"] = batch["cu_seq_lens_k"] = cu_seq_lens
     if "attention_mask" in features[0]:
         batch["attention_mask"] = torch.tensor(
-            [[attention_mask for sample in features for attention_mask in sample["attention_mask"]]], dtype=torch.int64
+            [[v for sample in features for v in sample["attention_mask"]]], dtype=torch.int64
         )
     return batch
 

--- a/bionemo-recipes/models/esm2/src/esm/collator.py
+++ b/bionemo-recipes/models/esm2/src/esm/collator.py
@@ -100,7 +100,6 @@ class MLMDataCollatorWithFlattening:
 
     def __init__(
         self,
-        # DataCollatorForLanguageModeling
         tokenizer: PreTrainedTokenizerBase,
         mlm: bool = True,
         mlm_probability: float | None = 0.15,

--- a/bionemo-recipes/models/esm2/tests/conftest.py
+++ b/bionemo-recipes/models/esm2/tests/conftest.py
@@ -19,9 +19,10 @@ import pytest
 import torch
 from datasets import Dataset
 from torch.utils.data import DataLoader
-from transformers import AutoTokenizer, DataCollatorForLanguageModeling
+from transformers import AutoModelForMaskedLM, AutoTokenizer, DataCollatorForLanguageModeling
 
 from esm.collator import MLMDataCollatorWithFlattening
+from esm.convert import convert_esm_hf_to_te
 
 
 # Fix Triton UTF-8 decoding issue by setting CUDA library path
@@ -119,3 +120,11 @@ def input_data(tokenizer, bshd_data_collator):
 @pytest.fixture
 def input_data_thd(tokenizer, thd_data_collator):
     return get_input_data(tokenizer, thd_data_collator)
+
+
+@pytest.fixture
+def te_model_checkpoint(tmp_path):
+    model_hf = AutoModelForMaskedLM.from_pretrained("facebook/esm2_t6_8M_UR50D")
+    model_te = convert_esm_hf_to_te(model_hf)
+    model_te.save_pretrained(tmp_path / "te_model_checkpoint")
+    return tmp_path / "te_model_checkpoint"

--- a/bionemo-recipes/models/esm2/tests/conftest.py
+++ b/bionemo-recipes/models/esm2/tests/conftest.py
@@ -58,16 +58,13 @@ def thd_data_collator(tokenizer):
     return MLMDataCollatorWithFlattening(
         tokenizer=tokenizer,
         mlm_probability=0.15,
-        pad_to_multiple_of=1024,
-        return_flash_attn_kwargs=True,
+        pad_to_multiple_of=8,
         seed=42,
     )
 
 
-def get_input_data(tokenizer, data_collator):
-    torch.manual_seed(42)
-
-    test_proteins = [
+def get_test_proteins():
+    return [
         "MLSATEKLSDYISSLFASVSIINSISTEDLFFLKLTCQTFSKDSEEYKAAYRILRGVQRGKVQIIEEALVS",
         "MFVFFAGTLVNQDTLNFRDQLNINVVGTVRGIAQDASKYLEYAIDSV",
         "MAATGSLILSDEEQAELIALAVRIVLACAGGSQNKELAAQLGVIETTVGEWRRRFAQNRVEGLRDEARPGAPSDDQ",
@@ -85,15 +82,22 @@ def get_input_data(tokenizer, data_collator):
         "MQILILPIPDQLQNPNKISQHLICITFVSEQTLPI",
     ]
 
-    dataset = Dataset.from_list([{"sequence": p} for p in test_proteins])
+
+@pytest.fixture
+def test_proteins():
+    return get_test_proteins()
+
+
+def get_input_data(tokenizer, data_collator):
+    torch.manual_seed(42)
+
+    dataset = Dataset.from_list([{"sequence": p} for p in get_test_proteins()])
 
     def tokenize_function(examples):
         return tokenizer(
             examples["sequence"],
             truncation=True,
-            padding="max_length",
             max_length=1024,
-            return_tensors="pt",
         )
 
     tokenized_proteins = dataset.map(

--- a/bionemo-recipes/models/esm2/tests/test_collator.py
+++ b/bionemo-recipes/models/esm2/tests/test_collator.py
@@ -1,0 +1,311 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from esm.collator import DataCollatorWithFlattening, MLMDataCollatorWithFlattening
+
+
+def test_data_collator_with_flattening_basic():
+    """Test DataCollatorWithFlattening with input_ids and attention_mask."""
+    collator = DataCollatorWithFlattening()
+
+    # Create test sequences of different lengths
+    features = [
+        {"input_ids": [0, 5, 6, 7, 2]},  # 5 tokens
+        {"input_ids": [0, 8, 9, 10, 11, 2]},  # 6 tokens
+        {"input_ids": [0, 12, 13, 2]},  # 4 tokens
+    ]
+
+    # Calculate expected total tokens
+    total_tokens = sum(len(feature["input_ids"]) for feature in features)
+
+    # Process batch
+    batch = collator(features, return_tensors="pt")
+
+    # Assert total number of tokens is unchanged
+    input_ids_tensor = batch["input_ids"]
+    assert input_ids_tensor.numel() == total_tokens, f"Expected {total_tokens} tokens, got {input_ids_tensor.numel()}"
+
+    # Assert output shape is [1, total_tokens]
+    assert input_ids_tensor.shape == (1, total_tokens), (
+        f"Expected shape (1, {total_tokens}), got {input_ids_tensor.shape}"
+    )
+
+    # Assert cu_seqlens_q tensor is created properly
+    expected_cu_seqlens = torch.tensor([0, 5, 11, 15], dtype=torch.int32)
+    torch.testing.assert_close(batch["cu_seq_lens_q"], expected_cu_seqlens)
+    torch.testing.assert_close(batch["cu_seq_lens_k"], expected_cu_seqlens)
+
+    # Assert max_length values are correct
+    assert batch["max_length_q"] == 6, f"Expected max_length_q=6, got {batch['max_length_q']}"
+    assert batch["max_length_k"] == 6, f"Expected max_length_k=6, got {batch['max_length_k']}"
+
+    # Assert flattened input_ids matches concatenated original sequences
+    expected_input_ids = torch.tensor([[0, 5, 6, 7, 2, 0, 8, 9, 10, 11, 2, 0, 12, 13, 2]], dtype=torch.int64)
+    torch.testing.assert_close(input_ids_tensor, expected_input_ids)
+
+    # Assert labels are not present when not provided in input
+    assert "labels" not in batch
+
+
+def test_data_collator_with_flattening_with_labels():
+    """Test DataCollatorWithFlattening with input_ids, attention_mask, and labels."""
+    collator = DataCollatorWithFlattening()
+
+    # Create test sequences with labels
+    features = [
+        {"input_ids": [0, 5, 6, 7, 2], "labels": [0, 5, 6, 7, 2]},  # 5 tokens
+        {"input_ids": [0, 8, 9, 10, 11, 2], "labels": [0, 8, 9, 10, 11, 2]},  # 6 tokens
+        {"input_ids": [0, 12, 13, 2], "labels": [0, 12, 13, 2]},  # 4 tokens
+    ]
+
+    # Calculate expected total tokens
+    total_tokens = sum(len(feature["input_ids"]) for feature in features)
+
+    # Process batch
+    batch = collator(features, return_tensors="pt")
+
+    # Assert total number of tokens is unchanged
+    input_ids_tensor = batch["input_ids"]
+    labels_tensor = batch["labels"]
+    assert input_ids_tensor.numel() == total_tokens, f"Expected {total_tokens} tokens, got {input_ids_tensor.numel()}"
+    assert labels_tensor.numel() == total_tokens, f"Expected {total_tokens} label tokens, got {labels_tensor.numel()}"
+
+    # Assert output shapes are [1, total_tokens]
+    assert input_ids_tensor.shape == (1, total_tokens), (
+        f"Expected input_ids shape (1, {total_tokens}), got {input_ids_tensor.shape}"
+    )
+    assert labels_tensor.shape == (1, total_tokens), (
+        f"Expected labels shape (1, {total_tokens}), got {labels_tensor.shape}"
+    )
+
+    # Assert cu_seqlens_q tensor is created properly
+    expected_cu_seqlens = torch.tensor([0, 5, 11, 15], dtype=torch.int32)
+    torch.testing.assert_close(batch["cu_seq_lens_q"], expected_cu_seqlens)
+    torch.testing.assert_close(batch["cu_seq_lens_k"], expected_cu_seqlens)
+
+    # Assert max_length values are correct
+    assert batch["max_length_q"] == 6, f"Expected max_length_q=6, got {batch['max_length_q']}"
+    assert batch["max_length_k"] == 6, f"Expected max_length_k=6, got {batch['max_length_k']}"
+
+    # Assert flattened input_ids and labels match concatenated original sequences
+    expected_input_ids = torch.tensor([[0, 5, 6, 7, 2, 0, 8, 9, 10, 11, 2, 0, 12, 13, 2]], dtype=torch.int64)
+    expected_labels = torch.tensor([[0, 5, 6, 7, 2, 0, 8, 9, 10, 11, 2, 0, 12, 13, 2]], dtype=torch.int64)
+
+    torch.testing.assert_close(input_ids_tensor, expected_input_ids)
+    torch.testing.assert_close(labels_tensor, expected_labels)
+
+    # Assert that sequence boundaries are properly maintained
+    # by checking that token positions match expected values
+    seq_lens = [5, 6, 4]  # lengths of the three sequences
+    start_idx = 0
+    for i, seq_len in enumerate(seq_lens):
+        end_idx = start_idx + seq_len
+        # Check that the sequence in the flattened tensor matches original
+        original_seq = torch.tensor(features[i]["input_ids"], dtype=torch.int64)
+        flattened_seq = input_ids_tensor[0, start_idx:end_idx]
+        torch.testing.assert_close(flattened_seq, original_seq)
+        start_idx = end_idx
+
+
+def test_data_collator_pads_to_multiple_of():
+    """Test DataCollatorWithFlattening with input_ids and attention_mask."""
+    collator = DataCollatorWithFlattening(pad_to_multiple_of=8, token_pad=1, label_pad=-100)
+
+    # Create test sequences with labels
+    features = [
+        {"input_ids": [0, 5, 6, 7, 2]},  # 5 tokens
+        {"input_ids": [0, 8, 9, 10, 11, 2]},  # 6 tokens
+        {"input_ids": [0, 12, 13, 2]},  # 4 tokens
+    ]
+
+    # Process batch
+    batch = collator(features)
+
+    # Assert total number of tokens is unchanged
+    assert batch["input_ids"].numel() == 16, f"Expected 16 tokens, got {batch['input_ids'].numel()}"
+
+    # Assert output shape is [1, 16]
+    assert batch["input_ids"].shape == (1, 16), f"Expected shape (1, 16), got {batch['input_ids'].shape}"
+
+    # Assert cu_seqlens_q tensor is created properly
+    expected_cu_seqlens = torch.tensor([0, 5, 11, 15, 16], dtype=torch.int32)
+    torch.testing.assert_close(batch["cu_seq_lens_q"], expected_cu_seqlens)
+    torch.testing.assert_close(batch["cu_seq_lens_k"], expected_cu_seqlens)
+
+    # Assert input_ids are padded with 1
+    assert batch["input_ids"][:, -1].item() == 1
+
+
+def test_mlm_data_collator_with_flattening_basic(tokenizer):
+    """Test MLMDataCollatorWithFlattening with basic input_ids and verify labels are created."""
+    collator = MLMDataCollatorWithFlattening(
+        tokenizer=tokenizer,
+        mlm_probability=0.15,
+    )
+
+    # Create test sequences of different lengths
+    features = [
+        {"input_ids": [0, 5, 6, 7, 2]},  # CLS + amino acids + EOS (5 tokens)
+        {"input_ids": [0, 8, 9, 10, 11, 2]},  # CLS + amino acids + EOS (6 tokens)
+        {"input_ids": [0, 12, 13, 14, 15, 16, 2]},  # CLS + amino acids + EOS (7 tokens)
+    ]
+
+    # Calculate expected total tokens
+    total_tokens = sum(len(feature["input_ids"]) for feature in features)
+
+    # Process batch
+    batch = collator(features, return_tensors="pt")
+
+    # Assert that input_ids and labels exist and have the same shape
+    assert "input_ids" in batch, "input_ids should be present in batch"
+    assert "labels" in batch, "labels should be present in batch"
+
+    input_ids_tensor = batch["input_ids"]
+    labels_tensor = batch["labels"]
+
+    # Assert both tensors have the same shape
+    assert input_ids_tensor.shape == labels_tensor.shape, (
+        f"input_ids and labels should have same shape, "
+        f"got input_ids: {input_ids_tensor.shape}, labels: {labels_tensor.shape}"
+    )
+
+    # Assert total number of tokens is unchanged
+    assert input_ids_tensor.numel() == total_tokens, f"Expected {total_tokens} tokens, got {input_ids_tensor.numel()}"
+    assert labels_tensor.numel() == total_tokens, f"Expected {total_tokens} label tokens, got {labels_tensor.numel()}"
+
+    # Assert output shape is [1, total_tokens]
+    assert input_ids_tensor.shape == (1, total_tokens), (
+        f"Expected shape (1, {total_tokens}), got {input_ids_tensor.shape}"
+    )
+
+    # Assert cu_seqlens_q tensor is created properly
+    expected_cu_seqlens = torch.tensor([0, 5, 11, 18], dtype=torch.int32)
+    torch.testing.assert_close(batch["cu_seq_lens_q"], expected_cu_seqlens)
+    torch.testing.assert_close(batch["cu_seq_lens_k"], expected_cu_seqlens)
+
+    # Assert max_length values are correct
+    assert batch["max_length_q"] == 7, f"Expected max_length_q=7, got {batch['max_length_q']}"
+    assert batch["max_length_k"] == 7, f"Expected max_length_k=7, got {batch['max_length_k']}"
+
+    # Assert that Flash Attention metadata is present
+    assert "cu_seq_lens_q" in batch, "cu_seq_lens_q should be present for Flash Attention"
+    assert "cu_seq_lens_k" in batch, "cu_seq_lens_k should be present for Flash Attention"
+    assert "max_length_q" in batch, "max_length_q should be present for Flash Attention"
+    assert "max_length_k" in batch, "max_length_k should be present for Flash Attention"
+
+
+def test_mlm_data_collator_with_flattening_masking(tokenizer, test_proteins):
+    """Test MLMDataCollatorWithFlattening with reproducible masking using a seed."""
+    # Use a fixed seed for reproducibility
+    collator = MLMDataCollatorWithFlattening(
+        tokenizer=tokenizer,
+        mlm_probability=0.15,
+        seed=42,
+    )
+
+    features = [tokenizer(protein) for protein in test_proteins]
+
+    # Calculate expected total tokens
+    total_tokens = sum(len(feature["input_ids"]) for feature in features)
+
+    batch = collator(features, return_tensors="pt")
+
+    # Assert shapes match
+    assert batch["input_ids"].shape == batch["labels"].shape
+    assert batch["input_ids"].shape == (1, total_tokens)
+
+    # Create original flattened sequence for comparison
+    original_flattened = torch.tensor(
+        [[token for sample in features for token in sample["input_ids"]]], dtype=torch.int64
+    )
+
+    # Assert that at least one token has been masked (i.e., input differs from original)
+    # Since we have 56 total tokens with 15% masking probability, we should get some masking
+    num_masked_positions = (batch["labels"] != -100).sum().item()
+    assert num_masked_positions > 0, "At least one token should be masked with this much input data"
+
+    # For positions where labels != -100, verify that:
+    # 1. The label contains the original token
+    # 2. The input_ids at that position might be MASK (4), original token, or random token
+    mask_positions = batch["labels"] != -100
+
+    # Check that labels at masked positions contain the original tokens
+    original_tokens_at_mask_positions = original_flattened[mask_positions]
+    labels_at_mask_positions = batch["labels"][mask_positions]
+    torch.testing.assert_close(labels_at_mask_positions, original_tokens_at_mask_positions)
+
+    # Check that non-masked positions have labels = -100
+    non_mask_positions = batch["labels"] == -100
+    assert non_mask_positions.sum() == total_tokens - num_masked_positions
+
+    # Assert that special tokens (CLS=0, EOS=2) are never masked
+    # Find positions of special tokens in the original sequence
+    cls_positions = original_flattened == 0
+    eos_positions = original_flattened == 2
+    special_token_positions = cls_positions | eos_positions
+
+    # Assert that labels at special token positions are -100 (not masked)
+    assert (batch["labels"][special_token_positions] == -100).all(), "Special tokens (CLS, EOS) should never be masked"
+
+    # Assert that the attention mask is all ones
+    assert (batch["attention_mask"] == 1).all()
+
+
+def test_mlm_data_collator_with_flattening_pad_to_multiple_of(tokenizer, test_proteins):
+    """Test MLMDataCollatorWithFlattening with pad_to_multiple_of."""
+
+    total_tokens = sum(len(tokenizer(protein)["input_ids"]) for protein in test_proteins)
+    remainder = -total_tokens % 8
+    assert remainder != 0, "Test assumes we need to pad to reach a multiple of 8"
+
+    collator = MLMDataCollatorWithFlattening(
+        tokenizer=tokenizer,
+        mlm_probability=0.15,
+        pad_to_multiple_of=8,
+    )
+
+    features = [tokenizer(protein) for protein in test_proteins]
+
+    batch = collator(features)
+
+    # Assert total number of tokens is divisible by 8
+    assert batch["input_ids"].numel() % 8 == 0, (
+        f"Expected {batch['input_ids'].numel()} tokens to be divisible by 8, got {batch['input_ids'].numel()}"
+    )
+
+    # Assert output shape is [1, total_tokens]
+    assert batch["input_ids"].shape == (1, batch["input_ids"].numel()), (
+        f"Expected shape (1, {batch['input_ids'].numel()}), got {batch['input_ids'].shape}"
+    )
+
+    # Assert that the last tokens are padding tokens
+    assert (batch["input_ids"][:, -remainder:] == tokenizer.pad_token_id).all()
+
+    # Assert that the last labels are masked
+    assert (batch["labels"][:, -remainder:] == -100).all()
+
+    # cu_seq_lens is usually len(input) + 1, but we also add one for the mock padding sequence.
+    assert len(batch["cu_seq_lens_q"]) == len(test_proteins) + 2
+    assert len(batch["cu_seq_lens_k"]) == len(test_proteins) + 2
+
+    # The remainder must be less than the max length of the sequences
+    assert batch["max_length_q"] == max(len(feature["input_ids"]) for feature in features)
+    assert batch["max_length_k"] == max(len(feature["input_ids"]) for feature in features)
+
+    # Assert that the attention mask is padded with zeros
+    assert (batch["attention_mask"][:, -remainder:] == 0).all()
+    assert (batch["attention_mask"][:, :-remainder] == 1).all()

--- a/bionemo-recipes/models/esm2/tests/test_fp8.py
+++ b/bionemo-recipes/models/esm2/tests/test_fp8.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+import transformer_engine
+from transformer_engine.common.recipe import DelayedScaling, Format, MXFP8BlockScaling
+from transformer_engine.pytorch.fp8 import check_fp8_support, check_mxfp8_support
+
+from esm.modeling_esm_te import NVEsmForMaskedLM
+
+
+def requires_fp8(func):
+    """Decorator to skip tests that require FP8 support."""
+    fp8_available, reason = check_fp8_support()
+    return pytest.mark.skipif(not fp8_available, reason=f"FP8 is not supported on this GPU: {reason}")(func)
+
+
+def requires_mxfp8(func):
+    """Decorator to skip tests that require MXFP8 support."""
+    mxfp8_available, reason = check_mxfp8_support()
+    return pytest.mark.skipif(not mxfp8_available, reason=f"MXFP8 is not supported on this GPU: {reason}")(func)
+
+
+@requires_fp8
+def test_fp8_forward_pass(te_model_checkpoint, input_data):
+    model_te = NVEsmForMaskedLM.from_pretrained(te_model_checkpoint, torch_dtype=torch.bfloat16)
+    model_te.to("cuda")
+    input_data = {k: v.to("cuda") for k, v in input_data.items()}
+
+    outputs = model_te(**input_data)
+
+    fp8_recipe = DelayedScaling(fp8_format=Format.HYBRID, amax_history_len=16, amax_compute_algo="max")
+    with transformer_engine.pytorch.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
+        outputs_fp8 = model_te(**input_data)
+
+    torch.testing.assert_close(outputs.loss, outputs_fp8.loss)
+    # torch.testing.assert_close(outputs.logits, outputs_fp8.logits)
+
+
+@requires_fp8
+def test_fp8_forward_pass_thd(te_model_checkpoint, input_data_thd):
+    model_te = NVEsmForMaskedLM.from_pretrained(
+        te_model_checkpoint, attn_input_format="thd", torch_dtype=torch.bfloat16
+    )
+    model_te.to("cuda")
+    input_data_thd = {k: v.to("cuda") if isinstance(v, torch.Tensor) else v for k, v in input_data_thd.items()}
+
+    outputs = model_te(**input_data_thd)
+
+    fp8_recipe = DelayedScaling(fp8_format=Format.HYBRID, amax_history_len=16, amax_compute_algo="max")
+    with transformer_engine.pytorch.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
+        outputs_fp8 = model_te(**input_data_thd)
+
+    torch.testing.assert_close(outputs.loss, outputs_fp8.loss)
+    # torch.testing.assert_close(outputs.logits, outputs_fp8.logits)
+
+
+@requires_mxfp8
+def test_mxfp8_forward_pass(te_model_checkpoint, input_data):
+    model_te = NVEsmForMaskedLM.from_pretrained(te_model_checkpoint, torch_dtype=torch.bfloat16)
+    model_te.to("cuda")
+    input_data = {k: v.to("cuda") for k, v in input_data.items()}
+
+    outputs = model_te(**input_data)
+
+    mxfp8_recipe = MXFP8BlockScaling(fp8_format=Format.E4M3)
+    with transformer_engine.pytorch.fp8_autocast(enabled=True, fp8_recipe=mxfp8_recipe):
+        outputs_fp8 = model_te(**input_data)
+
+    torch.testing.assert_close(outputs.loss, outputs_fp8.loss)
+    # torch.testing.assert_close(outputs.logits, outputs_fp8.logits)
+
+
+@requires_mxfp8
+def test_mxfp8_forward_pass_thd(te_model_checkpoint, input_data_thd):
+    model_te = NVEsmForMaskedLM.from_pretrained(
+        te_model_checkpoint, attn_input_format="thd", torch_dtype=torch.bfloat16
+    )
+    model_te.to("cuda")
+    input_data_thd = {k: v.to("cuda") if isinstance(v, torch.Tensor) else v for k, v in input_data_thd.items()}
+
+    outputs = model_te(**input_data_thd)
+
+    mxfp8_recipe = MXFP8BlockScaling(fp8_format=Format.E4M3)
+    with transformer_engine.pytorch.fp8_autocast(enabled=True, fp8_recipe=mxfp8_recipe):
+        outputs_fp8 = model_te(**input_data_thd)
+
+    torch.testing.assert_close(outputs.loss, outputs_fp8.loss)
+    # torch.testing.assert_close(outputs.logits, outputs_fp8.logits)

--- a/bionemo-recipes/models/esm2/tests/test_thd_inputs.py
+++ b/bionemo-recipes/models/esm2/tests/test_thd_inputs.py
@@ -32,7 +32,7 @@ def test_thd_from_collator_output(te_model_checkpoint, input_data_thd):
     assert outputs.loss < 3.0
 
 
-def test_thd_values_match(te_model_checkpoint, tokenizer, monkeypatch):
+def test_thd_values_match(te_model_checkpoint, tokenizer):
     # Manually masked input tokens so that both BSHD and THD models have the same mask pattern
 
     proteins = [
@@ -64,7 +64,7 @@ def test_thd_values_match(te_model_checkpoint, tokenizer, monkeypatch):
     ]
 
     bshd_collator = DataCollatorForTokenClassification(tokenizer=tokenizer, padding=True)
-    thd_collator = DataCollatorWithFlattening(return_flash_attn_kwargs=True)
+    thd_collator = DataCollatorWithFlattening()
 
     input_data_bshd = bshd_collator(sequences)
     input_data_thd = thd_collator(sequences)

--- a/bionemo-recipes/models/esm2/tests/test_thd_inputs.py
+++ b/bionemo-recipes/models/esm2/tests/test_thd_inputs.py
@@ -13,21 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import torch
-from transformers import AutoModelForMaskedLM, DataCollatorForTokenClassification
+from transformers import DataCollatorForTokenClassification
 
 from esm.collator import DataCollatorWithFlattening
-from esm.convert import convert_esm_hf_to_te
 from esm.modeling_esm_te import NVEsmForMaskedLM
-
-
-@pytest.fixture
-def te_model_checkpoint(tmp_path):
-    model_hf = AutoModelForMaskedLM.from_pretrained("facebook/esm2_t6_8M_UR50D")
-    model_te = convert_esm_hf_to_te(model_hf)
-    model_te.save_pretrained(tmp_path / "te_model_checkpoint")
-    return tmp_path / "te_model_checkpoint"
 
 
 def test_thd_from_collator_output(te_model_checkpoint, input_data_thd):


### PR DESCRIPTION
Adds padding to the vocab dimension of ESM-2 to make it compatible with FP8 and MXFP8 kernels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - FP8/MXFP8 execution support with parity checks; configurable padded vocabulary (padded_vocab_size, default 64) enabling FP8-friendly embeddings/LM outputs while truncating outputs back to the original vocab size.
- **Refactor**
  - Simplified, PyTorch-centric data-collation pipeline; collators enforce PyTorch tensors and support padding to a specified multiple.
- **Documentation**
  - Config docs updated to describe padded_vocab_size and its constraints.
- **Tests**
  - Added FP8/MXFP8 forward-pass tests, collator/unit tests, and state-dict padding validation; test fixtures reorganized for a shared converted checkpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->