### PR TITLE
Add FP8 and THD support to the esm-2 native recipe

### DIFF
--- a/bionemo-recipes/recipes/esm2_native_te/collator.py
+++ b/bionemo-recipes/recipes/esm2_native_te/collator.py
@@ -1,0 +1,347 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data collator for THD input format.
+
+Copied from models/esm2/src/esm/collator.py.
+
+This should eventually get moved to a separate package, or possibly upstreamed into `transformers`.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from transformers import DataCollatorForLanguageModeling, DefaultDataCollator, PreTrainedTokenizerBase
+
+
+logger = logging.getLogger(__name__)
+
+
+class MLMDataCollatorWithFlattening:
+    """Data collator that combines MLM masking with sequence packing for Flash Attention.
+
+    This data collator enables efficient training on variable-length sequences by:
+    1. First flattening multiple sequences into a single packed tensor (no padding between sequences)
+    2. Then applying MLM masking to the flattened sequence
+    3. Providing Flash Attention metadata (cu_seq_lens) for sequence boundary awareness
+    4. Optionally padding the total sequence length to be divisible by a specified number
+
+    The result is a THD-format batch optimized for Flash Attention with sequence packing,
+    eliminating the need for traditional attention masks while maintaining proper sequence
+    boundaries during attention computation.
+
+    **Padding to Multiple**: When `pad_to_multiple_of` is specified, the collator ensures
+    that the total number of tokens across all sequences is divisible by the given number.
+    This is accomplished by appending a mock sequence to the end of the packed batch with
+    padding tokens and corresponding labels set to -100. This feature is useful for
+    optimizing memory alignment and computational efficiency on specific hardware.
+
+    **Tensor Support**: Currently only supports PyTorch tensors (return_tensors="pt").
+    Other tensor formats are not implemented.
+
+    Args:
+        tokenizer (PreTrainedTokenizerBase): The tokenizer to use for masking tokens.
+        mlm (bool): Whether to use masked language modeling. Defaults to True.
+        mlm_probability (float | None): Probability of masking tokens. Defaults to 0.15.
+        mask_replace_prob (float): Probability of replacing masked tokens with [MASK]. Defaults to 0.8.
+        random_replace_prob (float): Probability of replacing masked tokens with random tokens. Defaults to 0.1.
+        return_tensors (str): Format for returned tensors. Only "pt" (PyTorch) is supported. Defaults to "pt".
+        seed (int | None): Random seed for reproducible masking. Defaults to None.
+        pad_to_multiple_of (int | None): If set, pads the total sequence length to be divisible
+            by this number by adding a mock sequence at the end. Defaults to None.
+
+    Example:
+        >>> from transformers import AutoTokenizer
+        >>> tokenizer = AutoTokenizer.from_pretrained("facebook/esm2_t6_8M_UR50D")
+        >>>
+        >>> # Input: Variable-length protein sequences
+        >>> sequences = [
+        ...     {"input_ids": [0, 5, 6, 7, 2]},      # CLS + amino acids + EOS (5 tokens)
+        ...     {"input_ids": [0, 8, 9, 10, 11, 2]}, # CLS + amino acids + EOS (6 tokens)
+        ...     {"input_ids": [0, 12, 13, 2]},       # CLS + amino acids + EOS (4 tokens)
+        ... ]  # Total: 15 tokens
+        >>>
+        >>> # Create collator with padding to multiple of 8
+        >>> collator = MLMDataCollatorWithFlattening(
+        ...     tokenizer=tokenizer,
+        ...     mlm_probability=0.15,
+        ...     pad_to_multiple_of=8,  # Pad 15 -> 16 tokens
+        ...     seed=42
+        ... )
+        >>>
+        >>> # Process batch
+        >>> batch = collator(sequences)
+        >>>
+        >>> # Output: Flattened, masked, and padded sequences
+        >>> print(batch['input_ids'].shape)    # torch.Size([1, 16])
+        >>> print(batch['labels'].shape)       # torch.Size([1, 16])
+        >>> print(batch['cu_seq_lens_q'])      # tensor([0, 5, 11, 15, 16], dtype=torch.int32)
+        >>>                                    # Note: Extra entry for mock padding sequence
+        >>> # Ready for Flash Attention without traditional attention masks!
+
+    Note:
+        The output is in THD (Total, Height, Depth) format with batch_size=1 and
+        sequence_length=total_tokens, optimized for Flash Attention's variable-length
+        sequence processing capabilities.
+    """
+
+    def __init__(
+        self,
+        tokenizer: PreTrainedTokenizerBase,
+        mlm: bool = True,
+        mlm_probability: float | None = 0.15,
+        mask_replace_prob: float = 0.8,
+        random_replace_prob: float = 0.1,
+        return_tensors: str = "pt",
+        seed: int | None = None,
+        pad_to_multiple_of: int | None = None,
+    ):
+        """Initialize the MLMDataCollatorWithFlattening.
+
+        Args:
+            tokenizer (PreTrainedTokenizerBase): The tokenizer to use for masking tokens.
+            mlm (bool): Whether to use masked language modeling. Defaults to True.
+            mlm_probability (float | None): Probability of masking tokens. Defaults to 0.15.
+            mask_replace_prob (float): Probability of replacing masked tokens with [MASK]. Defaults to 0.8.
+            random_replace_prob (float): Probability of replacing masked tokens with random tokens. Defaults to 0.1.
+            return_tensors (str): Format for returned tensors. Only "pt" (PyTorch) is supported. Defaults to "pt".
+            seed (int | None): Random seed for reproducible masking. Defaults to None.
+            pad_to_multiple_of (int | None): If set, pads the total sequence length to be divisible
+                by this number by adding a mock sequence at the end. Defaults to None.
+        """
+        self.mlm_collator = DataCollatorForLanguageModeling(
+            tokenizer=tokenizer,
+            mlm=mlm,
+            mlm_probability=mlm_probability,
+            mask_replace_prob=mask_replace_prob,
+            random_replace_prob=random_replace_prob,
+            return_tensors=return_tensors,
+            seed=seed,
+        )
+        self.return_tensors = return_tensors
+        self.pad_to_multiple_of = pad_to_multiple_of
+
+    def __call__(self, features, return_tensors=None):
+        """Process a batch of variable-length sequences for Flash Attention with MLM.
+
+        This method performs the following steps:
+        1. Flattens multiple sequences into a single packed tensor with Flash Attention metadata
+        2. Applies MLM masking to the flattened sequence while preserving special tokens
+        3. Optionally pads to a multiple of a specified number for hardware optimization
+
+        Args:
+            features (List[Dict[str, List[int]]]): List of tokenized sequences, each containing
+                'input_ids' and optionally 'attention_mask'. Example:
+                [
+                    {"input_ids": [0, 5, 6, 7, 2]},      # Protein sequence 1
+                    {"input_ids": [0, 8, 9, 10, 11, 2]}, # Protein sequence 2
+                    {"input_ids": [0, 12, 13, 2]}        # Protein sequence 3
+                ]
+            return_tensors (str, optional): Format for returned tensors. Only "pt" (PyTorch)
+                is supported. Defaults to None (uses collator default).
+
+        Returns:
+            Dict[str, torch.Tensor]: Batch dictionary containing:
+                - input_ids (torch.Tensor): Flattened and MLM-masked token sequences.
+                  Shape: [1, total_tokens] where total_tokens = sum of all sequence lengths
+                  (plus padding if pad_to_multiple_of is specified).
+                - labels (torch.Tensor): MLM labels with -100 for non-masked tokens and
+                  original token IDs for masked positions. Same shape as input_ids.
+                - cu_seq_lens_q (torch.IntTensor): Cumulative sequence lengths for queries.
+                  Shape: [num_sequences + 1] or [num_sequences + 2] if padding is added.
+                  Example: [0, 5, 11, 15] or [0, 5, 11, 15, 16] with padding.
+                - cu_seq_lens_k (torch.IntTensor): Cumulative sequence lengths for keys.
+                  Same as cu_seq_lens_q for self-attention.
+                - max_length_q (int): Maximum sequence length in the batch.
+                - max_length_k (int): Same as max_length_q for self-attention.
+                - attention_mask (torch.Tensor): Attention mask with 1s for actual tokens
+                  and 0s for padding tokens (if any).
+
+        Raises:
+            NotImplementedError: If return_tensors is not "pt".
+
+        Example:
+            >>> # Input features
+            >>> features = [
+            ...     {"input_ids": [0, 5, 6, 7, 2]},      # 5 tokens
+            ...     {"input_ids": [0, 8, 9, 10, 11, 2]}, # 6 tokens
+            ... ]
+            >>>
+            >>> batch = collator(features)
+            >>>
+            >>> # Output shapes and values
+            >>> batch['input_ids'].shape          # torch.Size([1, 11]) or larger if padded
+            >>> batch['labels'].shape             # torch.Size([1, 11]) or larger if padded
+            >>> batch['cu_seq_lens_q']            # tensor([0, 5, 11], dtype=torch.int32) or larger
+
+        Note:
+            The output is in THD (Total, Height, Depth) format with batch_size=1 and
+            sequence_length=total_tokens, optimized for Flash Attention's variable-length
+            sequence processing capabilities. When pad_to_multiple_of is used, an additional
+            mock sequence is appended to reach the desired total length.
+        """
+        if return_tensors is None:
+            return_tensors = self.return_tensors
+
+        if return_tensors != "pt":
+            raise NotImplementedError(f'return_tensors must be "pt", {return_tensors=} not implemented')
+
+        batch = _pt_flatten_collate(features)
+
+        special_tokens_mask = batch.pop("special_tokens_mask", None)
+        batch["input_ids"], batch["labels"] = self.mlm_collator.torch_mask_tokens(
+            batch["input_ids"], special_tokens_mask=special_tokens_mask
+        )
+
+        if self.pad_to_multiple_of is not None:
+            # Ensure token_pad is an integer, defaulting to 1 if pad_token_id is None or invalid
+            pad_token_id = self.mlm_collator.tokenizer.pad_token_id
+            if not isinstance(pad_token_id, int):
+                logger.warning(f"tokenizer.pad_token_id is not an integer, using 1 instead: {pad_token_id}")
+                pad_token_id = 1
+
+            batch = _pt_pad_to_multiple_of(
+                batch,
+                self.pad_to_multiple_of,
+                token_pad=pad_token_id,
+                label_pad=-100,
+            )
+
+        return batch
+
+
+@dataclass
+class DataCollatorWithFlattening(DefaultDataCollator):
+    """Data collator for sequence packing with flash attentions cu_seqlens-style attention.
+
+    Inspired by transformers.data.data_collator.DataCollatorWithFlattening.
+    """
+
+    pad_to_multiple_of: int | None = None
+    token_pad: int = 1
+    label_pad: int = -100
+    return_tensors: str = "pt"
+
+    def __call__(self, features: list[dict[str, list[int]]], return_tensors: str | None = None) -> dict[str, Any]:
+        """Collate a batch of variable-length sequences for Flash Attention with sequence packing.
+
+        Args:
+            features: List of tokenized sequences, each containing 'input_ids' and optionally 'labels'.
+            return_tensors: Currently only "pt" is supported.
+
+        Returns:
+            Dict[str, torch.Tensor]: Batch dictionary containing:
+                - input_ids (torch.Tensor): Flattened and MLM-masked token sequences.
+                  Shape: [1, total_tokens] where total_tokens = sum of all sequence lengths.
+                - labels (torch.Tensor): MLM labels with -100 for non-masked tokens and
+                  original token IDs for masked positions. Same shape as input_ids.
+                - cu_seq_lens_q (torch.IntTensor): Cumulative sequence lengths for queries.
+                  Shape: [num_sequences + 1]. Example: [0, 5, 11, 15].
+                - cu_seq_lens_k (torch.IntTensor): Cumulative sequence lengths for keys.
+                  Same as cu_seq_lens_q for self-attention.
+                - max_length_q (int): Maximum sequence length in the batch.
+                - max_length_k (int): Same as max_length_q for self-attention.
+                - attention_mask (torch.Tensor): Attention mask with 1s for non-padding tokens and 0s for padding tokens.
+        """
+        if not features:
+            raise ValueError("features must be a non-empty list")
+
+        if return_tensors is None:
+            return_tensors = self.return_tensors
+
+        if return_tensors != "pt":
+            raise NotImplementedError(f'return_tensors must be "pt", {return_tensors=} not implemented')
+
+        batch = _pt_flatten_collate(features)
+        if self.pad_to_multiple_of is not None:
+            batch = _pt_pad_to_multiple_of(batch, self.pad_to_multiple_of, self.token_pad, self.label_pad)
+        return batch
+
+
+def _pt_flatten_collate(features: list[dict[str, list[int]]]):
+    is_labels_provided = "labels" in features[0]
+    sample_lengths = [len(sample["input_ids"]) for sample in features]
+
+    batch = {}
+    batch["max_length_q"] = batch["max_length_k"] = max(sample_lengths)
+    batch["input_ids"] = torch.tensor(
+        [[token for sample in features for token in sample["input_ids"]]], dtype=torch.int64
+    )
+    if is_labels_provided:
+        batch["labels"] = torch.tensor(
+            [[label for sample in features for label in sample["labels"]]], dtype=torch.int64
+        )
+    cu_seq_lens = torch.zeros(len(features) + 1, dtype=torch.int32)
+    cu_seq_lens[1:] = torch.cumsum(torch.tensor(sample_lengths), dim=0, dtype=torch.int32)
+    batch["cu_seq_lens_q"] = batch["cu_seq_lens_k"] = cu_seq_lens
+    if "attention_mask" in features[0]:
+        batch["attention_mask"] = torch.tensor(
+            [[v for sample in features for v in sample["attention_mask"]]], dtype=torch.int64
+        )
+    return batch
+
+
+def _pt_pad_to_multiple_of(batch: dict[str, Any], pad_to_multiple_of: int, token_pad: int, label_pad: int):
+    """Pad a batch to a multiple of pad_to_multiple_of.
+
+    Appends a mock sequence to the end of the batch with the given token_pad and label_pad to make the total number of
+    tokens divisible by pad_to_multiple_of.
+
+    Args:
+        batch: Input batch, possibly containing labels and/or cu_seq_lens / max_length keys.
+        pad_to_multiple_of: Multiple to pad to.
+        token_pad: Token to pad with.
+        label_pad: Label to pad with.
+
+    Returns:
+        Batch dictionary with padded input_ids, labels, cu_seq_lens_q, cu_seq_lens_k, max_length_q, and max_length_k.
+    """
+    # Number of tokens we need to pad to make the total number of tokens divisible by pad_to_multiple_of
+    remainder = -batch["input_ids"].numel() % pad_to_multiple_of
+
+    if remainder == 0:
+        return batch
+
+    batch["input_ids"] = torch.cat(
+        [batch["input_ids"], torch.full((1, remainder), token_pad, dtype=batch["input_ids"].dtype)], dim=1
+    )
+
+    if "labels" in batch:
+        batch["labels"] = torch.cat(
+            [batch["labels"], torch.full((1, remainder), label_pad, dtype=batch["labels"].dtype)], dim=1
+        )
+
+    if "cu_seq_lens_q" in batch:
+        batch["cu_seq_lens_q"] = torch.cat(
+            [
+                batch["cu_seq_lens_q"],
+                torch.tensor([batch["cu_seq_lens_q"][-1] + remainder], dtype=batch["cu_seq_lens_q"].dtype),
+            ],
+            dim=0,
+        )
+        batch["cu_seq_lens_k"] = batch["cu_seq_lens_q"]
+
+    if "max_length_q" in batch:
+        batch["max_length_q"] = max(batch["max_length_q"], remainder)
+        batch["max_length_k"] = batch["max_length_q"]
+
+    if "attention_mask" in batch:
+        batch["attention_mask"] = torch.cat(
+            [batch["attention_mask"], torch.zeros((1, remainder), dtype=batch["attention_mask"].dtype)], dim=1
+        )
+
+    return batch

--- a/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
+++ b/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
@@ -11,6 +11,8 @@ dataset:
   micro_batch_size: ???
   num_workers: 1
   max_seq_length: 1024
+  use_sequence_packing: false
+  sequence_packing_pad_to_multiple_of: null
   load_dataset_kwargs:
     path: "parquet"
     split: "train"
@@ -33,6 +35,17 @@ fully_shard_kwargs:
   overlap_param_gather: true
   sync_grads_each_step: true
   average_in_collective: false
+
+# TransformerEngine FP8 config. See
+# https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/examples/fp8_primer.html for more information on
+# supported formats.
+fp8_config:
+  enabled: false
+  fp8_recipe: transformer_engine.common.recipe.DelayedScaling
+  fp8_format: "HYBRID"
+  fp8_recipe_kwargs:
+    amax_history_len: 16
+    amax_compute_algo: "max"
 
 # Optimizer config
 adamw_kwargs:

--- a/bionemo-recipes/recipes/esm2_native_te/tests/conftest.py
+++ b/bionemo-recipes/recipes/esm2_native_te/tests/conftest.py
@@ -16,6 +16,14 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 
 sys.path.append(Path(__file__).parent.parent.as_posix())
 sys.path.append(Path(__file__).parent.as_posix())
+
+
+@pytest.fixture
+def recipe_path() -> Path:
+    """Return the root directory of the recipe."""
+    return Path(__file__).parent.parent

--- a/bionemo-recipes/recipes/esm2_native_te/tests/test_train.py
+++ b/bionemo-recipes/recipes/esm2_native_te/tests/test_train.py
@@ -14,14 +14,13 @@
 # limitations under the License.
 
 import random
-import subprocess
-from pathlib import Path
 
 import pytest
 import torch
 import torch.distributed as dist
 from hydra import compose, initialize_config_dir
 from torch.distributed.device_mesh import _mesh_resources
+from transformer_engine.pytorch.fp8 import check_fp8_support
 
 from train_ddp import main as main_ddp
 from train_fsdp2 import main as main_fsdp2
@@ -36,31 +35,10 @@ def set_seed():
         torch.cuda.manual_seed_all(42)
 
 
-requires_multi_gpu = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
-    reason="Test requires at least 2 GPUs",
+requires_fp8 = pytest.mark.skipif(
+    not torch.cuda.is_available() or not check_fp8_support()[0],
+    reason="Test requires FP8 support: " + check_fp8_support()[1],
 )
-
-# Get the recipe directory
-recipe_dir = Path(__file__).parent.parent
-
-
-def run_train_cmd(cmd):
-    """Run a training command and check for errors."""
-
-    result = subprocess.run(
-        cmd,
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        timeout=240,
-    )
-
-    if result.returncode != 0:
-        print(f"STDOUT:\n{result.stdout}")
-        print(f"STDERR:\n{result.stderr}")
-        pytest.fail(f"Command:\n{' '.join(cmd)}\nfailed with exit code {result.returncode}")
 
 
 @pytest.fixture
@@ -81,22 +59,22 @@ def distributed_cleanup():
     _mesh_resources.mesh_dim_group_options.clear()
 
 
-def test_sanity_convergence_mfsdp(distributed_cleanup, tmp_path):
+def test_sanity_convergence_mfsdp(distributed_cleanup, tmp_path, recipe_path):
     """Test that the main function can be invoked with the correct arguments."""
 
     # Run the training script with Hydra configuration overrides
-    with initialize_config_dir(config_dir=str(recipe_dir / "hydra_config"), version_base="1.2"):
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
         sanity_config = compose(config_name="L0_sanity", overrides=[f"+wandb_init_args.dir={tmp_path}"])
 
     final_loss = main_mfsdp(sanity_config)
     assert final_loss < 3.0, f"Final loss {final_loss} is too high"
 
 
-def test_sanity_convergence_mfsdp_meta_device(distributed_cleanup, tmp_path):
+def test_sanity_convergence_mfsdp_meta_device(distributed_cleanup, tmp_path, recipe_path):
     """Test that the main function can be invoked with the correct arguments."""
 
     # Run the training script with Hydra configuration overrides
-    with initialize_config_dir(config_dir=str(recipe_dir / "hydra_config"), version_base="1.2"):
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
         sanity_config = compose(
             config_name="L0_sanity",
             overrides=[
@@ -109,11 +87,12 @@ def test_sanity_convergence_mfsdp_meta_device(distributed_cleanup, tmp_path):
     assert final_loss < 3.0, f"Final loss {final_loss} is too high"
 
 
-def test_sanity_convergence_mfsdp_eager_meta_device(distributed_cleanup, tmp_path):
+@pytest.mark.xfail(reason="Meta-device init seems to be having some issues with convergence (BIONEMO-2719)")
+def test_sanity_convergence_mfsdp_eager_meta_device(distributed_cleanup, tmp_path, recipe_path):
     """Test that the main function can be invoked with the correct arguments."""
 
     # Run the training script with Hydra configuration overrides
-    with initialize_config_dir(config_dir=str(recipe_dir / "hydra_config"), version_base="1.2"):
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
         sanity_config = compose(
             config_name="L0_sanity",
             overrides=[
@@ -127,22 +106,22 @@ def test_sanity_convergence_mfsdp_eager_meta_device(distributed_cleanup, tmp_pat
     assert final_loss < 3.0, f"Final loss {final_loss} is too high"
 
 
-def test_sanity_convergence_ddp(distributed_cleanup, tmp_path):
+def test_sanity_convergence_ddp(distributed_cleanup, tmp_path, recipe_path):
     """Test that the main function can be invoked wrapping the model in DDP."""
 
     # Run the training script with Hydra configuration overrides
-    with initialize_config_dir(config_dir=str(recipe_dir / "hydra_config"), version_base="1.2"):
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
         sanity_config = compose(config_name="L0_sanity", overrides=[f"+wandb_init_args.dir={tmp_path}"])
 
     final_loss = main_ddp(sanity_config)
     assert final_loss < 3.0, f"Final loss {final_loss} is too high"
 
 
-def test_sanity_convergence_ddp_non_streaming_dataset(distributed_cleanup, tmp_path):
+def test_sanity_convergence_ddp_non_streaming_dataset(distributed_cleanup, tmp_path, recipe_path):
     """Test that the training script works with a non-streaming dataset."""
 
     # Run the training script with Hydra configuration overrides
-    with initialize_config_dir(config_dir=str(recipe_dir / "hydra_config"), version_base="1.2"):
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
         sanity_config = compose(
             config_name="L0_sanity",
             overrides=[
@@ -155,11 +134,11 @@ def test_sanity_convergence_ddp_non_streaming_dataset(distributed_cleanup, tmp_p
     assert final_loss < 3.0, f"Final loss {final_loss} is too high"
 
 
-def test_sanity_convergence_fsdp2(distributed_cleanup, tmp_path):
+def test_sanity_convergence_fsdp2(distributed_cleanup, tmp_path, recipe_path):
     """Test that the main function can be invoked wrapping the model in FSDP2."""
 
     # Run the training script with Hydra configuration overrides
-    with initialize_config_dir(config_dir=str(recipe_dir / "hydra_config"), version_base="1.2"):
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
         sanity_config = compose(
             config_name="L0_sanity",
             overrides=[
@@ -171,12 +150,187 @@ def test_sanity_convergence_fsdp2(distributed_cleanup, tmp_path):
     assert final_loss < 3.0, f"Final loss {final_loss} is too high"
 
 
+@requires_fp8
+def test_sanity_mfsdp_fp8(distributed_cleanup, tmp_path, recipe_path):
+    # For MFSDP, we only check that the script can run successfully with FP8, not convergence.
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
+        sanity_config = compose(
+            config_name="L0_sanity",
+            overrides=[
+                f"+wandb_init_args.dir={tmp_path}",
+                "fp8_config.enabled=true",
+                "num_train_steps=4",
+            ],
+        )
+
+    main_mfsdp(sanity_config)
+
+
+@requires_fp8
+def test_sanity_ddp_fp8(distributed_cleanup, tmp_path, recipe_path):
+    # For DDP, we only check that the script can run successfully with FP8, not convergence.
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
+        sanity_config = compose(
+            config_name="L0_sanity",
+            overrides=[
+                f"+wandb_init_args.dir={tmp_path}",
+                "fp8_config.enabled=true",
+                "num_train_steps=4",
+            ],
+        )
+
+    main_ddp(sanity_config)
+
+
+@requires_fp8
+def test_sanity_convergence_fsdp2_fp8(distributed_cleanup, tmp_path, recipe_path):
+    """For FSDP2, we check that the script can run successfully with FP8 and check convergence."""
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
+        sanity_config = compose(
+            config_name="L0_sanity",
+            overrides=[
+                f"+wandb_init_args.dir={tmp_path}",
+                "fp8_config.enabled=true",
+            ],
+        )
+
+    final_loss = main_fsdp2(sanity_config)
+    assert final_loss < 3.0, f"Final loss {final_loss} is too high"
+
+
+def test_sanity_convergence_fsdp2_thd(distributed_cleanup, tmp_path, monkeypatch, recipe_path):
+    """For FSDP2, we check that the script can run successfully with FP8 and check convergence."""
+    if torch.cuda.get_device_capability() == (12, 0):
+        # TODO(BIONEMO-2840): On sm120, we need to set NVTE_FUSED_ATTN to 0 since TE will choose fused attn by default,
+        # but it's missing this THD implementation.
+        monkeypatch.setenv("NVTE_FUSED_ATTN", "0")
+
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
+        sanity_config = compose(
+            config_name="L0_sanity",
+            overrides=[
+                f"+wandb_init_args.dir={tmp_path}",
+                "dataset.use_sequence_packing=true",
+            ],
+        )
+
+    final_loss = main_fsdp2(sanity_config)
+    assert final_loss < 3.0, f"Final loss {final_loss} is too high"
+
+
+@requires_fp8
+def test_sanity_convergence_fsdp2_thd_fp8(distributed_cleanup, tmp_path, monkeypatch, recipe_path):
+    """For FSDP2, we check that the script can run successfully with THD + FP8 and check convergence."""
+    if torch.cuda.get_device_capability() == (12, 0):
+        # TODO(BIONEMO-2840): On sm120, we need to set NVTE_FUSED_ATTN to 0 since TE will choose fused attn by default,
+        # but it's missing this THD implementation.
+        monkeypatch.setenv("NVTE_FUSED_ATTN", "0")
+
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
+        sanity_config = compose(
+            config_name="L0_sanity",
+            overrides=[
+                f"+wandb_init_args.dir={tmp_path}",
+                "dataset.use_sequence_packing=true",
+                "dataset.sequence_packing_pad_to_multiple_of=16",
+                "fp8_config.enabled=true",
+            ],
+        )
+
+    final_loss = main_fsdp2(sanity_config)
+    assert final_loss < 3.0, f"Final loss {final_loss} is too high"
+
+
+def test_sanity_ddp_thd(distributed_cleanup, tmp_path, monkeypatch, recipe_path):
+    if torch.cuda.get_device_capability() == (12, 0):
+        # TODO(BIONEMO-2840): On sm120, we need to set NVTE_FUSED_ATTN to 0 since TE will choose fused attn by default,
+        # but it's missing this THD implementation.
+        monkeypatch.setenv("NVTE_FUSED_ATTN", "0")
+
+    # For DDP, we only check that the script can run successfully with THD, not convergence.
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
+        sanity_config = compose(
+            config_name="L0_sanity",
+            overrides=[
+                f"+wandb_init_args.dir={tmp_path}",
+                "dataset.use_sequence_packing=true",
+                "num_train_steps=4",
+            ],
+        )
+
+    main_ddp(sanity_config)
+
+
+def test_sanity_mfsdp_thd(distributed_cleanup, tmp_path, monkeypatch, recipe_path):
+    if torch.cuda.get_device_capability() == (12, 0):
+        # TODO(BIONEMO-2840): On sm120, we need to set NVTE_FUSED_ATTN to 0 since TE will choose fused attn by default,
+        # but it's missing this THD implementation.
+        monkeypatch.setenv("NVTE_FUSED_ATTN", "0")
+
+    # For MFSDP, we only check that the script can run successfully with THD, not convergence.
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
+        sanity_config = compose(
+            config_name="L0_sanity",
+            overrides=[
+                f"+wandb_init_args.dir={tmp_path}",
+                "dataset.use_sequence_packing=true",
+                "num_train_steps=4",
+            ],
+        )
+
+    main_mfsdp(sanity_config)
+
+
+def test_sanity_ddp_thd_fp8(distributed_cleanup, tmp_path, monkeypatch, recipe_path):
+    if torch.cuda.get_device_capability() == (12, 0):
+        # TODO(BIONEMO-2840): On sm120, we need to set NVTE_FUSED_ATTN to 0 since TE will choose fused attn by default,
+        # but it's missing this THD implementation.
+        monkeypatch.setenv("NVTE_FUSED_ATTN", "0")
+
+    # For DDP, we only check that the script can run successfully with THD, not convergence.
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
+        sanity_config = compose(
+            config_name="L0_sanity",
+            overrides=[
+                f"+wandb_init_args.dir={tmp_path}",
+                "dataset.use_sequence_packing=true",
+                "num_train_steps=4",
+                "fp8_config.enabled=true",
+                "dataset.sequence_packing_pad_to_multiple_of=16",
+            ],
+        )
+
+    main_ddp(sanity_config)
+
+
+def test_sanity_mfsdp_thd_fp8(distributed_cleanup, tmp_path, monkeypatch, recipe_path):
+    if torch.cuda.get_device_capability() == (12, 0):
+        # TODO(BIONEMO-2840): On sm120, we need to set NVTE_FUSED_ATTN to 0 since TE will choose fused attn by default,
+        # but it's missing this THD implementation.
+        monkeypatch.setenv("NVTE_FUSED_ATTN", "0")
+
+    # For MFSDP, we only check that the script can run successfully with THD, not convergence.
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
+        sanity_config = compose(
+            config_name="L0_sanity",
+            overrides=[
+                f"+wandb_init_args.dir={tmp_path}",
+                "dataset.use_sequence_packing=true",
+                "num_train_steps=4",
+                "fp8_config.enabled=true",
+                "dataset.sequence_packing_pad_to_multiple_of=16",
+            ],
+        )
+
+    main_mfsdp(sanity_config)
+
+
 @pytest.mark.xfail(reason="Meta-device init seems to be having some issues with convergence (BIONEMO-2719)")
-def test_sanity_convergence_fsdp2_meta_device(distributed_cleanup, tmp_path):
+def test_sanity_convergence_fsdp2_meta_device(distributed_cleanup, tmp_path, recipe_path):
     """Test that the main function can be invoked wrapping the model in FSDP2."""
 
     # Run the training script with Hydra configuration overrides
-    with initialize_config_dir(config_dir=str(recipe_dir / "hydra_config"), version_base="1.2"):
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
         sanity_config = compose(
             config_name="L0_sanity",
             overrides=[
@@ -189,11 +343,11 @@ def test_sanity_convergence_fsdp2_meta_device(distributed_cleanup, tmp_path):
     assert final_loss < 3.0, f"Final loss {final_loss} is too high"
 
 
-def test_sanity_convergence_mfsdp_eager(distributed_cleanup, tmp_path):
+def test_sanity_convergence_mfsdp_eager(distributed_cleanup, tmp_path, recipe_path):
     """Test that the main function can be invoked with the correct arguments."""
 
     # Run the training script with Hydra configuration overrides
-    with initialize_config_dir(config_dir=str(recipe_dir / "hydra_config"), version_base="1.2"):
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
         sanity_config = compose(
             config_name="L0_sanity",
             overrides=[f"+wandb_init_args.dir={tmp_path}", "model_tag=facebook/esm2_t6_8M_UR50D"],
@@ -203,11 +357,11 @@ def test_sanity_convergence_mfsdp_eager(distributed_cleanup, tmp_path):
     assert final_loss < 3.0, f"Final loss {final_loss} is too high"
 
 
-def test_sanity_convergence_ddp_eager(distributed_cleanup, tmp_path):
+def test_sanity_convergence_ddp_eager(distributed_cleanup, tmp_path, recipe_path):
     """Test that the main function can be invoked wrapping the model in DDP."""
 
     # Run the training script with Hydra configuration overrides
-    with initialize_config_dir(config_dir=str(recipe_dir / "hydra_config"), version_base="1.2"):
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
         sanity_config = compose(
             config_name="L0_sanity",
             overrides=[f"+wandb_init_args.dir={tmp_path}", "model_tag=facebook/esm2_t6_8M_UR50D"],
@@ -217,11 +371,11 @@ def test_sanity_convergence_ddp_eager(distributed_cleanup, tmp_path):
     assert final_loss < 3.0, f"Final loss {final_loss} is too high"
 
 
-def test_sanity_convergence_fsdp2_eager(distributed_cleanup, tmp_path):
+def test_sanity_convergence_fsdp2_eager(distributed_cleanup, tmp_path, recipe_path):
     """Test that the main function can be invoked wrapping the model in FSDP2."""
 
     # Run the training script with Hydra configuration overrides
-    with initialize_config_dir(config_dir=str(recipe_dir / "hydra_config"), version_base="1.2"):
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
         sanity_config = compose(
             config_name="L0_sanity",
             overrides=[f"+wandb_init_args.dir={tmp_path}", "model_tag=facebook/esm2_t6_8M_UR50D"],
@@ -231,11 +385,12 @@ def test_sanity_convergence_fsdp2_eager(distributed_cleanup, tmp_path):
     assert final_loss < 3.0, f"Final loss {final_loss} is too high"
 
 
-def test_sanity_convergence_fsdp2_eager_meta_device(distributed_cleanup, tmp_path):
+@pytest.mark.xfail(reason="Meta-device init seems to be having some issues with convergence (BIONEMO-2719)")
+def test_sanity_convergence_fsdp2_eager_meta_device(distributed_cleanup, tmp_path, recipe_path):
     """Test that the main function can be invoked wrapping the model in FSDP2 and using meta-device init."""
 
     # Run the training script with Hydra configuration overrides
-    with initialize_config_dir(config_dir=str(recipe_dir / "hydra_config"), version_base="1.2"):
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
         sanity_config = compose(
             config_name="L0_sanity",
             overrides=[
@@ -247,80 +402,3 @@ def test_sanity_convergence_fsdp2_eager_meta_device(distributed_cleanup, tmp_pat
 
     final_loss = main_fsdp2(sanity_config)
     assert final_loss < 3.0, f"Final loss {final_loss} is too high"
-
-
-# These tests don't check convergence, they just check that the training script runs successfully on multiple GPUs.
-
-
-@requires_multi_gpu
-def test_multi_gpu_train_te_ddp(tmp_path):
-    # Run 'accelerate launch train.py' as a subprocess
-    run_train_cmd(
-        [
-            "torchrun",
-            "--nproc_per_node",
-            "2",
-            "--master_port",
-            f"{random.randint(20000, 40000)}",
-            "train_ddp.py",
-            "--config-name",
-            "L0_sanity",
-            "num_train_steps=4",
-        ]
-    )
-
-
-@requires_multi_gpu
-def test_multi_gpu_train_te_mfsdp(tmp_path):
-    # Run 'accelerate launch train.py' as a subprocess
-    run_train_cmd(
-        [
-            "torchrun",
-            "--nproc_per_node",
-            "2",
-            "--master_port",
-            f"{random.randint(20000, 40000)}",
-            "train_mfsdp.py",
-            "--config-name",
-            "L0_sanity",
-            "num_train_steps=4",
-        ]
-    )
-
-
-@requires_multi_gpu
-def test_multi_gpu_train_te_fsdp2(tmp_path):
-    # Run 'accelerate launch train.py' as a subprocess
-    run_train_cmd(
-        [
-            "torchrun",
-            "--nproc_per_node",
-            "2",
-            "--master_port",
-            f"{random.randint(20000, 40000)}",
-            "train_fsdp2.py",
-            "--config-name",
-            "L0_sanity",
-            "num_train_steps=4",
-        ]
-    )
-
-
-@requires_multi_gpu
-def test_multi_gpu_train_eager_fsdp2_meta_device(tmp_path):
-    # Run 'accelerate launch train.py' as a subprocess
-    run_train_cmd(
-        [
-            "torchrun",
-            "--nproc_per_node",
-            "2",
-            "--master_port",
-            f"{random.randint(20000, 40000)}",
-            "train_fsdp2.py",
-            "--config-name",
-            "L0_sanity",
-            "model_tag=facebook/esm2_t6_8M_UR50D",
-            "use_meta_device=true",
-            "num_train_steps=4",
-        ]
-    )

--- a/bionemo-recipes/recipes/esm2_native_te/tests/test_train_two_gpu.py
+++ b/bionemo-recipes/recipes/esm2_native_te/tests/test_train_two_gpu.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These tests don't check convergence, they just check that the training script runs successfully on multiple GPUs.
+
+import subprocess
+
+import pytest
+import torch
+
+
+requires_multi_gpu = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+    reason="Test requires at least 2 GPUs",
+)
+
+
+def run_train_cmd(cmd, recipe_path):
+    """Run a training command and check for errors."""
+
+    result = subprocess.run(
+        cmd,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=240,
+        cwd=str(recipe_path),
+    )
+
+    if result.returncode != 0:
+        print(f"STDOUT:\n{result.stdout}")
+        print(f"STDERR:\n{result.stderr}")
+        pytest.fail(f"Command:\n{' '.join(cmd)}\nfailed with exit code {result.returncode}")
+
+
+@requires_multi_gpu
+def test_multi_gpu_train_te_ddp(tmp_path, recipe_path):
+    # Run 'accelerate launch train.py' as a subprocess
+    run_train_cmd(
+        [
+            "torchrun",
+            "--nproc_per_node",
+            "2",
+            "--standalone",
+            "train_ddp.py",
+            "--config-name",
+            "L0_sanity",
+            "num_train_steps=4",
+        ],
+        recipe_path,
+    )
+
+
+@requires_multi_gpu
+def test_multi_gpu_train_te_mfsdp(tmp_path, recipe_path):
+    # Run 'accelerate launch train.py' as a subprocess
+    run_train_cmd(
+        [
+            "torchrun",
+            "--nproc_per_node",
+            "2",
+            "--standalone",
+            "train_mfsdp.py",
+            "--config-name",
+            "L0_sanity",
+            "num_train_steps=4",
+        ],
+        recipe_path,
+    )
+
+
+@requires_multi_gpu
+def test_multi_gpu_train_te_fsdp2(tmp_path, recipe_path):
+    # Run 'accelerate launch train.py' as a subprocess
+    run_train_cmd(
+        [
+            "torchrun",
+            "--nproc_per_node",
+            "2",
+            "--standalone",
+            "train_fsdp2.py",
+            "--config-name",
+            "L0_sanity",
+            "num_train_steps=4",
+        ],
+        recipe_path,
+    )
+
+
+@requires_multi_gpu
+def test_multi_gpu_train_eager_fsdp2_meta_device(tmp_path, recipe_path):
+    # Run 'accelerate launch train.py' as a subprocess
+    run_train_cmd(
+        [
+            "torchrun",
+            "--nproc_per_node",
+            "2",
+            "--standalone",
+            "train_fsdp2.py",
+            "--config-name",
+            "L0_sanity",
+            "model_tag=facebook/esm2_t6_8M_UR50D",
+            "use_meta_device=true",
+            "num_train_steps=4",
+        ],
+        recipe_path,
+    )

--- a/bionemo-recipes/recipes/esm2_native_te/train_ddp.py
+++ b/bionemo-recipes/recipes/esm2_native_te/train_ddp.py
@@ -18,11 +18,13 @@ import time
 
 import hydra
 import torch
+import transformer_engine.pytorch
 import wandb
 from omegaconf import DictConfig, OmegaConf
 from torch.distributed.device_mesh import init_device_mesh
 from torch.optim import AdamW
 from tqdm import tqdm
+from transformer_engine.common.recipe import Format
 from transformers import AutoConfig, AutoModelForMaskedLM
 
 from dataset import create_dataloader
@@ -58,6 +60,9 @@ def main(args: DictConfig) -> float | None:
 
     # Create an empty ESM-2 model with a masked language model head.
     config = AutoConfig.from_pretrained(args.model_tag, trust_remote_code=True, dtype=torch.bfloat16)
+    # If we're using sequence packing with TE layers, we need to pass the `attn_input_format` argument.
+    if args.dataset.use_sequence_packing:
+        config.attn_input_format = "thd"
     model = AutoModelForMaskedLM.from_config(config, trust_remote_code=True)
 
     # The huggingface model has a contact head that we don't use in masked language pre-training, so we delete it to
@@ -83,12 +88,20 @@ def main(args: DictConfig) -> float | None:
         output_device=dist_config.local_rank,
         device_mesh=device_mesh["ddp"],
     )
-    model.train()
+
+    # Create an FP8 recipe
+    if args.fp8_config.enabled:
+        fp8_recipe = hydra.utils.get_class(args.fp8_config.fp8_recipe)(
+            fp8_format=Format[args.fp8_config.fp8_format], **args.fp8_config.fp8_recipe_kwargs
+        )
+    else:
+        fp8_recipe = None
 
     # Create a dataloader that just infinitely loops over the dataset.
     train_iterator = create_dataloader(dist_config, **args.dataset)
 
     # Training loop.
+    model.train()
     if dist_config.is_main_process():
         progress_bar = tqdm(range(args.num_train_steps), desc="Training", disable=False)
     previous_step_time = time.perf_counter()
@@ -96,11 +109,12 @@ def main(args: DictConfig) -> float | None:
     for step in range(args.num_train_steps):
         # Get batch.
         batch = next(train_iterator)
-        batch = {k: v.to(device) for k, v in batch.items()}
+        batch = {k: v.to(device) if isinstance(v, torch.Tensor) else v for k, v in batch.items()}
 
         # Forward pass with mixed precision.
         with torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16):
-            outputs = model(**batch)
+            with transformer_engine.pytorch.fp8_autocast(enabled=args.fp8_config.enabled, fp8_recipe=fp8_recipe):
+                outputs = model(**batch)
 
         # Backward pass.
         loss = outputs.loss

--- a/bionemo-recipes/recipes/esm2_native_te/train_mfsdp.py
+++ b/bionemo-recipes/recipes/esm2_native_te/train_mfsdp.py
@@ -26,6 +26,7 @@ from omegaconf import DictConfig, OmegaConf
 from torch.distributed.device_mesh import init_device_mesh
 from torch.optim import AdamW
 from tqdm import tqdm
+from transformer_engine.common.recipe import Format
 from transformers import AutoConfig, AutoModelForMaskedLM
 
 from dataset import create_dataloader
@@ -70,6 +71,9 @@ def main(args: DictConfig) -> float | None:
 
     # Create an empty ESM-2 model with a masked language model head.
     config = AutoConfig.from_pretrained(args.model_tag, trust_remote_code=True, dtype=torch.bfloat16)
+    # If we're using sequence packing with TE layers, we need to pass the `attn_input_format` argument.
+    if args.dataset.use_sequence_packing:
+        config.attn_input_format = "thd"
     model = AutoModelForMaskedLM.from_config(config, trust_remote_code=True)
 
     # The huggingface model has a contact head that we don't use in masked language pre-training, so we delete it to
@@ -110,6 +114,15 @@ def main(args: DictConfig) -> float | None:
     # Create a dataloader that just infinitely loops over the dataset.
     train_iterator = create_dataloader(dist_config, **args.dataset)
 
+    # Create an FP8 recipe
+    if args.fp8_config.enabled:
+        fp8_recipe = hydra.utils.get_class(args.fp8_config.fp8_recipe)(
+            fp8_format=Format[args.fp8_config.fp8_format], **args.fp8_config.fp8_recipe_kwargs
+        )
+        logger.info("Training with FP8: %s", fp8_recipe)
+    else:
+        fp8_recipe = None
+
     # Training loop.
     model.train()
     if dist_config.is_main_process():
@@ -119,11 +132,12 @@ def main(args: DictConfig) -> float | None:
     for step in range(args.num_train_steps):
         # Get batch.
         batch = next(train_iterator)
-        batch = {k: v.to(device) for k, v in batch.items()}
+        batch = {k: v.to(device) if isinstance(v, torch.Tensor) else v for k, v in batch.items()}
 
         # Forward pass with mixed precision.
         with torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16):
-            outputs = model(**batch)
+            with transformer_engine.pytorch.fp8_autocast(enabled=args.fp8_config.enabled, fp8_recipe=fp8_recipe):
+                outputs = model(**batch)
 
         # Backward pass.
         loss = outputs.loss


### PR DESCRIPTION
Adds additional tests to the esm-2 model, and implements THD and FP8 training in the ESM-2 native recipe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional sequence packing for variable-length inputs with masking-aware packing.

- Improvements
  - Safer device transfers (only tensors moved) and FP8-aware training paths using TransformerEngine autocast.
  - Data collator supports flattened/packed batches and optional padding to multiples.

- Configuration
  - New dataset flags: use_sequence_packing and sequence_packing_pad_to_multiple_of.
  - New fp8_config block to enable and tune FP8.

- Tests
  - FP8 gating and expanded FP8 test coverage across runtimes; new two-GPU sanity subprocess tests.

- Chores
  - Updated default container image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->