### PR TITLE
pin megatron-fsdp and add backwards tests

### DIFF
--- a/bionemo-recipes/models/esm2/pyproject.toml
+++ b/bionemo-recipes/models/esm2/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "hydra-core",
     "lightning",
     "megatron-core@git+https://github.com/NVIDIA/Megatron-LM.git", # Currently at ToT until mfsdp is in a release.
-    "megatron-fsdp",
+    "megatron-fsdp==0.1.0rc0",
     "nemo_toolkit[lightning]",                                     # tested with 2.3.1
     "omegaconf",
     "pytest",

--- a/bionemo-recipes/models/esm2/src/esm/collator.py
+++ b/bionemo-recipes/models/esm2/src/esm/collator.py
@@ -57,7 +57,6 @@ class MLMDataCollatorWithFlattening:
         mlm_probability (float | None): Probability of masking tokens. Defaults to 0.15.
         mask_replace_prob (float): Probability of replacing masked tokens with [MASK]. Defaults to 0.8.
         random_replace_prob (float): Probability of replacing masked tokens with random tokens. Defaults to 0.1.
-        tf_experimental_compile (bool): Whether to use TensorFlow experimental compilation. Defaults to False.
         return_tensors (str): Format for returned tensors. Only "pt" (PyTorch) is supported. Defaults to "pt".
         seed (int | None): Random seed for reproducible masking. Defaults to None.
         pad_to_multiple_of (int | None): If set, pads the total sequence length to be divisible
@@ -105,7 +104,6 @@ class MLMDataCollatorWithFlattening:
         mlm_probability: float | None = 0.15,
         mask_replace_prob: float = 0.8,
         random_replace_prob: float = 0.1,
-        tf_experimental_compile: bool = False,
         return_tensors: str = "pt",
         seed: int | None = None,
         pad_to_multiple_of: int | None = None,
@@ -118,7 +116,6 @@ class MLMDataCollatorWithFlattening:
             mlm_probability (float | None): Probability of masking tokens. Defaults to 0.15.
             mask_replace_prob (float): Probability of replacing masked tokens with [MASK]. Defaults to 0.8.
             random_replace_prob (float): Probability of replacing masked tokens with random tokens. Defaults to 0.1.
-            tf_experimental_compile (bool): Whether to use TensorFlow experimental compilation. Defaults to False.
             return_tensors (str): Format for returned tensors. Only "pt" (PyTorch) is supported. Defaults to "pt".
             seed (int | None): Random seed for reproducible masking. Defaults to None.
             pad_to_multiple_of (int | None): If set, pads the total sequence length to be divisible
@@ -130,7 +127,6 @@ class MLMDataCollatorWithFlattening:
             mlm_probability=mlm_probability,
             mask_replace_prob=mask_replace_prob,
             random_replace_prob=random_replace_prob,
-            tf_experimental_compile=tf_experimental_compile,
             return_tensors=return_tensors,
             seed=seed,
         )

--- a/bionemo-recipes/models/esm2/tests/conftest.py
+++ b/bionemo-recipes/models/esm2/tests/conftest.py
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import os
 
 import pytest
 import torch
+import transformer_engine.pytorch
 from datasets import Dataset
 from torch.utils.data import DataLoader
 from transformers import AutoModelForMaskedLM, AutoTokenizer, DataCollatorForLanguageModeling
@@ -36,6 +38,7 @@ if not os.environ.get("TRITON_LIBCUDA_PATH"):
 def use_te_debug(monkeypatch):
     monkeypatch.setenv("NVTE_DEBUG", "1")
     monkeypatch.setenv("NVTE_DEBUG_LEVEL", "2")
+    importlib.reload(transformer_engine.pytorch)
 
 
 @pytest.fixture

--- a/bionemo-recipes/models/esm2/tests/test_fp8.py
+++ b/bionemo-recipes/models/esm2/tests/test_fp8.py
@@ -31,11 +31,14 @@ def requires_fp8(func):
 def requires_mxfp8(func):
     """Decorator to skip tests that require MXFP8 support."""
     mxfp8_available, reason = check_mxfp8_support()
+    if torch.cuda.get_device_capability() == (12, 0):
+        mxfp8_available = False
+        reason = "MXFP8 is not supported on sm120"
     return pytest.mark.skipif(not mxfp8_available, reason=f"MXFP8 is not supported on this GPU: {reason}")(func)
 
 
 @requires_fp8
-def test_fp8_forward_pass(te_model_checkpoint, input_data):
+def test_fp8_forward_and_backward_pass(te_model_checkpoint, input_data):
     model_te = NVEsmForMaskedLM.from_pretrained(te_model_checkpoint, torch_dtype=torch.bfloat16)
     model_te.to("cuda")
 
@@ -45,12 +48,18 @@ def test_fp8_forward_pass(te_model_checkpoint, input_data):
     fp8_recipe = DelayedScaling()
     with transformer_engine.pytorch.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
         outputs_fp8 = model_te(**input_data)
+    outputs_fp8.loss.backward()
 
     torch.testing.assert_close(outputs_fp8.loss, outputs.loss)
 
 
 @requires_fp8
-def test_fp8_forward_pass_thd(te_model_checkpoint, input_data_thd):
+def test_fp8_forward_and_backward_pass_thd(te_model_checkpoint, input_data_thd, monkeypatch):
+    if torch.cuda.get_device_capability() == (12, 0):
+        # TODO(BIONEMO-2840): On sm120, we need to set NVTE_FUSED_ATTN to 0 since TE will choose fused attn by default,
+        # but it's missing this THD implementation.
+        monkeypatch.setenv("NVTE_FUSED_ATTN", "0")
+
     model_te = NVEsmForMaskedLM.from_pretrained(
         te_model_checkpoint, attn_input_format="thd", torch_dtype=torch.bfloat16
     )
@@ -62,12 +71,13 @@ def test_fp8_forward_pass_thd(te_model_checkpoint, input_data_thd):
     fp8_recipe = DelayedScaling()
     with transformer_engine.pytorch.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
         outputs_fp8 = model_te(**input_data)
+    outputs_fp8.loss.backward()
 
     torch.testing.assert_close(outputs_fp8.loss, outputs.loss)
 
 
 @requires_mxfp8
-def test_mxfp8_forward_pass(te_model_checkpoint, input_data):
+def test_mxfp8_forward_and_backward_pass(te_model_checkpoint, input_data):
     model_te = NVEsmForMaskedLM.from_pretrained(te_model_checkpoint, torch_dtype=torch.bfloat16)
     model_te.to("cuda")
 
@@ -77,12 +87,13 @@ def test_mxfp8_forward_pass(te_model_checkpoint, input_data):
     mxfp8_recipe = MXFP8BlockScaling()
     with transformer_engine.pytorch.fp8_autocast(enabled=True, fp8_recipe=mxfp8_recipe):
         outputs_fp8 = model_te(**input_data)
+    outputs_fp8.loss.backward()
 
     torch.testing.assert_close(outputs_fp8.loss, outputs.loss)
 
 
 @requires_mxfp8
-def test_mxfp8_forward_pass_thd(te_model_checkpoint, input_data_thd):
+def test_mxfp8_forward_and_backward_pass_thd(te_model_checkpoint, input_data_thd):
     model_te = NVEsmForMaskedLM.from_pretrained(
         te_model_checkpoint, attn_input_format="thd", torch_dtype=torch.bfloat16
     )
@@ -94,5 +105,6 @@ def test_mxfp8_forward_pass_thd(te_model_checkpoint, input_data_thd):
     mxfp8_recipe = MXFP8BlockScaling()
     with transformer_engine.pytorch.fp8_autocast(enabled=True, fp8_recipe=mxfp8_recipe):
         outputs_fp8 = model_te(**input_data)
+    outputs_fp8.loss.backward()
 
     torch.testing.assert_close(outputs_fp8.loss, outputs.loss)

--- a/bionemo-recipes/models/esm2/tests/test_thd.py
+++ b/bionemo-recipes/models/esm2/tests/test_thd.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from transformers import DataCollatorForTokenClassification
+
+from esm.collator import DataCollatorWithFlattening
+from esm.modeling_esm_te import NVEsmForMaskedLM
+
+
+def test_thd_from_collator_output(te_model_checkpoint, input_data_thd):
+    model_thd = NVEsmForMaskedLM.from_pretrained(
+        te_model_checkpoint, attn_input_format="thd", torch_dtype=torch.bfloat16
+    )
+    model_thd.to("cuda")
+    input_data_thd = {k: v.to("cuda") if isinstance(v, torch.Tensor) else v for k, v in input_data_thd.items()}
+    with torch.no_grad(), torch.amp.autocast("cuda", dtype=torch.bfloat16):
+        outputs = model_thd(**input_data_thd, output_hidden_states=True)
+
+    assert outputs.loss < 3.0
+
+
+def test_thd_values_match(te_model_checkpoint, tokenizer):
+    # Manually masked input tokens so that both BSHD and THD models have the same mask pattern
+
+    proteins = [
+        "MLSATEKLSDYISSLFASVSIINSISTEDLFFLKLTCQTFSKDSEEYKAAYRILRGVQRGKVQIIEEALVS",
+        "MFVFFAGTLVNQDTLNFRDQLNINVVGTVRGIAQDASKYLEYAIDSV",
+        "MAATGSLILSDEEQAELIALAVRIVLACAGGSQNKELAAQLGVIETTVGEWRRRFAQNRVEGLRDEARPGAPSDDQ",
+        "MSAVLSAVASDDWTAFAKLVHPYVHWTADGITTRGRTRVMARLSGHDGVKPASSYELRDGQVYRWTS",
+        "MSDPAAEPPADTSGIAWRKSSYSGPNGNCVELAQISGDHVGIRNSRDLHGSVLTCTRAEFAALLCDIKAGRFDSLIL",
+        "MRRPKLRRSGVLMSHPARGQPIKDASTEAAAERRPHVTSSERQDVSDQDTR",
+        "MQTITVAGGNLFQIAAQYLGDATQWIRIAQLNGLADPVLSGVVTLTIPQPNPLAGGGVVGQ",
+        "MVFSLEQFVRGQGWQSITSNSDNEVPKPRQVYEVKAVCHPGAWRVKARVFGTSQGIPFDYSQASMERRVAQDECDRRPQ",
+        "AGDGTGCNPTLSKAAGVELDNSDSGEVFVIYLHIIIAIIVLISINLIGFLYF",
+        "MKVGVDPSVCEAHGACMSILPEVFDLDDDEVLQIRDGELAPSEEESAERAVASCPMGALRLSR",
+        "MWISERPPSRMALGSQSQMSLPGIPARCLHS",
+        "MIDNSIRLFDADDSELFSLAEVPLDNKPIQRDTDSLSQWGDTWLREIQHS",
+        "MVKNLFFNKIKNATLKVANISRCYLPFPPPPCPPPEPLEPPEPPAPLEPAPDPPPLPPFPVPDILPAI",
+        "MSYINDITQSNSSILNVNVKINDHNSDEMYRNETKWYGEQFRYQSNPRFSRSSTSKNEKGFVQKKT",
+        "MQILILPIPDQLQNPNKISQHLICITFVSEQTLPI",
+    ]
+
+    sequences = [tokenizer(protein) for protein in proteins]
+    sequences = [
+        {
+            "input_ids": seq["input_ids"],
+            "attention_mask": seq["attention_mask"],
+            "labels": seq["input_ids"],
+        }
+        for seq in sequences
+    ]
+
+    bshd_collator = DataCollatorForTokenClassification(tokenizer=tokenizer, padding=True)
+    thd_collator = DataCollatorWithFlattening()
+
+    input_data_bshd = bshd_collator(sequences)
+    input_data_thd = thd_collator(sequences)
+
+    torch.testing.assert_close(
+        input_data_bshd["input_ids"][input_data_bshd["attention_mask"].to(bool)],
+        input_data_thd["input_ids"].flatten(0),
+    )
+
+    torch.testing.assert_close(
+        input_data_bshd["labels"][input_data_bshd["attention_mask"].to(bool)],
+        input_data_thd["labels"].flatten(0),
+    )
+
+    model_bshd = NVEsmForMaskedLM.from_pretrained(te_model_checkpoint, torch_dtype=torch.bfloat16)
+    model_thd = NVEsmForMaskedLM.from_pretrained(
+        te_model_checkpoint, attn_input_format="thd", torch_dtype=torch.bfloat16
+    )
+    model_bshd.to("cuda")
+    model_thd.to("cuda")
+
+    input_data_bshd = {k: v.to("cuda") for k, v in input_data_bshd.items()}
+    input_data_thd = {k: v.to("cuda") if isinstance(v, torch.Tensor) else v for k, v in input_data_thd.items()}
+
+    bshd_outputs = model_bshd(**input_data_bshd)
+    thd_outputs = model_thd(**input_data_thd)
+
+    torch.testing.assert_close(bshd_outputs.loss, thd_outputs.loss)
+
+    # bshd_logits = bshd_outputs.logits[input_data_bshd["attention_mask"].to(bool)]
+    # TODO(BIONEMO-2801): Investigate why these are not close on sm89 but pass on sm120.
+    # torch.testing.assert_close(bshd_logits, thd_outputs.logits)
+
+
+def test_thd_backwards(te_model_checkpoint, input_data_thd, monkeypatch):
+    if torch.cuda.get_device_capability() == (12, 0):
+        # TODO(BIONEMO-2840): On sm120, we need to set NVTE_FUSED_ATTN to 0 since TE will choose fused attn by default,
+        # but it's missing this THD implementation.
+        monkeypatch.setenv("NVTE_FUSED_ATTN", "0")
+
+    model_thd = NVEsmForMaskedLM.from_pretrained(
+        te_model_checkpoint, attn_input_format="thd", torch_dtype=torch.bfloat16
+    )
+    model_thd.to("cuda")
+    input_data = {k: v.to("cuda") if isinstance(v, torch.Tensor) else v for k, v in input_data_thd.items()}
+    outputs = model_thd(**input_data)
+    outputs.loss.backward()


### PR DESCRIPTION
Fix models/esm2 tests by pinning megatron-fsdp and adding additional backwards tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Expanded FP8 tests to include backward passes.
  - Added THD test suite covering collator parity, inference loss checks, and backpropagation.
  - Conditional handling for newer GPUs (SM120) and attention-fusion toggling in tests.
  - More reliable test setup by reloading the TE backend; improved MXFP8 availability guard.

- Chores
  - Pinned megatron-fsdp to 0.1.0rc0 for reproducible installs.

- Breaking Changes
  - Removed the TensorFlow experimental compilation option from the MLM data-collator constructor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->