### PR TITLE
update devcontainer for recipes

### DIFF
--- a/.devcontainer/recipes/Dockerfile
+++ b/.devcontainer/recipes/Dockerfile
@@ -2,3 +2,5 @@ FROM nvcr.io/nvidia/pytorch:25.06-py3
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/workspace/requirements.txt \
     PIP_CONSTRAINT= pip install -r /workspace/requirements.txt
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/

--- a/.devcontainer/recipes/devcontainer.json
+++ b/.devcontainer/recipes/devcontainer.json
@@ -8,14 +8,20 @@
     "mounts": [
         "source=${localEnv:HOME}/.cache,target=/home/ubuntu/.cache,type=bind,consistency=cached",
         "source=${localEnv:HOME}/.netrc,target=/home/ubuntu/.netrc,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.bash_history_devcontainer,target=/home/ubuntu/.bash_history,type=bind,consistency=cached"
+        "source=${localEnv:HOME}/.bash_history_devcontainer,target=/home/ubuntu/.bash_history,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.ssh,target=/home/ubuntu/.ssh,readonly,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.gnupg,target=/home/ubuntu/.gnupg,type=bind,consistency=cached"
     ],
     "postCreateCommand": ".devcontainer/recipes/postCreateCommand.sh",
+    "initializeCommand": ".devcontainer/recipes/initializeCommand.sh",
     "remoteUser": "ubuntu",
     "runArgs": [
         "--gpus=all",
         "--shm-size=4g"
     ],
+    "containerEnv": {
+        "PRE_COMMIT_HOME": "/home/ubuntu/.cache/pre-commit-devcontainer"
+    },
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/recipes/initializeCommand.sh
+++ b/.devcontainer/recipes/initializeCommand.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Create the mounted config directories if they don't already exist
+
+mkdir -p ~/.devcontainer_cache
+mkdir -p ~/.ssh
+mkdir -p ~/.cache/pre-commit-devcontainer
+mkdir -p ~/.gnupg
+[ ! -f ~/.netrc ] && touch ~/.netrc
+
+# Create the ~/.bash_history_devcontainer file if it doesn't exist
+[ ! -f ~/.bash_history_devcontainer ] && touch ~/.bash_history_devcontainer
+
+exit 0

--- a/.devcontainer/recipes/postCreateCommand.sh
+++ b/.devcontainer/recipes/postCreateCommand.sh
@@ -1,0 +1,3 @@
+uv tool install pre-commit --with pre-commit-uv --force-reinstall
+uv tool update-shell
+pre-commit install

--- a/.devcontainer/recipes/postCreateCommand.sh
+++ b/.devcontainer/recipes/postCreateCommand.sh
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
 uv tool install pre-commit --with pre-commit-uv --force-reinstall
-uv tool update-shell
-pre-commit install
+# Run via uv to avoid relying on updated PATH in this shell
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  uvx pre-commit install
+fi


### PR DESCRIPTION
Addresses some of @savitha-eng's onboarding issues with the recipe devcontainer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Dev container now includes the uv tool and uses it to install pre-commit (with guard to only install hooks inside a git repo).
  - Automatic initialization creates caches, SSH/GPG directories, and history/netrc files if missing.
  - Adds host-mounted read-only SSH keys and GnuPG data for secure in-container use.

- Chores
  - Establishes PRE_COMMIT_HOME for isolated caching.
  - Keeps existing bash-history mount behavior with minor formatting updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->