### PR TITLE
Add initial L1_3B config

### DIFF
--- a/bionemo-recipes/recipes/esm2_accelerate_te/hydra_config/L1_3B.yaml
+++ b/bionemo-recipes/recipes/esm2_accelerate_te/hydra_config/L1_3B.yaml
@@ -1,0 +1,16 @@
+defaults:
+  - defaults
+  - _self_
+
+model_tag: nvidia/esm2_t36_3B_UR50D
+
+stop_after_n_steps: 10_000
+
+trainer:
+  run_name: "esm2_t36_3B_UR50D_perf"
+  per_device_train_batch_size: 16
+  per_device_eval_batch_size: 16
+  report_to: "wandb"
+  learning_rate: 4e-4
+  weight_decay: 0.01
+  warmup_steps: 20_000


### PR DESCRIPTION
Add initial `L1_3B` config for `esm2_accelerate`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a ready-to-use training configuration preset for the ESM2 3B model, enabling quicker experiment setup.
  - Includes sensible defaults for trainer settings: global/run naming, per-GPU and global batch sizes, learning rate scheduling with warmup, weight decay, and early stop criteria.
  - Built-in optional Weights & Biases reporting for experiment tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->