### PR TITLE
add fp8 decorator to esm2 tests

### DIFF
--- a/bionemo-recipes/recipes/esm2_native_te/tests/test_train.py
+++ b/bionemo-recipes/recipes/esm2_native_te/tests/test_train.py
@@ -281,6 +281,7 @@ def test_sanity_mfsdp_thd(distributed_cleanup, tmp_path, monkeypatch, recipe_pat
     main_mfsdp(sanity_config)
 
 
+@requires_fp8
 def test_sanity_ddp_thd_fp8(distributed_cleanup, tmp_path, monkeypatch, recipe_path):
     if torch.cuda.get_device_capability() == (12, 0):
         # TODO(BIONEMO-2840): On sm120, we need to set NVTE_FUSED_ATTN to 0 since TE will choose fused attn by default,
@@ -303,6 +304,7 @@ def test_sanity_ddp_thd_fp8(distributed_cleanup, tmp_path, monkeypatch, recipe_p
     main_ddp(sanity_config)
 
 
+@requires_fp8
 def test_sanity_mfsdp_thd_fp8(distributed_cleanup, tmp_path, monkeypatch, recipe_path):
     if torch.cuda.get_device_capability() == (12, 0):
         # TODO(BIONEMO-2840): On sm120, we need to set NVTE_FUSED_ATTN to 0 since TE will choose fused attn by default,


### PR DESCRIPTION
Forgot these in my fp8+thd PR, adding to fix tests on devices without FP8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * FP8-dependent THD training tests are now conditionally skipped when FP8 support isn’t available, preventing false failures on unsupported hardware and improving CI reliability.
  * Non-FP8 test coverage and behavior remain unchanged, ensuring consistent validation for standard configurations.
  * This update streamlines local and CI test runs across diverse environments without impacting runtime features or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->