### PR TITLE
[WIP] LLAMA3 Integration with BioNeMo Recipes with ASCII Tokenization/EVO2-Style Dataloader

### DIFF
--- a/bionemo-recipes/recipes/llama_native_te_nvfsdp/__init__.py
+++ b/bionemo-recipes/recipes/llama_native_te_nvfsdp/__init__.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLAMA3 recipe with ASCII tokenization and genomic windowing for BioNeMo."""
+
+from tokenizer import NucleotideASCIITokenizer
+from .dataloader import GenomicSequenceDataset, create_genomic_dataloader, infinite_dataloader
+
+__all__ = [
+    "NucleotideASCIITokenizer",
+    "GenomicSequenceDataset", 
+    "create_genomic_dataloader",
+    "infinite_dataloader",
+]

--- a/bionemo-recipes/recipes/llama_native_te_nvfsdp/dataloader.py
+++ b/bionemo-recipes/recipes/llama_native_te_nvfsdp/dataloader.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+
+"""
+Simple LLAMA3 Genomic Dataloader (no Lightning dependencies).
+
+Implements meeting requirements:
+1. First tiling, then tokenization  
+2. Fixed window positions + randomized access (EVO2 style)
+3. SQL backend for speed
+4. EVO2-style overlap ratio (200bp default)
+"""
+
+import sqlite3
+import random
+import numpy as np
+from typing import Dict, Optional, Tuple, Iterator
+from pathlib import Path
+import torch
+from torch.utils.data import Dataset, DataLoader, DistributedSampler
+from omegaconf import DictConfig
+
+from tokenizer import NucleotideASCIITokenizer
+
+
+class GenomicSequenceDataset(Dataset):
+    """
+    EVO2-style genomic dataset with proper tiling and randomization.
+    
+    Key features:
+    1. First tiling (pre-compute window mappings)
+    2. Then tokenization (ASCII nucleotide encoding)
+    3. Fixed positions + shuffled access (like EVO2)
+    """
+    
+    def __init__(
+        self,
+        database_path: str,
+        seq_length: int = 8192,
+        tokenizer: Optional[NucleotideASCIITokenizer] = None,
+        stride: int = 7992,  # EVO2 default: 200bp overlap
+        min_window_length: int = 1000,
+        seed: int = 42,
+        rc_augmentation: bool = False,
+    ):
+        """
+        Initialize genomic dataset with EVO2-style tiling.
+        
+        Args:
+            database_path: Path to SQLite database with sequences
+            seq_length: Window size (8192 for LLAMA3)
+            tokenizer: ASCII tokenizer for nucleotides
+            stride: Stride between windows (7992 = 8192-200 for EVO2 overlap)
+            min_window_length: Minimum effective window length
+            seed: Random seed for reproducible randomization
+            rc_augmentation: Apply reverse complement augmentation
+        """
+        self.database_path = Path(database_path)
+        self.seq_length = seq_length
+        self.stride = stride
+        self.min_window_length = min_window_length
+        self.seed = seed
+        self.rc_augmentation = rc_augmentation
+        
+        if tokenizer is None:
+            self.tokenizer = NucleotideASCIITokenizer()
+        else:
+            self.tokenizer = tokenizer
+            
+        # Initialize random state
+        self.rng = np.random.RandomState(seed)
+        random.seed(seed)
+        
+        # Step 1: Load sequences from database
+        self._load_sequences()
+        
+        # Step 2: First create window mappings (EVO2 style)
+        self._create_window_mappings()
+        
+        # Step 3: Randomize lookups - shuffle window indices
+        self._randomize_window_access()
+        
+        print(f"Dataset ready: {len(self.window_mappings):,} windows with EVO2-style tiling")
+    
+    def _load_sequences(self):
+        """Load sequence metadata from SQLite database."""
+        if not self.database_path.exists():
+            raise FileNotFoundError(f"Database not found: {self.database_path}")
+            
+        with sqlite3.connect(str(self.database_path)) as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT contig_id, length FROM sequences ORDER BY contig_id")
+            self.sequences = cursor.fetchall()
+            
+        print(f"Loaded {len(self.sequences)} sequences from database")
+    
+    def _create_window_mappings(self):
+        """
+        Step 1: First tiling - create window mappings EVO2 style.
+        
+        Fixed window positions (no jitter) like EVO2.
+        """
+        self.window_mappings = []  # List of (seq_idx, contig_id, start_pos, effective_length)
+        
+        total_windows = 0
+        for seq_idx, (contig_id, seq_length) in enumerate(self.sequences):
+            if seq_length < self.min_window_length:
+                continue
+            
+            # Calculate number of windows (EVO2 formula)
+            if seq_length <= self.seq_length:
+                # Short sequence: single window
+                num_windows = 1
+                positions = [0]
+            else:
+                # Long sequence: EVO2 stride-based windows
+                num_windows = 1 + (seq_length - self.seq_length) // self.stride
+                positions = [i * self.stride for i in range(num_windows)]
+            
+            # Create window mappings for this sequence (fixed positions)
+            for i, start_pos in enumerate(positions):
+                effective_length = min(self.seq_length, seq_length - start_pos)
+                if effective_length >= self.min_window_length:
+                    self.window_mappings.append((seq_idx, contig_id, start_pos, effective_length))
+                    total_windows += 1
+        
+        print(f"Created {total_windows:,} window mappings with stride={self.stride} (overlap={self.seq_length - self.stride}bp)")
+    
+    def _randomize_window_access(self):
+        """
+        Step 3: Randomize lookups - shuffle window indices.
+        
+        Uses fixed window positions (like EVO2) but randomizes access order.
+        This ensures we don't just get position-0 windows from each sequence.
+        """
+        # Create shuffled indices for randomized access
+        self.shuffled_indices = list(range(len(self.window_mappings)))
+        random.shuffle(self.shuffled_indices)
+        print(f"Shuffled {len(self.shuffled_indices):,} window indices for randomized access")
+    
+    def __len__(self) -> int:
+        """Return number of windows."""
+        return len(self.window_mappings)
+    
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        """
+        Get a windowed sequence sample.
+        
+        Process:
+        1. Map shuffled index to actual window (randomized lookup)
+        2. Retrieve sequence from SQL database (tiled position)
+        3. Tokenize with ASCII encoding (then tokenization)
+        """
+        # Map shuffled index to actual window (randomized lookup)
+        actual_idx = self.shuffled_indices[idx % len(self.shuffled_indices)]
+        seq_idx, contig_id, start_pos, window_length = self.window_mappings[actual_idx]
+        
+        # Retrieve sequence from SQL database (speed requirement)
+        with sqlite3.connect(str(self.database_path)) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT substr(nt_sequence, ?, ?) FROM sequences WHERE contig_id = ?",
+                (start_pos + 1, window_length, contig_id)  # SQLite is 1-indexed
+            )
+            result = cursor.fetchone()
+            
+        if result is None:
+            raise ValueError(f"Sequence {contig_id} not found in database")
+            
+        sequence = result[0].upper()
+        
+        # Apply reverse complement augmentation if enabled
+        if self.rc_augmentation and self.rng.rand() > 0.5:
+            sequence = self._reverse_complement(sequence)
+        
+        # Step 2: Then tokenization - ASCII encoding (meeting requirement)
+        token_ids = self.tokenizer.encode(sequence, add_special_tokens=True)
+        
+        # Pad or truncate to target length
+        if len(token_ids) < self.seq_length:
+            token_ids.extend([self.tokenizer.pad_token_id] * (self.seq_length - len(token_ids)))
+        else:
+            token_ids = token_ids[:self.seq_length]
+        
+        # Create tensors
+        tokens = torch.tensor(token_ids, dtype=torch.long)
+        
+        # Create labels for autoregressive training
+        labels = tokens.clone()
+        labels[:-1] = tokens[1:]
+        labels[-1] = self.tokenizer.pad_token_id
+        
+        # Create attention mask (1 for real tokens, 0 for padding)
+        attention_mask = (tokens != self.tokenizer.pad_token_id).long()
+        
+        # Create loss mask (don't compute loss on special tokens)
+        loss_mask = attention_mask.clone()
+        loss_mask[tokens == self.tokenizer.bos_token_id] = 0
+        loss_mask[tokens == self.tokenizer.eos_token_id] = 0
+        
+        return {
+            "input_ids": tokens,
+            "labels": labels,
+            "attention_mask": attention_mask,
+            "loss_mask": loss_mask.float(),
+            "seq_idx": torch.tensor(idx, dtype=torch.long),
+        }
+    
+    def _reverse_complement(self, sequence: str) -> str:
+        """Apply reverse complement transformation to DNA sequence."""
+        complement = {'A': 'T', 'T': 'A', 'C': 'G', 'G': 'C', 'N': 'N'}
+        return ''.join(complement.get(base, 'N') for base in reversed(sequence))
+
+
+def infinite_dataloader(dataloader: DataLoader, sampler: DistributedSampler) -> Iterator[Dict[str, torch.Tensor]]:
+    """Create an infinite dataloader that loops through epochs.
+    
+    Args:
+        dataloader: The DataLoader to loop through.
+        sampler: The DistributedSampler to set epochs for.
+        
+    Yields:
+        Dict containing batch data.
+    """
+    epoch = 0
+    while True:
+        sampler.set_epoch(epoch)  # Update epoch for proper shuffling
+        for batch in dataloader:
+            yield batch
+        epoch += 1  # Increment epoch counter after completing one full pass
+
+
+def create_genomic_dataloader(args: DictConfig, tokenizer: NucleotideASCIITokenizer) -> Tuple[Iterator[Dict[str, torch.Tensor]], int]:
+    """
+    Create genomic dataloader compatible with Bruno's training script.
+    
+    This creates an infinite iterator matching Bruno's interface while
+    implementing EVO2-style tiling and randomization.
+    """
+    # Create simple dataset for Bruno's training loop
+    dataset = GenomicSequenceDataset(
+        database_path=args.dataset.database_path,
+        seq_length=args.dataset.seq_length,
+        tokenizer=tokenizer,
+        stride=args.dataset.get("stride", args.dataset.seq_length - 200),  # EVO2 default
+        min_window_length=args.dataset.get("min_window_length", 1000),
+        seed=args.dataset.get("seed", 42),
+        rc_augmentation=args.dataset.get("rc_augmentation", False),
+    )
+    
+    # Create distributed sampler for FSDP compatibility (following ESM2/Geneformer pattern)
+    train_sampler = DistributedSampler(dataset)
+    
+    # Create dataloader
+    dataloader = DataLoader(
+        dataset,
+        batch_size=args.dataset.batch_size,
+        sampler=train_sampler,  # Use distributed sampler instead of shuffle=True
+        num_workers=args.dataset.get("num_workers", 0),
+        pin_memory=True,
+        drop_last=True,
+        persistent_workers=args.dataset.get("num_workers", 0) > 0,
+    )
+    
+    # Calculate epoch length  
+    epoch_len = len(dataloader)  # Use dataloader length for distributed setting
+    
+    print(f"Created genomic dataloader: {len(dataset):,} windows, {epoch_len:,} batches per epoch")
+    print(f"Tiling: stride={dataset.stride}, overlap={dataset.seq_length - dataset.stride}bp")
+    print("Randomization: fixed_positions=True, shuffled_access=True (EVO2 style)")
+    print("Distributed: DistributedSampler for FSDP compatibility")
+    
+    # Create infinite iterator (matches Bruno's interface and other recipes)
+    train_iterator = infinite_dataloader(dataloader, train_sampler)
+    
+    return train_iterator, epoch_len

--- a/bionemo-recipes/recipes/llama_native_te_nvfsdp/hydra_config/L0_sanity.yaml
+++ b/bionemo-recipes/recipes/llama_native_te_nvfsdp/hydra_config/L0_sanity.yaml
@@ -1,0 +1,28 @@
+# Sanity test configuration for LLAMA3 genomic training  
+defaults:
+  - defaults
+
+# Reduced model architecture for memory constraints
+model_layers: 4   # Reduce from 32 to 4 layers for memory constraints
+hidden_size: 2048 # Reduce from 4096 to 2048 for memory constraints
+
+dataset:
+  seq_length: 8192  # 
+  batch_size: 1
+  num_workers: 0  # Single-threaded for debugging
+  stride: 7992  # EVO2-style: 8192 - 200 = 7992 (consistent 200bp overlap)
+
+# Quick training run
+num_train_steps: 25  # More steps to see continued learning
+
+# Learning rate scheduler
+lr_scheduler_kwargs:
+  num_warmup_steps: 2  # Minimal warmup for sanity test
+  num_training_steps: ${num_train_steps}
+
+# Wandb config for testing
+wandb_init_args:
+  project: "llama3-genomic-pretraining"  
+  name: "l0-sanity-test-ddp"
+  notes: "Sanity test for LLAMA3 genomic training pipeline with DDP"
+  tags: ["llama3", "genomic", "sanity-test", "ascii-tokenizer", "ddp"]

--- a/bionemo-recipes/recipes/llama_native_te_nvfsdp/hydra_config/L1_pilot.yaml
+++ b/bionemo-recipes/recipes/llama_native_te_nvfsdp/hydra_config/L1_pilot.yaml
@@ -1,0 +1,38 @@
+# Pilot configuration for LLAMA3 genomic training (WIP testing)
+defaults:
+  - defaults
+
+# Slightly larger model for realistic testing (but still memory-safe)
+model_layers: 8   # Double the sanity test layers (still 1/4 of full model)
+hidden_size: 2048 # Keep reduced hidden size for memory safety
+
+dataset:
+  seq_length: 8192  # Full sequence length to test RoPE
+  batch_size: 1     # Conservative for memory
+  num_workers: 4    # More realistic data loading
+  stride: 7992      # EVO2-style: 8192 - 200 = 7992 (200bp overlap)
+
+# More realistic training run
+num_train_steps: 200  # Enough to see learning trends
+micro_batch_size: 1   # Conservative for memory
+
+# Learning rate scheduler
+lr_scheduler_kwargs:
+  num_warmup_steps: 20  # 10% warmup
+  num_training_steps: ${num_train_steps}
+
+# Optimizer (slightly more conservative)
+adamw_kwargs:
+  lr: 2.0e-4  # Reduced from 4e-4 for stability
+  fused: true
+  betas: [0.9, 0.98]
+  eps: 1.0e-8
+  weight_decay: 0.1
+
+# Wandb config for pilot testing
+wandb_init_args:
+  project: "llama3-genomic-pretraining"  
+  name: "l1-pilot-8layers-8k-context"
+  notes: "Pilot test: 8-layer LLAMA3 with 8K context, ASCII tokenization, dynamic RoPE"
+  tags: ["llama3", "genomic", "pilot", "ascii-tokenizer", "dynamic-rope", "wip"]
+  mode: "online"

--- a/bionemo-recipes/recipes/llama_native_te_nvfsdp/hydra_config/ddp_defaults.yaml
+++ b/bionemo-recipes/recipes/llama_native_te_nvfsdp/hydra_config/ddp_defaults.yaml
@@ -1,0 +1,44 @@
+# DDP configuration for LLAMA3 genomic training
+defaults:
+  - defaults
+
+# Model configuration optimized for DDP
+model:
+  hidden_size: 1024
+  intermediate_size: 2048  
+  num_layers: 12
+  num_attention_heads: 16
+  max_position_embeddings: 8192
+  seq_length: 8192
+
+# Dataset configuration optimized for DDP
+dataset:
+  seq_length: 8192
+  batch_size: 8  # Larger batch size for DDP
+  num_workers: 8
+  stride: 4096
+  min_window_length: 1000
+  rc_augmentation: false
+  seed: 42
+
+# Training configuration
+num_train_steps: 1000
+use_meta_device: false  # DDP typically doesn't use meta device
+
+# Optimizer configuration
+adamw_kwargs:
+  lr: 5.0e-4
+  betas: [0.9, 0.95]
+  weight_decay: 0.1
+
+# Learning rate scheduler
+lr_scheduler_kwargs:
+  num_warmup_steps: 100
+  num_training_steps: ${num_train_steps}
+
+# Weights and Biases logging
+wandb_init_args:
+  project: "llama3-genomic-pretraining"
+  name: "llama3-ddp-8k-genomic"
+  notes: "LLAMA3 DDP training on genomic sequences with ASCII tokenization and 8k windowing"
+  tags: ["llama3", "genomic", "ascii-tokenizer", "ddp", "production"]

--- a/bionemo-recipes/recipes/llama_native_te_nvfsdp/hydra_config/defaults.yaml
+++ b/bionemo-recipes/recipes/llama_native_te_nvfsdp/hydra_config/defaults.yaml
@@ -1,0 +1,57 @@
+# Bruno's FSDP configuration adapted for genomic training
+defaults:
+  - _self_
+
+# Model configuration (Bruno's style)
+model_name: "meta-llama/Llama-2-7b-hf"
+max_seq_length: 8192
+
+# Dataset configuration (genomic-specific) 
+dataset:
+  database_path: "/workspace/data/glm_dataset_opengenome2-metagenome_1024.sqlite"
+  seq_length: 8192
+  batch_size: 4
+  num_workers: 8
+  stride: 7992  # EVO2-style minimal overlap (follow Bruno's performance focus)
+  min_window_length: 1000
+  rc_augmentation: false
+  seed: 42
+
+# Training configuration
+micro_batch_size: 2
+num_train_steps: 1000
+
+# FSDP config (Bruno's approach)
+use_fsdp: true
+fully_shard_kwargs:
+  zero_dp_strategy: "optim_grads_params"
+  calculate_per_token_loss: false
+  init_model_with_meta_device: true
+  check_for_nan_in_grad: true
+  grad_reduce_in_fp32: false
+  preserve_fp32_weights: true
+  overlap_grad_reduce: true
+  overlap_param_gather: true
+  sync_grads_each_step: true
+  average_in_collective: false
+
+# Optimizer config (Bruno's settings)
+adamw_kwargs:
+  lr: 4.0e-4
+  fused: true
+  betas: [0.9, 0.98]
+  eps: 1.0e-8
+  weight_decay: 0.1
+
+# Learning rate scheduler
+lr_scheduler_kwargs:
+  num_warmup_steps: 100
+  num_training_steps: ${num_train_steps}
+
+# Weights and Biases logging
+wandb_init_args:
+  project: "llama3-genomic-pretraining"
+  name: "llama3-ascii-tokenization-8k-fsdp"
+  notes: "LLAMA3 training on genomic sequences with Bruno's FSDP setup + genomic dataloader"
+  tags: ["llama3", "genomic", "ascii-tokenizer", "fsdp", "bruno-recipe"]
+  mode: "online"  # Can be overridden to "disabled" for testing

--- a/bionemo-recipes/recipes/llama_native_te_nvfsdp/model.py
+++ b/bionemo-recipes/recipes/llama_native_te_nvfsdp/model.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gc
+import re
+
+import torch
+import transformer_engine as te
+from torch import nn
+from torch import Tensor
+from transformer_engine.pytorch.attention.rope import RotaryPositionEmbedding
+from transformers import AutoConfig
+from transformers import LlamaForCausalLM
+from transformers import LlamaModel
+from transformers.models.llama.configuration_llama import LlamaConfig
+from transformers.models.llama.modeling_llama import LlamaPreTrainedModel
+from transformers.models.llama.modeling_llama import LlamaRMSNorm
+from transformers.utils import logging
+
+logger = logging.get_logger(__name__)
+
+
+class NVLlamaDecoderLayer(te.pytorch.TransformerLayer):
+    """NVLlamaEncoder is a TransformerEngine-optimized Llama encoder."""
+
+    def __init__(self, config: LlamaConfig, te_rope_emb: Tensor | tuple[Tensor, Tensor] | None, *args, **kwargs):
+        super().__init__(
+            hidden_size=config.hidden_size,
+            ffn_hidden_size=config.intermediate_size,
+            num_attention_heads=config.num_attention_heads,
+            bias=False,
+            layernorm_epsilon=config.rms_norm_eps,
+            hidden_dropout=0,
+            attention_dropout=0,
+            fuse_qkv_params=False,
+            normalization="RMSNorm",
+            activation="swiglu",
+            attn_input_format="bshd",
+            num_gqa_groups=config.num_key_value_heads,
+        )
+        self.te_rope_emb = te_rope_emb
+
+    def forward(self, hidden_states, *args, attention_mask, **kwargs):
+        """
+        Custom forward to make sure we only pass relevant arguments to the
+        forward pass of the `TransformerLayer`. Also, make sure the output
+        format matches the output of the HF's `LlamaDecoderLayer`.
+        """
+        return super().forward(hidden_states, attention_mask=attention_mask, rotary_pos_emb=self.te_rope_emb)
+
+
+@staticmethod
+def _convert_llama_state_dict_to_nv_llama(hf_state_dict: dict, layer_prefix_pattern: str, config: LlamaConfig):
+    # collect all layer prefixes to update
+    all_layer_prefixes = set()
+    for param_key in hf_state_dict.keys():
+        m = re.match(layer_prefix_pattern, param_key)
+        if m is not None:
+            all_layer_prefixes.add(m.group())
+
+    for layer_prefix in all_layer_prefixes:
+        # When loading weights into models with less number of layers, skip the
+        # copy if the corresponding layer doesn't exist in HF model
+        if layer_prefix + "input_layernorm.weight" in hf_state_dict:
+            hf_state_dict[layer_prefix + "self_attention.layernorm_qkv.layer_norm_weight"] = hf_state_dict[layer_prefix + "input_layernorm.weight"]
+            del hf_state_dict[layer_prefix + "input_layernorm.weight"]
+
+        if layer_prefix + "self_attn.q_proj.weight" in hf_state_dict:
+            hf_state_dict[layer_prefix + "self_attention.layernorm_qkv.query_weight"] = hf_state_dict[layer_prefix + "self_attn.q_proj.weight"]
+            del hf_state_dict[layer_prefix + "self_attn.q_proj.weight"]
+
+        if layer_prefix + "self_attn.k_proj.weight" in hf_state_dict:
+            hf_state_dict[layer_prefix + "self_attention.layernorm_qkv.key_weight"] = hf_state_dict[layer_prefix + "self_attn.k_proj.weight"]
+            del hf_state_dict[layer_prefix + "self_attn.k_proj.weight"]
+
+        if layer_prefix + "self_attn.v_proj.weight" in hf_state_dict:
+            hf_state_dict[layer_prefix + "self_attention.layernorm_qkv.value_weight"] = hf_state_dict[layer_prefix + "self_attn.v_proj.weight"]
+            del hf_state_dict[layer_prefix + "self_attn.v_proj.weight"]
+
+        if layer_prefix + "self_attn.o_proj.weight" in hf_state_dict:
+            hf_state_dict[layer_prefix + "self_attention.proj.weight"] = hf_state_dict[
+                layer_prefix + "self_attn.o_proj.weight"
+            ]
+            del hf_state_dict[layer_prefix + "self_attn.o_proj.weight"]
+
+        if layer_prefix + "post_attention_layernorm.weight" in hf_state_dict:
+            hf_state_dict[layer_prefix + "layernorm_mlp.layer_norm_weight"] = hf_state_dict[
+                layer_prefix + "post_attention_layernorm.weight"
+            ]
+            del hf_state_dict[layer_prefix + "post_attention_layernorm.weight"]
+
+        # It may happen that gate_proj.weight and up_proj.weight will be in the different files, so we need to
+        # load them separately.
+        if layer_prefix + "mlp.gate_proj.weight" in hf_state_dict:
+            if hf_state_dict.get(layer_prefix + "layernorm_mlp.fc1_weight") is None:
+                t = hf_state_dict[layer_prefix + "mlp.gate_proj.weight"]
+                rows, cols = t.shape
+                hf_state_dict[layer_prefix + "layernorm_mlp.fc1_weight"] = torch.empty((2 * rows, cols), dtype=t.dtype, device=t.device)
+
+            hf_state_dict[layer_prefix + "layernorm_mlp.fc1_weight"].data[: config.intermediate_size] = hf_state_dict[layer_prefix + "mlp.gate_proj.weight"].data
+            del hf_state_dict[layer_prefix + "mlp.gate_proj.weight"]
+
+        if layer_prefix + "mlp.up_proj.weight" in hf_state_dict:
+            if hf_state_dict.get(layer_prefix + "layernorm_mlp.fc1_weight") is None:
+                t = hf_state_dict[layer_prefix + "mlp.gate_proj.weight"]
+                rows, cols = t.shape
+                hf_state_dict[layer_prefix + "layernorm_mlp.fc1_weight"] = torch.empty((2 * rows, cols), dtype=t.dtype, device=t.device)
+
+            hf_state_dict[layer_prefix + "layernorm_mlp.fc1_weight"].data[config.intermediate_size :] = hf_state_dict[layer_prefix + "mlp.up_proj.weight"].data
+            del hf_state_dict[layer_prefix + "mlp.up_proj.weight"]
+
+        if layer_prefix + "mlp.down_proj.weight" in hf_state_dict:
+            hf_state_dict[layer_prefix + "layernorm_mlp.fc2_weight"]= hf_state_dict[
+                layer_prefix + "mlp.down_proj.weight"
+            ]
+            del hf_state_dict[layer_prefix + "mlp.down_proj.weight"]
+
+
+# @balvisio: Might be better to inherit from PreTrainedModel instead of overriding
+class NVLlamaPreTrainedModel(LlamaPreTrainedModel):
+    """An abstract class to handle weights initialization and pretrained model loading."""
+    _no_split_modules = ["TransformerLayer"]
+    _can_record_outputs = {
+        "hidden_states": te.pytorch.TransformerLayer,
+        "attentions": te.pytorch.MultiheadAttention,
+    }
+
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path=None, *model_args, config=None, **kwargs):
+        # Before loading the model, set the default dtype for torch
+        torch_dtype = kwargs.get("torch_dtype", None)
+        if torch_dtype is not None:
+            torch.set_default_dtype(torch_dtype)
+
+        if config is None:
+            config = AutoConfig.from_pretrained(pretrained_model_name_or_path)
+        config._attn_implementation = "flash_attention_2"
+
+        hf_cls, layer_prefix_pattern = NV_TO_HF_CLASS_MAP[cls]
+        # 1. If user passed state_dict directly, just convert and load
+        state_dict = kwargs.pop("state_dict", None)
+        if state_dict is not None:
+            _convert_llama_state_dict_to_nv_llama(state_dict, layer_prefix_pattern, config)
+            return super().from_pretrained(
+                pretrained_model_name_or_path, *model_args, config=config, state_dict=state_dict, **kwargs
+            )
+
+        # 2. Try loading baseline LLaMA for extraction
+        try:
+            temp_model = hf_cls.from_pretrained(pretrained_model_name_or_path, config=config, *model_args, **kwargs)
+            state_dict = temp_model.state_dict()
+
+            # Detect if it's baseline LLaMA or already NVLlama.
+            if any("self_attn.q_proj" in k for k in state_dict.keys()):
+                # Looks like baseline LLaMA → convert
+                _convert_llama_state_dict_to_nv_llama(state_dict, layer_prefix_pattern, config)
+                # Since we will be passing the 'state_dict', we don't pass the name of the model in 'pretrained_model_name_or_path'
+                pretrained_model_name_or_path = None
+                # To avoid printing WARNING about missing keys in 'state_dict' such as 'layers.0.layernorm_mlp._extra_state'
+                kwargs["_keys_to_ignore_on_load_missing"] = [r".*_extra_state$"]
+                # Pass the generation_config for generation but set 'use_cache' to False
+                generation_config = temp_model.generation_config
+                generation_config.use_cache = False
+                kwargs["generation_config"] = generation_config
+
+            del temp_model
+            gc.collect()
+        except Exception as e:
+            logger.warning(f"Could not load as LlamaModel, falling back to standard loading: {e}")
+
+        # Load NVLlama using maybe (if 'state_dict' is not None) converted weights
+        model = super().from_pretrained(
+            pretrained_model_name_or_path, *model_args, config=config, state_dict=state_dict, **kwargs
+        )
+        model = model.cuda()
+
+        # Needed for the cases when using TELlamaForCausalLM
+        model.config.use_cache = False
+
+        # Make sure memory is freed.
+        del state_dict
+        gc.collect()
+
+        return model
+
+
+class NoOp(nn.Module):
+    def __init__(self, return_input=True):
+        super().__init__()
+        self.return_input = return_input
+
+    def forward(self, *x):
+        if self.return_input:
+            return x
+        return None
+
+
+class NVLlamaModel(NVLlamaPreTrainedModel, LlamaModel):
+    """Llama model. This model uses NVDIA's TransformerEngine to optimize attention layer training and inference."""
+    def __init__(self, config: LlamaConfig, **kwargs):
+        NVLlamaPreTrainedModel.__init__(self, config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        # The TE RotaryPositionEmbedding layer works differently from the LlamaRotaryEmbedding. The forward() method of:
+        # - TE RotaryPositionEmbedding: Takes the 'max_seq_length' and creates rotary position embedding frequencies.
+        #   They are passed to the Transformer Layer.
+        # - LlamaRotaryEmbedding: Calculates the positional embeddings given the embeddings and positions_ids. These
+        #   are passed to the Decoder Layer.
+        #
+        # When using the TE/NVDecoderLayer we ignore the 'position_embeddings' passed by in the model.forward().
+        self.decoder_rotary_emb = RotaryPositionEmbedding(
+            config.hidden_size // config.num_attention_heads,
+            rotary_base=config.rope_theta,
+        )
+        # ESM-2 style: Keep both pre-computed (for efficiency) and dynamic computation capability
+        self.te_rope_emb = self.decoder_rotary_emb(max_seq_len=config.max_position_embeddings).cuda()
+        self._cached_max_seq_len = config.max_position_embeddings
+
+        # For the rotary_emb we just do a NoOp since we don't use its outputs.
+        self.rotary_emb = NoOp(return_input=False)
+
+        self.layers = nn.ModuleList(
+            [
+                NVLlamaDecoderLayer(config, self.te_rope_emb)
+                for _ in range(config.num_hidden_layers)
+            ]
+        )
+
+        self.norm = LlamaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.gradient_checkpointing = False
+
+        _keys_to_ignore_on_load_missing = kwargs.pop("_keys_to_ignore_on_load_missing", None)
+        if _keys_to_ignore_on_load_missing:
+            self.__class__._keys_to_ignore_on_load_missing = _keys_to_ignore_on_load_missing
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def _get_rope_embeddings(self, seq_len: int):
+        """Get RoPE embeddings for given sequence length, computing dynamically if needed (ESM-2 style)."""
+        if seq_len <= self._cached_max_seq_len:
+            # Use pre-computed cache (fast path)
+            return self.te_rope_emb[:seq_len]
+        else:
+            # Compute dynamically for longer sequences (ESM-2 approach)
+            dynamic_rope_emb = self.decoder_rotary_emb(max_seq_len=seq_len).to(
+                device=self.te_rope_emb.device, dtype=self.te_rope_emb.dtype
+            )
+            return dynamic_rope_emb
+
+    def forward(self, input_ids=None, attention_mask=None, position_ids=None, **kwargs):
+        """Enhanced forward with dynamic RoPE computation."""
+        # Get sequence length
+        if input_ids is not None:
+            seq_len = input_ids.shape[1]
+        else:
+            seq_len = kwargs.get('inputs_embeds', torch.zeros(1, 1, 1)).shape[1]
+        
+        # Get appropriate RoPE embeddings (dynamic if needed)
+        current_rope_emb = self._get_rope_embeddings(seq_len)
+        
+        # Update all layers with current RoPE embeddings
+        for layer in self.layers:
+            layer.te_rope_emb = current_rope_emb
+            
+        # Call parent forward
+        return super().forward(input_ids=input_ids, attention_mask=attention_mask, position_ids=position_ids, **kwargs)
+
+
+class NVLlamaForCausalLM(NVLlamaPreTrainedModel, LlamaForCausalLM):
+    def __init__(self, config, **kwargs):
+        _keys_to_ignore_on_load_missing = kwargs.pop("_keys_to_ignore_on_load_missing", None)
+        if _keys_to_ignore_on_load_missing:
+            self.__class__._keys_to_ignore_on_load_missing = _keys_to_ignore_on_load_missing
+
+        NVLlamaPreTrainedModel.__init__(self, config)
+        self.model = NVLlamaModel(config, **kwargs)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+
+# Used to know which HF model we should instantiate to get the appropriate 'state_dict'.
+# The second element is the pattern used to rename 'state_dict' keys to make it NV compatible.
+NV_TO_HF_CLASS_MAP = {
+    NVLlamaModel: (LlamaModel, "layers.\d+."),
+    NVLlamaForCausalLM: (LlamaForCausalLM, "model.layers.\d+.")
+}

--- a/bionemo-recipes/recipes/llama_native_te_nvfsdp/test_infer_sequential.py
+++ b/bionemo-recipes/recipes/llama_native_te_nvfsdp/test_infer_sequential.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+import pytest
+import torch
+import pickle
+import os
+from pathlib import Path
+from transformers import AutoConfig, LlamaForCausalLM
+from model import NVLlamaForCausalLM
+
+@pytest.mark.parametrize("model_name", ["meta-llama/Llama-2-7b-hf"])
+def test_hf_and_te_llama_equivalence_sequential(model_name: str, tol=0.25):
+    """Sequential test that loads one model at a time and saves outputs to pickle files"""
+    
+    print(f"Testing {model_name} (Sequential with Pickle Comparison)")
+    print("=" * 60)
+    
+    device = torch.device("cuda:0")
+    
+    # Clear cache first
+    torch.cuda.empty_cache()
+    
+    config = AutoConfig.from_pretrained(model_name, torch_dtype=torch.float16)
+    
+    # Optional: Reduce layers for memory safety
+    # config.num_hidden_layers = 16  # Uncomment to reduce layers
+    
+    # Create dummy input (fixed seed for reproducibility)
+    torch.manual_seed(42)
+    input_ids = torch.randint(low=0, high=config.vocab_size, size=(1, 32), device=device)
+    input_ids_cpu = input_ids.cpu()  # Save CPU version for later
+    
+    print(f"Input created: {input_ids.shape} (seed=42 for reproducibility)")
+    
+    # Create output directory
+    output_dir = Path("model_outputs")
+    output_dir.mkdir(exist_ok=True)
+    
+    # ===== STEP 1: Load and test NV model =====
+    print("\nStep 1: Loading NVLlama model...")
+    nv_model = NVLlamaForCausalLM.from_pretrained(
+        model_name, config=config, torch_dtype=torch.float16
+    ).to(device)
+    nv_model.eval()
+    print(f"NVLlama loaded on GPU")
+    
+    # Get NV model output
+    with torch.no_grad():
+        nv_logits = nv_model(input_ids).logits
+    print(f"NVLlama forward pass: {nv_logits.shape}")
+    
+    # Save NV results to pickle
+    nv_results = {
+        "logits": nv_logits.cpu(),
+        "model_name": model_name,
+        "model_type": "NVLlama",
+        "input_ids": input_ids_cpu,
+        "config_layers": config.num_hidden_layers,
+        "config_hidden": config.hidden_size
+    }
+    
+    nv_pickle_path = output_dir / "nv_model_output.pkl"
+    with open(nv_pickle_path, "wb") as f:
+        pickle.dump(nv_results, f)
+    print(f"NVLlama results saved to {nv_pickle_path}")
+    
+    # Clean up NV model
+    del nv_model, nv_logits
+    torch.cuda.empty_cache()
+    print("NVLlama unloaded, GPU memory cleared")
+    
+    # ===== STEP 2: Load and test HF model =====
+    print("\nStep 2: Loading HuggingFace model...")
+    hf_model = LlamaForCausalLM.from_pretrained(
+        model_name, config=config, torch_dtype=torch.float16
+    ).to(device)
+    hf_model.eval()
+    print(f"HuggingFace loaded on GPU")
+    
+    # Get HF model output
+    with torch.no_grad():
+        hf_logits = hf_model(input_ids).logits
+    print(f"HuggingFace forward pass: {hf_logits.shape}")
+    
+    # Save HF results to pickle
+    hf_results = {
+        "logits": hf_logits.cpu(),
+        "model_name": model_name,
+        "model_type": "HuggingFace",
+        "input_ids": input_ids_cpu,
+        "config_layers": config.num_hidden_layers,
+        "config_hidden": config.hidden_size
+    }
+    
+    hf_pickle_path = output_dir / "hf_model_output.pkl"
+    with open(hf_pickle_path, "wb") as f:
+        pickle.dump(hf_results, f)
+    print(f"HuggingFace results saved to {hf_pickle_path}")
+    
+    # Clean up HF model
+    del hf_model, hf_logits
+    torch.cuda.empty_cache()
+    print("HuggingFace unloaded, GPU memory cleared")
+    
+    # ===== STEP 3: Load and compare results =====
+    print("\nStep 3: Loading pickled results for comparison...")
+    
+    with open(nv_pickle_path, "rb") as f:
+        nv_data = pickle.load(f)
+    
+    with open(hf_pickle_path, "rb") as f:
+        hf_data = pickle.load(f)
+    
+    nv_logits_loaded = nv_data["logits"]
+    hf_logits_loaded = hf_data["logits"]
+    
+    print(f"Results loaded from disk")
+    print(f"   NV logits: {nv_logits_loaded.shape}")
+    print(f"   HF logits: {hf_logits_loaded.shape}")
+    
+    # ===== STEP 4: Compare results =====
+    print("\nStep 4: Comparing model outputs...")
+    
+    # Check shapes
+    assert hf_logits_loaded.shape == nv_logits_loaded.shape, \
+        f"Shape mismatch: HF {hf_logits_loaded.shape} vs NV {nv_logits_loaded.shape}"
+    print(f"Shapes match: {hf_logits_loaded.shape}")
+    
+    # Check input consistency
+    assert torch.equal(nv_data["input_ids"], hf_data["input_ids"]), \
+        "Input mismatch between saved results"
+    print(f"Input consistency verified")
+    
+    # Compare outputs
+    diff = torch.abs(hf_logits_loaded - nv_logits_loaded)
+    max_diff = torch.max(diff).item()
+    mean_diff = torch.mean(diff).item()
+    
+    print(f"Difference statistics:")
+    print(f"   Max absolute diff: {max_diff:.6f}")
+    print(f"   Mean absolute diff: {mean_diff:.6f}")
+    print(f"   Tolerance: {tol}")
+    
+    # Final comparison
+    outputs_match = torch.allclose(hf_logits_loaded, nv_logits_loaded, atol=tol, rtol=tol)
+    
+    if outputs_match:
+        print(f"Models match within tolerance {tol}")
+        print("\nSequential test PASSED!")
+    else:
+        print(f"Models differ more than tolerance {tol}")
+        print(f"   Consider increasing tolerance or investigating differences")
+        raise AssertionError(f"Models differ more than tol={tol}")
+    
+    # Clean up pickle files
+    print(f"\nCleaning up pickle files...")
+    nv_pickle_path.unlink()
+    hf_pickle_path.unlink()
+    print(f"Temporary files cleaned up")
+
+if __name__ == "__main__":
+    test_hf_and_te_llama_equivalence_sequential("meta-llama/Llama-2-7b-hf")

--- a/bionemo-recipes/recipes/llama_native_te_nvfsdp/tokenizer.py
+++ b/bionemo-recipes/recipes/llama_native_te_nvfsdp/tokenizer.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ASCII byte-level tokenizer for nucleotide sequences."""
+
+from typing import List, Union
+import torch
+
+
+class NucleotideASCIITokenizer:
+    """
+    ASCII byte-level tokenizer for nucleotide sequences (A, T, C, G).
+    
+    This tokenizer converts nucleotide characters to their ASCII values using ord(),
+    as specified in the meeting requirements for LLAMA3 genomic data processing.
+    """
+    
+    def __init__(self, vocab_size: int = 256):
+        """
+        Initialize the ASCII tokenizer.
+        
+        Args:
+            vocab_size: Maximum vocabulary size (256 for full ASCII range)
+        """
+        self.vocab_size = vocab_size
+        
+        # Standard nucleotide characters and their ASCII values
+        self.nucleotides = {'A': ord('A'), 'T': ord('T'), 'C': ord('C'), 'G': ord('G')}
+        self.unknown_char = ord('N')  # Use N for unknown/ambiguous nucleotides
+        self.pad_token_id = 0
+        self.eos_token_id = 1
+        self.bos_token_id = 2
+        
+        # Special tokens for sequence boundaries
+        self.special_tokens = {
+            '<PAD>': self.pad_token_id,
+            '<EOS>': self.eos_token_id, 
+            '<BOS>': self.bos_token_id,
+        }
+    
+    def encode(self, sequence: str, add_special_tokens: bool = True) -> List[int]:
+        """
+        Encode a nucleotide sequence to token IDs using ASCII values.
+        
+        Args:
+            sequence: Input nucleotide sequence string (e.g., "ATCGATCG")
+            add_special_tokens: Whether to add BOS/EOS tokens
+            
+        Returns:
+            List of token IDs (ASCII values)
+        """
+        if not isinstance(sequence, str):
+            raise ValueError("Input must be a string")
+            
+        # Convert to uppercase and get ASCII values
+        sequence = sequence.upper().strip()
+        token_ids = []
+        
+        if add_special_tokens:
+            token_ids.append(self.bos_token_id)
+            
+        for char in sequence:
+            if char in self.nucleotides:
+                token_ids.append(self.nucleotides[char])
+            elif char.isalpha():  # Handle other nucleotide codes (N, R, Y, etc.)
+                token_ids.append(ord(char))
+            # Skip non-alphabetic characters (spaces, numbers, etc.)
+            
+        if add_special_tokens:
+            token_ids.append(self.eos_token_id)
+            
+        return token_ids
+    
+    def decode(self, token_ids: Union[List[int], torch.Tensor]) -> str:
+        """
+        Decode token IDs back to nucleotide sequence.
+        
+        Args:
+            token_ids: List of token IDs or tensor
+            
+        Returns:
+            Decoded nucleotide sequence string
+        """
+        if isinstance(token_ids, torch.Tensor):
+            token_ids = token_ids.cpu().tolist()
+            
+        decoded_chars = []
+        for token_id in token_ids:
+            if token_id == self.pad_token_id:
+                continue  # Skip padding
+            elif token_id == self.bos_token_id or token_id == self.eos_token_id:
+                continue  # Skip special tokens
+            elif 32 <= token_id <= 126:  # Valid ASCII printable range
+                decoded_chars.append(chr(token_id))
+            else:
+                decoded_chars.append('N')  # Unknown token
+                
+        return ''.join(decoded_chars)
+    
+    def text_to_ids(self, text: str) -> List[int]:
+        """
+        Convert text to token IDs (compatibility with NeMo tokenizer interface).
+        
+        Args:
+            text: Input nucleotide sequence
+            
+        Returns:
+            List of token IDs
+        """
+        return self.encode(text, add_special_tokens=False)
+    
+    def ids_to_text(self, ids: List[int]) -> str:
+        """
+        Convert token IDs to text (compatibility with NeMo tokenizer interface).
+        
+        Args:
+            ids: List of token IDs
+            
+        Returns:
+            Decoded text
+        """
+        return self.decode(ids)
+    
+    @property
+    def eod(self) -> int:
+        """End of document token ID (compatibility with NeMo)."""
+        return self.eos_token_id
+    
+    def __len__(self) -> int:
+        """Return vocabulary size."""
+        return self.vocab_size

--- a/bionemo-recipes/recipes/llama_native_te_nvfsdp/train.py
+++ b/bionemo-recipes/recipes/llama_native_te_nvfsdp/train.py
@@ -1,0 +1,297 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+
+import hydra
+import torch
+import torch.distributed as dist
+import transformer_engine.pytorch
+import wandb
+from megatron_fsdp.fully_shard import fully_shard
+from omegaconf import DictConfig, OmegaConf
+from torch.distributed.device_mesh import init_device_mesh
+from torch.optim import AdamW
+from torch.optim.lr_scheduler import LambdaLR
+from tqdm import tqdm
+from transformers import AutoConfig
+
+from dataloader import create_genomic_dataloader
+from model import NVLlamaForCausalLM
+from tokenizer import NucleotideASCIITokenizer
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+@dataclass
+class DistributedConfig:
+    """Class to track distributed ranks."""
+
+    rank: int = field(default_factory=dist.get_rank)
+    local_rank: int = field(default_factory=lambda: int(os.environ["LOCAL_RANK"]))
+    world_size: int = field(default_factory=dist.get_world_size)
+
+    def is_main_process(self) -> bool:
+        """This is the global rank 0 process, to be used for wandb logging, etc."""
+        return self.rank == 0
+
+
+def get_linear_schedule_with_warmup(
+    optimizer,
+    num_warmup_steps=2_000,
+    num_training_steps=500_000,
+    last_epoch=-1,
+):
+    """Linear warmup and decay scheduler for ESM-2 pretraining.
+
+    The description from Lin 2022 is: The learning rate is warmed up over the first 2,000 steps
+    to a peak value of 4e-4 (1.6e-4 for the 15B parameter model), and then linearly decayed to
+    one tenth of its peak value over the 90% of training duration. We've found internally that a
+    longer warmup helps convergence for larger models (3B+) with bf16 precision.
+    """
+    decay_steps = int(num_training_steps * 0.9)
+
+    def lr_lambda(current_step: int):
+        if current_step < num_warmup_steps:
+            # Warmup phase: linearly increase learning rate
+            return float(current_step) / float(max(1, num_warmup_steps))
+        # Decay phase: linearly decay to one tenth of peak over 90% of training
+        elif current_step > decay_steps:
+            return 0.1  # one tenth of peak learning rate after decay period
+        else:
+            # Linear decay from 1.0 to 0.1 over decay_steps-num_warmup_steps
+            return 1.0 - 0.9 * (current_step - num_warmup_steps) / float(max(1, decay_steps - num_warmup_steps))
+
+    return LambdaLR(optimizer, lr_lambda, last_epoch)
+
+
+@hydra.main(config_path="hydra_config", config_name="L0_sanity.yaml", version_base="1.2")
+def main(args: DictConfig):
+    """Train Llama with TE layers using accelerate.
+
+    Valid model names are:
+    - "meta-llama/Meta-Llama-3-8B"
+    - "meta-llama/Llama-2-7b-hf"
+    """
+    # Initialize distributed training and create a device mesh for FSDP.
+    # We have to create a dummy mesh dimension for context parallel and tensor parallel for things
+    # to work correctly with megatron-fsdp.
+    
+    dist.init_process_group(backend="nccl")
+    dist_config = DistributedConfig()
+    
+    torch.cuda.set_device(dist_config.local_rank)
+    device_mesh = init_device_mesh(
+        "cuda",
+        mesh_shape=(dist_config.world_size, 1),
+        mesh_dim_names=("fsdp", "tp"),
+    )
+    device = torch.device(f"cuda:{dist_config.local_rank}")
+    logger.info("Initialized distributed training: %s", dist_config)
+
+    if dist_config.is_main_process():
+        wandb.init(**args.wandb_init_args, config=dict(OmegaConf.to_container(args, resolve=True, throw_on_missing=True)))
+
+    # Create tokenizer for genomic sequences (ASCII nucleotide encoding)
+    tokenizer = NucleotideASCIITokenizer(vocab_size=256)
+
+    # Create model config from pretrained (ESM-2 pattern: config from HF, weights from scratch)
+    config = AutoConfig.from_pretrained(
+        f"{args.model_name}", trust_remote_code=True, torch_dtype=torch.bfloat16
+    )
+    
+    # Reduce model layers if specified (for memory constraints)
+    if hasattr(args, 'model_layers') and args.model_layers:
+        original_layers = config.num_hidden_layers
+        config.num_hidden_layers = args.model_layers
+        logger.info(f"Reducing model layers: {original_layers} → {config.num_hidden_layers}")
+    
+    # Reduce hidden size if specified (for memory constraints)
+    if hasattr(args, 'hidden_size') and args.hidden_size:
+        original_hidden_size = config.hidden_size
+        config.hidden_size = args.hidden_size
+        # Also need to adjust intermediate_size proportionally (typically 8/3 * hidden_size for LLAMA)
+        config.intermediate_size = int(args.hidden_size * 8 / 3)
+        logger.info(f"Reducing hidden size: {original_hidden_size} → {config.hidden_size}")
+        logger.info(f"Adjusting intermediate size: {config.intermediate_size}")
+    
+    # Update config for genomic tokenizer BEFORE model creation
+    config.vocab_size = len(tokenizer)
+    config.pad_token_id = tokenizer.pad_token_id
+    config.eos_token_id = tokenizer.eos_token_id
+    config.bos_token_id = tokenizer.bos_token_id
+    
+    # Set RoPE for base pretraining (not extended context) - scale_factor = 1.0
+    target_seq_len = args.dataset.seq_length
+    config.max_position_embeddings = max(target_seq_len, config.max_position_embeddings)
+    
+    # Ensure rope_scaling is set for base pretraining (scale_factor=1.0 means no scaling)
+    # Default HF configs might have rope_scaling set for extended context, which we don't want
+    if hasattr(config, 'rope_scaling') and config.rope_scaling is not None:
+        logger.info(f"Removing rope_scaling from config (was: {config.rope_scaling})")
+        config.rope_scaling = None  # No scaling for base pretraining
+    
+    logger.info(f"Creating model from config with random weights (ESM-2/Peter's pattern)")
+    logger.info(f"Config: vocab_size={config.vocab_size}, max_position_embeddings={config.max_position_embeddings}")
+    
+    # Initialize model with random weights (ESM-2 pattern)
+    model = NVLlamaForCausalLM(config=config)
+    
+    # Model now handles dynamic RoPE computation (ESM-2 style) - no manual intervention needed!
+    if target_seq_len > 4096:
+        logger.info(f"Using dynamic RoPE for {target_seq_len} sequence length (handled in model.py)")
+
+    # Log model and number of parameters on main process.
+    if dist_config.is_main_process():
+        logger.info("model:\n%s", model)
+        logger.info(f"total number of parameters: {sum(p.numel() for p in model.parameters()):,}")
+
+    # Create optimizer.
+    optimizer = AdamW(model.parameters(), **args.adamw_kwargs)
+
+    # # Wrap model in megatron-fsdp if we're using it, otherwise wrap with DDP.
+    if args.use_fsdp:
+        model, optimizer = fully_shard(
+            module=model,
+            optimizer=optimizer,
+            fsdp_unit_modules=[
+                transformer_engine.pytorch.TransformerLayer,
+                transformer_engine.pytorch.LayerNorm,
+                transformer_engine.pytorch.LayerNormLinear,
+            ],
+            device_mesh=device_mesh,
+            dp_shard_dim="fsdp",
+            tp_dim="tp",
+            **args.fully_shard_kwargs,
+        )
+
+    else:
+        model = model.to(device=device)
+        model = torch.nn.parallel.DistributedDataParallel(
+            model,
+            device_ids=[dist_config.local_rank],
+            output_device=dist_config.local_rank,
+            device_mesh=device_mesh["fsdp"],
+        )
+
+    # This is important; the LR scheduler modifies optimizer.step(), so this needs to get created
+    # after the optimizer gets wrapped in FSDP. Here we use a warmup and linear decay scheduler.
+    scheduler = get_linear_schedule_with_warmup(optimizer, **args.lr_scheduler_kwargs)
+
+    # Training loop.
+    model.train()
+    if dist_config.is_main_process():
+        progress_bar = tqdm(range(args.num_train_steps), desc="Training", disable=False)
+
+    # Create genomic dataloader with distributed sampling for FSDP
+    train_iterator, epoch_len = create_genomic_dataloader(args, tokenizer)
+
+    # Training loop.
+    previous_step_time = time.perf_counter()
+    for step in range(args.num_train_steps):
+        # Get batch.
+        batch = next(train_iterator)
+        batch = {k: v.to(device) for k, v in batch.items()}
+
+        # Forward pass with mixed precision.
+        with torch.cuda.amp.autocast(dtype=torch.bfloat16):
+            outputs = model(**batch)
+
+        # Backward pass.
+        loss = outputs.loss
+        loss.backward()
+
+        # Compute and clip gradient norms.
+        total_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0).item()
+
+        # Step optimizer.
+        optimizer.step()
+        scheduler.step()
+        optimizer.zero_grad()
+
+        # Log metrics to logger and wandb on main process.
+        if dist_config.is_main_process():
+            current_time = time.perf_counter()
+            step_time = current_time - previous_step_time
+            previous_step_time = current_time
+
+            current_lr = optimizer.param_groups[0]["lr"]
+            logger.info(
+                "Step %d loss: %f, grad_norm: %f, lr: %f",
+                step,
+                loss.detach().item(),
+                total_norm,
+                current_lr,
+            )
+            wandb.log(
+                {
+                    "train/loss": loss.item(),
+                    "train/global_step": step,
+                    "train/learning_rate": current_lr,
+                    "train/grad_norm": total_norm,
+                    "train/epoch": step / epoch_len,
+                    "train/step_time": step_time,
+                }
+            )
+
+            if dist_config.is_main_process():
+                progress_bar.update(1)
+                progress_bar.set_postfix({"loss": loss.item()})
+
+    # Clean up distributed training
+    if dist_config.is_main_process():
+        wandb.finish()
+
+    dist.destroy_process_group()
+
+    ###################
+    ##################
+    #################
+    # Inference
+    model.eval()
+
+    # Post-training inference test  
+    logger.info("Testing model inference after training...")
+    
+    try:
+        device = next(model.parameters()).device  # get model's device
+        
+        # Set model to eval mode for inference
+        model.eval()
+        
+        # Create a simple genomic sequence test
+        # A=65, T=84, C=67, G=71 in ASCII
+        genomic_sequence = [65, 84, 67, 71, 65, 84, 67, 71, 0, 0]  # ATCGATCG + padding
+        input_ids = torch.tensor([genomic_sequence], dtype=torch.long, device=device)  # (1, 10)
+        
+        # Run inference (no gradients needed)
+        with torch.no_grad():
+            outputs = model(input_ids)
+            
+        # outputs.logits should be [batch_size, seq_len, vocab_size] = (1, 10, 256)
+        logger.info(f"Inference successful! Output shape: {outputs.logits.shape}")
+        logger.info(f"Sample logits for first position: {outputs.logits[0, 0, :10].tolist()}")
+        
+    except Exception as e:
+        logger.warning(f"Post-training inference test failed (non-critical): {e}")
+        logger.info("Training completed successfully despite inference test failure")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description
This PR implements a complete end-to-end genomic foundation model training pipeline using LLAMA3 architecture with EVO2-compatible data processing and distributed training capabilities.
#### Key Components:
**Genomic Tokenization System:**
ASCII character-level tokenization with 256-token vocabulary covering complete ASCII character set
Direct nucleotide encoding supporting standard nucleotides (A, T, C, G, N) and IUPAC ambiguity codes
EVO2-compatible byte-level tokenization methodology
Integrated BOS, EOS, and PAD tokens for proper sequence boundary management
**EVO2-Style Genomic Dataloader (following the Sharded Eden Dataloader):**
Efficient sequence windowing: 8192-token sequences with 7992-token stride (200bp overlap) - following the EVO2 approach
Randomization: fixed window positions with shuffled access order for training stability (
SQLite backend integration for high-performance sequence retrieval
Full FSDP and DDP distributed training compatibility
Memory-efficient streaming with configurable parameters
Currently processes small subsample dataset (1,024 sequences into 254,043 training windows) with future scaling planned for production datasets
**Model Pipeline Architecture:**
Dynamic RoPE implementation supporting arbitrary sequence lengths with ESM-2 style computation
Random weight initialization using from-config approach to avoid text-domain bias
Memory-optimized LLAMA3: 8-layer, 403M parameter configuration for development/testing
FSDP integration with TransformerEngine optimization
Complete Weights & Biases integration for experiment tracking
**Quick Validation Results: - Much more testing needed**
L0 Sanity: 4-layer model, 25 steps, 3-minute validation
L1 Pilot: 8-layer model, 200 steps, 50-minute training
Stable training convergence demonstrated (loss: 6.1 → 1.38 over 200 steps)
Consistent 23.5GB GPU memory usage with 4.1 iterations/second sustained performance
Note: Much more extensive validation is needed with full-scale models and production datasets
### Usage
Quick validation run:
`cd bionemo-recipes/recipes/llama_native_te_nvfsdp
torchrun --nproc_per_node=1 train.py --config-name=L0_sanity`
More Realistic training run (still very small scale):
`cd bionemo-recipes/recipes/llama_native_te_nvfsdp
torchrun --nproc_per_node=1 train.py --config-name=L1_pilot`
Configuration customization:
Type of changes
[x] New feature (non-breaking change which adds functionality)
[ ] Bug fix (non-breaking change which fixes an issue)
[ ] Refactor
[ ] Documentation update
[ ] Other (please describe):
CI Pipeline Configuration
Configure CI behavior by applying the relevant labels. By default, only basic unit tests are run.
[ ] ciflow:skip - Skip all CI tests for this PR
[ ] ciflow:notebooks - Run Jupyter notebooks execution tests for bionemo2
[ ] ciflow:slow - Run slow single GPU integration tests marked as @pytest.mark.slow for bionemo2
[ ] ciflow:all - Run all tests (unit tests, slow tests, and notebooks) for bionemo2. This label can be used to enforce running tests for all bionemo2.
[x] ciflow:all-recipes - Run tests for all recipes (under bionemo-recipes). This label can be used to enforce running tests for all recipes.
Unit tests marked as @pytest.mark.multi_gpu or @pytest.mark.distributed are not run in the PR pipeline.
For more details, see CONTRIBUTING
> [!NOTE]
> By default, only basic unit tests are run. Add appropriate labels to enable an additional test coverage.
Authorizing CI Runs
We use copy-pr-bot to manage authorization of CI
runs on NVIDIA's compute resources.
If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
/ok to test comment on the pull request to trigger CI. This will need to be done for each new commit.
Pre-submit Checklist
[x] I have tested these changes locally
[ ] I have updated the documentation accordingly
[ ] I have added/updated tests as needed
[] All existing tests pass successfully
### Next Steps:
- Dataset Scaling: Scale from current subsample (1K sequences) to larger datasets (10M+ sequences)
- Model Scaling: Increase to 16+ layers and full parameter counts for training
- Multi-Node Training: Test and validate existing FSDP implementation across multiple GPU nodes
- THD Sequence Packing
- Extended Context Training: Support for longer context lengths (32K+ tokens) with iterative training strategies and memory optimization
- Extended Validation: Comprehensive evaluation with downstream genomic tasks and comparative benchmarking against EVO2
