### PR TITLE
adds attn mask type

### DIFF
--- a/bionemo-recipes/models/esm2/src/esm/modeling_esm_te.py
+++ b/bionemo-recipes/models/esm2/src/esm/modeling_esm_te.py
@@ -60,6 +60,7 @@ class NVEsmConfig(EsmConfig):
         micro_batch_size: Optional[int] = None,
         max_seq_length: Optional[int] = None,
         padded_vocab_size: Optional[int] = 64,
+        attn_mask_type: str = "padding",
         **kwargs,
     ):
         """Initialize the NVEsmConfig with additional TE-related config options.
@@ -89,6 +90,7 @@ class NVEsmConfig(EsmConfig):
                 ensure same kernels are used for forward propogation and activation recompute phase.
             padded_vocab_size: The padded vocabulary size to support FP8. If not provided, defaults
                 to vocab_size. Must be greater than or equal to vocab_size.
+            attn_mask_type: The type of attention mask to use.
             **kwargs: Additional config options to pass to EsmConfig.
         """
         super().__init__(**kwargs)
@@ -99,6 +101,7 @@ class NVEsmConfig(EsmConfig):
         self.fuse_qkv_params = fuse_qkv_params
         self.micro_batch_size = micro_batch_size
         self.max_seq_length = max_seq_length
+        self.attn_mask_type = attn_mask_type
 
         # Set padded_vocab_size with default fallback to vocab_size
         self.padded_vocab_size = padded_vocab_size if padded_vocab_size is not None else self.vocab_size
@@ -133,7 +136,7 @@ class NVEsmEncoder(nn.Module):
                     qkv_weight_interleaved=config.qkv_weight_interleaved,
                     layer_number=i + 1,
                     layer_type="encoder",
-                    self_attn_mask_type="padding",
+                    self_attn_mask_type=config.attn_mask_type,
                     activation=config.encoder_activation,
                     attn_input_format=config.attn_input_format,
                     seq_length=config.max_seq_length,


### PR DESCRIPTION
### Description

<!-- Provide a detailed description of the changes in this PR -->

#### Usage

<!--- How does a user interact with the changed code -->

```python
TODO: Add code snippet
```

### Type of changes

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

### CI Pipeline Configuration

Configure CI behavior by applying the relevant labels. By default, only basic unit tests are run.

- [ciflow:skip](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:skip) - Skip all CI tests for this PR
- [ciflow:notebooks](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:notebooks) - Run Jupyter notebooks execution tests for bionemo2
- [ciflow:slow](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:slow) - Run slow single GPU integration tests marked as @pytest.mark.slow for bionemo2
- [ciflow:all](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:all) - Run all tests (unit tests, slow tests, and notebooks) for bionemo2. This label can be used to enforce running tests for all bionemo2.
- [ciflow:all-recipes](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:all-recipes) - Run tests for all recipes (under bionemo-recipes). This label can be used to enforce running tests for all recipes.

Unit tests marked as `@pytest.mark.multi_gpu` or `@pytest.mark.distributed` are not run in the PR pipeline.

For more details, see [CONTRIBUTING](CONTRIBUTING.md)

> [!NOTE]
> By default, only basic unit tests are run. Add appropriate labels to enable an additional test coverage.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Pre-submit Checklist

<!--- Ensure all items are completed before submitting -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to select the attention mask type for ESM models, enabling customization beyond the previous fixed behavior.
  * Default remains “padding,” ensuring no changes for existing setups unless explicitly configured.
  * The selected attention mask type is consistently applied across encoder layers for predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->