### PR TITLE
ensure branch resolves correctly for commit_sha

### DIFF
--- a/ci/lepton/model_convergence/scripts/wrap_template.sh
+++ b/ci/lepton/model_convergence/scripts/wrap_template.sh
@@ -104,6 +104,13 @@ fi
 # Inject/overwrite the resolved framework commit (only if we actually got one)
 if [ -n "${COMMIT_SHA:-}" ]; then
   ALL_CONFIG_JSON_UPDATED="$(printf '%s' "$ALL_CONFIG_JSON_UPDATED" | jq -c --arg commit "$COMMIT_SHA" '.commit_sha = $commit')"
+
+  # Find which branch contains this commit
+  RESOLVED_BRANCH="$(cd bionemo-framework && git branch -r --contains "$COMMIT_SHA" | grep 'origin/' | head -1 | sed 's|.*origin/||' || true)"
+
+  if [ -n "$RESOLVED_BRANCH" ] && [ "$RESOLVED_BRANCH" != "HEAD" ]; then
+    ALL_CONFIG_JSON_UPDATED="$(printf '%s' "$ALL_CONFIG_JSON_UPDATED" | jq -c --arg branch "$RESOLVED_BRANCH" '.branch = $branch')"
+  fi
 fi
 
 # Extract values from config (with sensible defaults)


### PR DESCRIPTION
Ensure branch resolves correctly when user provides a commit_sha.

That is, ensure our logs don't accidentally log a `main` branch (default) if the commit_sha belongs to a different branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI metadata: when a commit is specified, the system now also resolves and records the corresponding branch (if identifiable and not HEAD) alongside the commit. This enhances traceability of builds and generated configuration metadata. Behavior remains unchanged when no commit is provided, ensuring no impact on runtime or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->