### PR TITLE
remove xfail flag from esm2 fp8 test

### DIFF
--- a/bionemo-recipes/recipes/esm2_accelerate_te/tests/test_accelerate_esm2.py
+++ b/bionemo-recipes/recipes/esm2_accelerate_te/tests/test_accelerate_esm2.py
@@ -43,7 +43,6 @@ def test_te_with_dynamo_config(tmp_path):
     assert train_loss < 3.0, f"Final train_loss {train_loss} should be less than 3.0"
 
 
-@pytest.mark.xfail(reason="TODO(BIONEMO-2782): FP8 will require padding ESM-2 weights to be a multiple of 8.")
 def test_te_with_fp8_config(tmp_path):
     train_loss = launch_accelerate("fp8.yaml", tmp_path, 1, "L0_sanity", "model_tag=nvidia/esm2_t6_8M_UR50D")
     assert train_loss < 3.0, f"Final train_loss {train_loss} should be less than 3.0"


### PR DESCRIPTION
With #1160 merged, we can now run fp8 tests with ESM-2. While mxfp8 should work, these kernels are currently only available on 100+ series server cards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Converted a previously expected-failure FP8 scenario into a standard test, enabling regular validation in CI.
  - Improves confidence in FP8 support and provides clearer, more accurate test reporting.
  - Enhances test robustness without altering runtime behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->