### PR TITLE
Fix checkpoint bug bad checkpoint hydra structure

### DIFF
--- a/bionemo-recipes/recipes/esm2_native_te/hydra_config/L1_15B_perf_test.yaml
+++ b/bionemo-recipes/recipes/esm2_native_te/hydra_config/L1_15B_perf_test.yaml
@@ -22,4 +22,9 @@ adamw_kwargs:
 lr_scheduler_kwargs:
   num_warmup_steps: 20_000
 
-ckpt_dir: "checkpoints/esm2_t48_15B_UR50D_sanity"
+# Checkpoint config
+checkpoint:
+  ckpt_dir: "checkpoints/esm2_t48_15B_UR50D_sanity"
+  resume_from_checkpoint: false
+  use_distributed_checkpoint_fsdp2: true
+  save_every_n_steps: 500

--- a/bionemo-recipes/recipes/esm2_native_te/hydra_config/L1_3B.yaml
+++ b/bionemo-recipes/recipes/esm2_native_te/hydra_config/L1_3B.yaml
@@ -17,4 +17,9 @@ wandb_init_args:
 lr_scheduler_kwargs:
   num_warmup_steps: 20_000
 
-ckpt_dir: "checkpoints/esm2_t36_3B_UR50D_sanity"
+# Checkpoint config
+checkpoint:
+  ckpt_dir: "checkpoints/esm2_t36_3B_UR50D_sanity"
+  resume_from_checkpoint: false
+  use_distributed_checkpoint_fsdp2: true
+  save_every_n_steps: 500

--- a/bionemo-recipes/recipes/esm2_native_te/hydra_config/L1_650M.yaml
+++ b/bionemo-recipes/recipes/esm2_native_te/hydra_config/L1_650M.yaml
@@ -15,4 +15,9 @@ wandb_init_args:
   project: "bionemo-recipes-pstjohn"
   mode: "offline"
 
-ckpt_dir: "checkpoints/esm2_t33_650M_UR50D_sanity"
+# Checkpoint config
+checkpoint:
+  ckpt_dir: "checkpoints/esm2_t33_650M_UR50D_sanity"
+  resume_from_checkpoint: false
+  use_distributed_checkpoint_fsdp2: true
+  save_every_n_steps: 500


### PR DESCRIPTION
### Description

<!-- Provide a detailed description of the changes in this PR -->

#### Usage

<!--- How does a user interact with the changed code -->

```python
TODO: Add code snippet
```

### Type of changes

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

### CI Pipeline Configuration

Configure CI behavior by applying the relevant labels. By default, only basic unit tests are run.

- [ciflow:skip](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:skip) - Skip all CI tests for this PR
- [ciflow:notebooks](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:notebooks) - Run Jupyter notebooks execution tests for bionemo2
- [ciflow:slow](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:slow) - Run slow single GPU integration tests marked as @pytest.mark.slow for bionemo2
- [ciflow:all](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:all) - Run all tests (unit tests, slow tests, and notebooks) for bionemo2. This label can be used to enforce running tests for all bionemo2.
- [ciflow:all-recipes](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:all-recipes) - Run tests for all recipes (under bionemo-recipes). This label can be used to enforce running tests for all recipes.

Unit tests marked as `@pytest.mark.multi_gpu` or `@pytest.mark.distributed` are not run in the PR pipeline.

For more details, see [CONTRIBUTING](CONTRIBUTING.md)

> [!NOTE]
> By default, only basic unit tests are run. Add appropriate labels to enable an additional test coverage.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Pre-submit Checklist

<!--- Ensure all items are completed before submitting -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified checkpoint configuration with options for distributed checkpointing, explicit resume control, and a default save cadence (every 500 steps).
- Refactor
  - Consolidated standalone checkpoint path into a single checkpoint block across relevant model configurations for consistency and easier management.
- Improvements
  - More predictable and resilient training runs with periodic saves and better support for distributed training environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->