### PR TITLE
remove esm2_native_te_mfsdp_thd option and reorder ui options

### DIFF
--- a/.github/workflows/convergence-tests.yml
+++ b/.github/workflows/convergence-tests.yml
@@ -11,15 +11,6 @@ on:
         options:
           - h100-sxm
           - h200
-      branch:
-        description: "Branch to use (ignored if commit SHA is provided)"
-        required: true
-        default: "main"
-        type: string
-      commit_sha:
-        description: "Commit SHA (optional - overrides branch if provided)"
-        required: false
-        type: string
       model_config:
         description: "Model configuration to use"
         required: true
@@ -28,10 +19,18 @@ on:
         options:
           - esm2_accelerate_te.yaml
           - esm2_native_te
-          - esm2_native_te_mfsdp_thd
           - geneformer_native_te_mfsdp_fp8
       config_override:
         description: "Optional: run only these product configs (CSV). Examples: 10m  or  10m,4b. Leave blank to run all."
+        required: false
+        type: string
+      branch:
+        description: "Branch to use (ignored if commit SHA is provided)"
+        required: true
+        default: "main"
+        type: string
+      commit_sha:
+        description: "Commit SHA (optional - overrides branch if provided)"
         required: false
         type: string
 


### PR DESCRIPTION
Remove `esm2_native_te_mfsdp_thd` option from config selection and reorder ui options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restored manual CI trigger inputs for branch and commit SHA, enabling targeted runs in the workflow.
  * General workflow cleanup to streamline configuration.
* **User Impact**
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->