### PR TITLE
enable jetart n benchmarks as data source if possible

### DIFF
--- a/ci/benchmarks/partial-conv/amplify_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/amplify_pretrain.yaml
@@ -1,5 +1,10 @@
 scope: partial-conv
 time_limit: 14400
+# enable this when the data issue problem is fixed
+artifacts:
+  # Artifact data mount paths for script execution, specified as mount_path: artifact_tag pairs.
+  # See Confluence Onboarding Guide section 5.4 for more details on locating this data.
+  /root/.cache/huggingface/datasets/chandar-lab___ur100_p: text/ur100p/processed/25_04
 key_segments:
   # Modify keys to be renamed (str) or excluded (False) from run identifier. By default, all args under script_args are included.
   num_layers: False

--- a/ci/benchmarks/partial-conv/esm2_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/esm2_pretrain.yaml
@@ -1,5 +1,9 @@
 scope: partial-conv
 time_limit: 14400
+artifacts:
+  # Artifact data mount paths for script execution, specified as mount_path: artifact_tag pairs.
+  # See Confluence Onboarding Guide section 5.4 for more details on locating this data.
+  /data-jetart/20240809_uniref_2024_03/: text/uniprot/2024_03/processed-esm2-2024-10-uncompressed
 key_segments:
   # Modify keys to be renamed (str) or excluded (False) from run identifier. By default, all args under script_args are included.
   data_path: False
@@ -9,7 +13,7 @@ script_args:
   # Arguments not referenced in the script string must have the 'arg' field specified.
   # See jet/core/configs.py for the specification of the configuration class
   workspace: /workspace/bionemo2
-  data_path: /data/20240809_uniref_2024_03/data
+  data_path: /data-jetart/20240809_uniref_2024_03/
   model: esm2
   variant: train
   config_name: 650M

--- a/ci/benchmarks/partial-conv/evo2_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/evo2_pretrain.yaml
@@ -1,5 +1,10 @@
 scope: partial-conv
 time_limit: 14400
+# artifacts:
+#   # Artifact data mount paths for script execution, specified as mount_path: artifact_tag pairs.
+#   # See Confluence Onboarding Guide section 5.4 for more details on locating this data.
+#   # Needs update of script_args.data_path: /data-jetart/evo2. Cannot be enabled since Evo2 does not work with read-only folders as data mount.
+#   /data-jetart/evo2/data : text/opengenome2/processed/2025-01
 key_segments:
   # Modify keys to be renamed (str) or excluded (False) from run identifier. By default, all args under script_args are included.
   data_path: False

--- a/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
@@ -15,7 +15,7 @@ script_args:
   # Arguments not referenced in the script string must have the 'arg' field specified.
   # See jet/core/configs.py for the specification of the configuration class
   workspace: /workspace/bionemo2
-  data_path: /data/cellxgene_scdl
+  data_path: /data-jetart/cellxgene_scdl
   model: geneformer
   variant: train
   config_name: 10M

--- a/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
+++ b/ci/benchmarks/partial-conv/geneformer_pretrain.yaml
@@ -1,5 +1,9 @@
 scope: partial-conv
 time_limit: 14400
+artifacts:
+  # Artifact data mount paths for script execution, specified as mount_path: artifact_tag pairs.
+  # See Confluence Onboarding Guide section 5.4 for more details on locating this data.
+  /data-jetart/cellxgene_scdl : tabular/cellxgene/processed/scdl-2025-06-20
 key_segments:
   # Modify keys to be renamed (str) or excluded (False) from run identifier. By default, all args under script_args are included.
   data_path: False
@@ -26,8 +30,6 @@ script_args:
   num_workers: 4
 script: |-
   # Copying data to shared memory filesystem in Linux that provides a RAM-based temporary storage location
-  COPY_FLAG="/tmp/copy_done_${{SLURMD_NODENAME}}";
-  NEW_DATA_PATH="/dev/shm/data_path_${{SLURMD_NODENAME}}";
   COPY_FLAG="/tmp/copy_done_${{SLURMD_NODENAME}}";
   NEW_DATA_PATH="/dev/shm/data_path_${{SLURMD_NODENAME}}";
   if [ "$SLURM_LOCALID" = "0" ]; then


### PR DESCRIPTION
### Description

This configuration setup allows switching workflows between clusters, without worrying about whether the data is available, as it depends on the data synced with JETArt (special cluster-specific folders) and their ID keys.  

#### Usage

<!--- How does a user interact with the changed code -->

```python
TODO: Add code snippet
```

### Type of changes

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

### CI Pipeline Configuration

Configure CI behavior by applying the relevant labels. By default, only basic unit tests are run.

- [ciflow:skip](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:skip) - Skip all CI tests for this PR
- [ciflow:notebooks](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:notebooks) - Run Jupyter notebooks execution tests for bionemo2
- [ciflow:slow](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:slow) - Run slow single GPU integration tests marked as @pytest.mark.slow for bionemo2
- [ciflow:all](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:all) - Run all tests (unit tests, slow tests, and notebooks) for bionemo2. This label can be used to enforce running tests for all bionemo2.
- [ciflow:all-recipes](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:all-recipes) - Run tests for all recipes (under bionemo-recipes). This label can be used to enforce running tests for all recipes.

Unit tests marked as `@pytest.mark.multi_gpu` or `@pytest.mark.distributed` are not run in the PR pipeline.

For more details, see [CONTRIBUTING](CONTRIBUTING.md)

> [!NOTE]
> By default, only basic unit tests are run. Add appropriate labels to enable an additional test coverage.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

### Pre-submit Checklist

<!--- Ensure all items are completed before submitting -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass successfully
