### PR TITLE
Upgrade Megatron-FSDP to 0.1.0rc4.

### DIFF
--- a/bionemo-recipes/models/esm2/pyproject.toml
+++ b/bionemo-recipes/models/esm2/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "jinja2",
     "lightning",
     "megatron-core@git+https://github.com/NVIDIA/Megatron-LM.git", # Currently at ToT until mfsdp is in a release.
-    "megatron-fsdp==0.1.0rc0",
+    "megatron-fsdp",
     "nemo_toolkit[lightning]",                                     # tested with 2.3.1
     "omegaconf",
     "pytest",

--- a/bionemo-recipes/models/esm2/tests/test_distributed_strategies.py
+++ b/bionemo-recipes/models/esm2/tests/test_distributed_strategies.py
@@ -197,7 +197,7 @@ if __name__ == "__main__":
                 device_mesh=device_mesh,
                 dp_shard_dim="dp",
                 tp_dim="tp",
-                sync_grads_each_step=True,
+                sync_model_each_microbatch=True,
                 preserve_fp32_weights=False,  # TODO: cory, any idea why this is needed?
             )
 

--- a/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
+++ b/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
@@ -34,7 +34,7 @@ fully_shard_kwargs:
   preserve_fp32_weights: true
   overlap_grad_reduce: true
   overlap_param_gather: true
-  sync_grads_each_step: true
+  sync_model_each_microbatch: true
   average_in_collective: false
 
 # TransformerEngine FP8 config. See

--- a/bionemo-recipes/recipes/esm2_native_te/requirements.txt
+++ b/bionemo-recipes/recipes/esm2_native_te/requirements.txt
@@ -1,6 +1,6 @@
 datasets
 hydra-core
-megatron-fsdp==0.1.0rc0
+megatron-fsdp
 torch
 tqdm
 transformer_engine

--- a/bionemo-recipes/recipes/esm2_native_te/requirements.txt
+++ b/bionemo-recipes/recipes/esm2_native_te/requirements.txt
@@ -4,5 +4,5 @@ megatron-fsdp
 torch
 tqdm
 transformer_engine
-transformers @ git+https://github.com/huggingface/transformers
+transformers
 wandb

--- a/bionemo-recipes/recipes/esm2_native_te/train_mfsdp.py
+++ b/bionemo-recipes/recipes/esm2_native_te/train_mfsdp.py
@@ -92,6 +92,7 @@ def main(args: DictConfig) -> float | None:
             transformer_engine.pytorch.LayerNorm,
             transformer_engine.pytorch.LayerNormLinear,
             transformers.models.esm.modeling_esm.EsmLayer,
+            transformers.models.esm.modeling_esm.EsmEmbeddings,
         ],
         device_mesh=device_mesh,
         dp_shard_dim="fsdp",

--- a/bionemo-recipes/recipes/geneformer_native_te_mfsdp_fp8/hydra_config/defaults.yaml
+++ b/bionemo-recipes/recipes/geneformer_native_te_mfsdp_fp8/hydra_config/defaults.yaml
@@ -36,7 +36,7 @@ training:
     preserve_fp32_weights: true
     overlap_grad_reduce: true
     overlap_param_gather: true
-    sync_grads_each_step: true
+    sync_model_each_microbatch: true
     average_in_collective: false
   fp8_recipe_kwargs:
     fp8_format: "hybrid"

--- a/bionemo-recipes/recipes/geneformer_native_te_mfsdp_fp8/requirements.txt
+++ b/bionemo-recipes/recipes/geneformer_native_te_mfsdp_fp8/requirements.txt
@@ -1,5 +1,5 @@
 datasets
-megatron-fsdp==0.1.0rc0
+megatron-fsdp
 hydra-core
 safetensors
 torch

--- a/bionemo-recipes/recipes/vit/config/defaults.yaml
+++ b/bionemo-recipes/recipes/vit/config/defaults.yaml
@@ -54,7 +54,6 @@ fsdp:
     - vit.AttentionPoolLatent
     - torch.nn.LayerNorm
     - torch.nn.Linear
-  use_hybrid_fsdp: true
   outer_dp_sharding_strategy: "optim"
   grad_reduce_in_fp32: false
   preserve_fp32_weights: true

--- a/bionemo-recipes/recipes/vit/config/vit_base_patch16_224.yaml
+++ b/bionemo-recipes/recipes/vit/config/vit_base_patch16_224.yaml
@@ -52,7 +52,6 @@ fsdp:
     - vit.AttentionPoolLatent
     - torch.nn.LayerNorm
     - torch.nn.Linear
-  use_hybrid_fsdp: true
   outer_dp_sharding_strategy: 1
   grad_reduce_in_fp32: false
   preserve_fp32_weights: true

--- a/bionemo-recipes/recipes/vit/requirements.txt
+++ b/bionemo-recipes/recipes/vit/requirements.txt
@@ -1,7 +1,7 @@
 torch
 torchvision
 transformer_engine
-megatron-fsdp==0.1.0rc1
+megatron-fsdp
 hydra-core
 einops
 wandb

--- a/bionemo-recipes/recipes/vit/train.py
+++ b/bionemo-recipes/recipes/vit/train.py
@@ -77,8 +77,6 @@ def main(cfg) -> None:
             zero_dp_strategy=cfg.fsdp.zero_dp_strategy,
             # FSDP "Unit Modules" - The sub-modules of the model that you want to shard!
             fsdp_unit_modules=cfg.fsdp.fsdp_unit_modules,
-            # Use Hybrid FSDP (HSDP).
-            use_hybrid_fsdp=cfg.fsdp.use_hybrid_fsdp,
             # Inter / Outer DP Sharding Strategy: None (0) -> Optim (1) -> Grad (2) -> Weights (3)
             # Note: This adds a second stage of sharding that generalizes DP-Replicate. Think of it
             # like an extra stage of NCCL divide-and-conquer when using all-gather or reduce-scatter.
@@ -90,7 +88,7 @@ def main(cfg) -> None:
             # Always required to use Megatron-FSDP. What we shard on.
             dp_shard_dim="dp_cp_shard",
             # Required if using HSDP. The second / intermediate set of data-parallel process groups.
-            dp_inter_dim="dp_outer",
+            dp_outer_dim="dp_outer",
             # Required if using TP, either from TransformerEngine (TP=1) / Megatron or DTensor-based TP.
             tp_dim="tp",
             # Required if using HSDP. Created by flattening everything we shard on, e.g. DP-CP.
@@ -101,9 +99,9 @@ def main(cfg) -> None:
             grad_reduce_in_fp32=cfg.fsdp.grad_reduce_in_fp32,
             # Store distributed optimization state in FP32.
             preserve_fp32_weights=cfg.fsdp.preserve_fp32_weights,
-            # Sync gradients each step. Allows for gradient transformations after backward pass, but
-            # deactivates compute-communication overlap going into the subsequent training step.
-            sync_grads_each_step=True,
+            # Sync model parameters and gradients each step. Allows for param and gradient mods after BWD
+            # pass, but deactivates compute-communication overlap going into the subsequent training step.
+            sync_model_each_microbatch=True,
             # Preprocess state dict for DCP checkpointing. Required for Torch Distributed Checkpoint.
             preproc_state_dict_for_dcp_ckpt=True,
         )


### PR DESCRIPTION
### Description

<!-- Provide a detailed description of the changes in this PR -->

- Small upgrade for MFSDP that fixes bugs.
- Use `megatron_fsdp.uneven_dtensor.gather_uneven_dtensor_to_full_tensor` to manually create root module checkpoint state dictionaries on CPU.
- JIRA: https://jirasw.nvidia.com/browse/BIONEMO-2850

#### Usage

<!--- How does a user interact with the changed code -->

- Added `dp_outer_dim` and `sync_model_each_microbatch` args.
- For HF Safetensors, write unsharded model checkpoints via `save_pretrained`.

```python
        from megatron_fsdp.uneven_dtensor import gather_uneven_dtensor_to_full_tensor

        unsharded_state_dict = {
            # Gather all parameters to CPU, and remove the "module." prefix from the Megatron-FSDP class wrapper.
            k.removeprefix("module."): gather_uneven_dtensor_to_full_tensor(
                v, target_device=torch.device("cpu")
            ).to_local()
            if isinstance(v, torch.distributed.tensor.DTensor)
            else v
            for k, v in model.state_dict().items()
        }
```

```python
        # Initialize Megatron-FSDP.
        model, optimizer = fully_shard(
            # Torch (Root) Module
            model,
            # Torch Optimizer
            optimizer=optimizer,
            # ZeRO Sharding Strategy: None (0) -> Optim (1) -> Grad (2) -> Weights (3)
            zero_dp_strategy=cfg.fsdp.zero_dp_strategy,
            # FSDP "Unit Modules" - The sub-modules of the model that you want to shard!
            fsdp_unit_modules=cfg.fsdp.fsdp_unit_modules,
            # Inter / Outer DP Sharding Strategy: None (0) -> Optim (1) -> Grad (2) -> Weights (3)
            # Note: This adds a second stage of sharding that generalizes DP-Replicate. Think of it
            # like an extra stage of NCCL divide-and-conquer when using all-gather or reduce-scatter.
            # Currently, this does not fully-shard the gradients and weights, only the optimizer state,
            # so the memory will be only marginally better than sharding on only DP-Shard.
            outer_dp_sharding_strategy=cfg.fsdp.outer_dp_sharding_strategy,
            # Megatron-FSDP Device Mesh / Distributed Environment
            device_mesh=device_mesh,
            # Always required to use Megatron-FSDP. What we shard on.
            dp_shard_dim="dp_cp_shard",
            # Required if using HSDP. The second / intermediate set of data-parallel process groups.
            dp_outer_dim="dp_outer",
            # Required if using TP, either from TransformerEngine (TP=1) / Megatron or DTensor-based TP.
            tp_dim="tp",
            # Required if using HSDP. Created by flattening everything we shard on, e.g. DP-CP.
            hybrid_fsdp_group=device_mesh["hsdp"].get_group(),
            # Load the model on device in shards to avoid OOM. Requires device("meta")-init for model.
            init_model_with_meta_device=cfg.fsdp.init_model_with_meta_device,
            # Reduce gradients in FP32.
            grad_reduce_in_fp32=cfg.fsdp.grad_reduce_in_fp32,
            # Store distributed optimization state in FP32.
            preserve_fp32_weights=cfg.fsdp.preserve_fp32_weights,
            # Sync model parameters and gradients each step. Allows for param and gradient mods after BWD
            # pass, but deactivates compute-communication overlap going into the subsequent training step.
            sync_model_each_microbatch=True,
            # Preprocess state dict for DCP checkpointing. Required for Torch Distributed Checkpoint.
            preproc_state_dict_for_dcp_ckpt=True,
        )
```

### Type of changes

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

### CI Pipeline Configuration

Configure CI behavior by applying the relevant labels. By default, only basic unit tests are run.

- [ciflow:skip](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:skip) - Skip all CI tests for this PR
- [ciflow:notebooks](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:notebooks) - Run Jupyter notebooks execution tests for bionemo2
- [ciflow:slow](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:slow) - Run slow single GPU integration tests marked as @pytest.mark.slow for bionemo2
- [ciflow:all](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:all) - Run all tests (unit tests, slow tests, and notebooks) for bionemo2. This label can be used to enforce running tests for all bionemo2.
- [ciflow:all-recipes](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:all-recipes) - Run tests for all recipes (under bionemo-recipes). This label can be used to enforce running tests for all recipes.

Unit tests marked as `@pytest.mark.multi_gpu` or `@pytest.mark.distributed` are not run in the PR pipeline.

For more details, see [CONTRIBUTING](CONTRIBUTING.md)

> [!NOTE]
> By default, only basic unit tests are run. Add appropriate labels to enable an additional test coverage.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Pre-submit Checklist

<!--- Ensure all items are completed before submitting -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * mFSDP wrapping expanded to include ESM embeddings.

* **Refactor**
  * Per-step gradient sync replaced with microbatch-level model sync across configs and training.
  * Removed hybrid FSDP toggle; dp_inter_dim renamed to dp_outer_dim.

* **Chores**
  * megatron-fsdp (and some transformer pins) unpinned in recipes.

* **Tests**
  * Distributed strategy tests updated to use microbatch-level model sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->