### PR TITLE
remove head mask from esm2, unpin esm2_native_te from tot git

### DIFF
--- a/bionemo-recipes/models/esm2/src/esm/modeling_esm_te.py
+++ b/bionemo-recipes/models/esm2/src/esm/modeling_esm_te.py
@@ -337,7 +337,6 @@ class NVEsmModel(NVEsmPreTrainedModel):
         input_ids: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
-        head_mask: Optional[torch.Tensor] = None,
         inputs_embeds: Optional[torch.Tensor] = None,
         output_hidden_states: Optional[bool] = None,
         cu_seq_lens_q: torch.IntTensor | None = None,
@@ -351,7 +350,6 @@ class NVEsmModel(NVEsmPreTrainedModel):
             input_ids (torch.Tensor): The input ids.
             attention_mask (torch.Tensor): The attention mask.
             position_ids (torch.Tensor): The position ids.
-            head_mask (torch.Tensor): The head mask.
             inputs_embeds (torch.Tensor): The input embeddings.
             output_hidden_states (bool): Whether to output the hidden states.
             cu_seq_lens_q (torch.IntTensor): The cumulative sequence lengths for the query state, if using THD inputs.
@@ -388,13 +386,6 @@ class NVEsmModel(NVEsmPreTrainedModel):
 
         # TE expects a boolean attention mask, where 1s are masked and 0s are not masked
         extended_attention_mask = extended_attention_mask < -1
-
-        # Prepare head mask if needed
-        # 1.0 in head_mask indicate we keep the head
-        # attention_probs has shape bsz x n_heads x N x N
-        # input head_mask has shape [num_heads] or [num_hidden_layers x num_heads]
-        # and head_mask is converted to shape [num_hidden_layers x batch x num_heads x seq_length x seq_length]
-        head_mask = self.get_head_mask(head_mask, self.config.num_hidden_layers)
 
         embedding_output = self.embeddings(
             input_ids=input_ids,

--- a/bionemo-recipes/recipes/esm2_native_te/requirements.txt
+++ b/bionemo-recipes/recipes/esm2_native_te/requirements.txt
@@ -4,5 +4,5 @@ megatron-fsdp==0.1.0rc0
 torch
 tqdm
 transformer_engine
-transformers @ git+https://github.com/huggingface/transformers
+transformers
 wandb


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed support for per-head attention masking in the ESM2 TE model. Workflows relying on per-head masks will no longer be accepted; standard attention masking and overall model behavior remain unchanged.

* **Chores**
  * Switched the Transformers dependency from a Git source to the PyPI package for simpler, more reliable installation and version management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->