### PR TITLE
Set up Slack Alerts for nv-gha-actions

### DIFF
--- a/.github/nv-slack-bot.yaml
+++ b/.github/nv-slack-bot.yaml
@@ -9,8 +9,8 @@ notifications:
         channels:
           - id: ${{ vars.BIONEMO_FW_CI_ALERTS_SLACK_ID }} # bionemo-fw-ci-alerts
     match: >
-      workflow_run.conclusion = "failure" 
-      and workflow_run.name = "BioNeMo Framework CI" 
+      workflow_run.conclusion = "failure"
+      and workflow_run.name = "BioNeMo Framework CI"
       and workflow_run.event = "schedule"
     message:
       body: |
@@ -28,8 +28,8 @@ notifications:
         channels:
           - id: ${{ vars.BIONEMO_FW_CI_ALERTS_SLACK_ID }}
     match: >
-      workflow_run.conclusion = "failure" 
-      and workflow_run.name = "BioNeMo Recipes CI" 
+      workflow_run.conclusion = "failure"
+      and workflow_run.name = "BioNeMo Recipes CI"
       and workflow_run.event = "schedule"
     message:
       body: |


### PR DESCRIPTION
### Description
This PR sets up notifications for nightly workflow failures on Github actions. Alerts happen for scheduled failures related to BioNemo Framework CI and BioNeMo Recipes CI. Addresses this Jira ticket: https://jirasw.nvidia.com/browse/BIONEMO-2748?filter=-1

### Type of changes

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

### CI Pipeline Configuration

Configure CI behavior by applying the relevant labels:
/label SKIP_CI
- [SKIP_CI](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#skip_ci) - Skip all continuous integration tests
- [INCLUDE_NOTEBOOKS_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_notebooks_tests) - Execute notebook validation tests in pytest
- [INCLUDE_SLOW_TESTS](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/user-guide/contributing/contributing.md#include_slow_tests) - Execute tests labelled as slow in pytest for extensive testing

> [!NOTE]
> By default, the notebooks validation tests are skipped unless explicitly enabled.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Usage

N/A - this is purely a configuration for Slack notifications. 

### Pre-submit Checklist

This change will be tested in production. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Slack notifications for nightly CI failures for BioNeMo Framework and BioNeMo Recipes workflows.
  * Notifications include workflow names and links, delivered to the team’s Slack channel to improve visibility and response to nightly build issues.
  * Messages use templates and suppress webhook payloads on error; no public APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->