### PR TITLE
Schedule job every day at 4am, with defaults

### DIFF
--- a/.github/workflows/convergence-tests.yml
+++ b/.github/workflows/convergence-tests.yml
@@ -14,7 +14,7 @@ on:
       model_config:
         description: "Model configuration to use"
         required: true
-        default: ""
+        default: "esm2_native_te"
         type: choice
         options:
           - esm2_accelerate_te.yaml
@@ -86,7 +86,7 @@ jobs:
           python ci/lepton/model_convergence/scripts/launch_job.py \
             --config-name "recipes/$MODEL_CONFIG" \
             $RUN_ONLY_ARGS \
-            branch=$"BRANCH" \
+            branch="$BRANCH" \
             commit_sha=$COMMIT_SHA \
             node_group=$NODE_GROUP \
-            gpu_type=$"GPU_TYPE"
+            gpu_type="$GPU_TYPE"

--- a/.github/workflows/convergence-tests.yml
+++ b/.github/workflows/convergence-tests.yml
@@ -11,6 +11,19 @@ on:
         options:
           - h100-sxm
           - h200
+      model_config:
+        description: "Model configuration to use"
+        required: true
+        default: ""
+        type: choice
+        options:
+          - esm2_accelerate_te.yaml
+          - esm2_native_te
+          - geneformer_native_te_mfsdp_fp8
+      config_override:
+        description: "Optional: run only these product configs (CSV). Examples: 10m  or  10m,4b. Leave blank to run all."
+        required: false
+        type: string
       branch:
         description: "Branch to use (ignored if commit SHA is provided)"
         required: true
@@ -18,20 +31,6 @@ on:
         type: string
       commit_sha:
         description: "Commit SHA (optional - overrides branch if provided)"
-        required: false
-        type: string
-      model_config:
-        description: "Model configuration to use"
-        required: true
-        default: "esm2_accelerate"
-        type: choice
-        options:
-          - esm2_accelerate_te.yaml
-          - esm2_native_te
-          - esm2_native_te_mfsdp_thd
-          - geneformer_native_te_mfsdp_fp8
-      config_override:
-        description: "Optional: run only these product configs (CSV). Examples: 10m  or  10m,4b. Leave blank to run all."
         required: false
         type: string
   schedule:

--- a/.github/workflows/convergence-tests.yml
+++ b/.github/workflows/convergence-tests.yml
@@ -11,19 +11,6 @@ on:
         options:
           - h100-sxm
           - h200
-      model_config:
-        description: "Model configuration to use"
-        required: true
-        default: "esm2_accelerate"
-        type: choice
-        options:
-          - esm2_accelerate_te.yaml
-          - esm2_native_te
-          - geneformer_native_te_mfsdp_fp8
-      config_override:
-        description: "Optional: run only these product configs (CSV). Examples: 10m  or  10m,4b. Leave blank to run all."
-        required: false
-        type: string
       branch:
         description: "Branch to use (ignored if commit SHA is provided)"
         required: true
@@ -33,6 +20,22 @@ on:
         description: "Commit SHA (optional - overrides branch if provided)"
         required: false
         type: string
+      model_config:
+        description: "Model configuration to use"
+        required: true
+        default: "esm2_accelerate"
+        type: choice
+        options:
+          - esm2_accelerate_te.yaml
+          - esm2_native_te
+          - esm2_native_te_mfsdp_thd
+          - geneformer_native_te_mfsdp_fp8
+      config_override:
+        description: "Optional: run only these product configs (CSV). Examples: 10m  or  10m,4b. Leave blank to run all."
+        required: false
+        type: string
+  schedule:
+    - cron: "0 12 * * *" # everyday at 4am PST
 
 jobs:
   submit-lepton-jobs:
@@ -57,30 +60,34 @@ jobs:
       - name: Submit Lepton Jobs
         env:
           LEP_LOGIN_CREDENTIALS: ${{ secrets.LEP_LOGIN_CREDENTIALS }}
+          GPU_TYPE: ${{ github.event.inputs.gpu_type      || 'h100-sxm' }}
+          BRANCH: ${{ github.event.inputs.branch        || 'main' }}
+          COMMIT_SHA: ${{ github.event.inputs.commit_sha    || '' }}
+          MODEL_CONFIG: ${{ github.event.inputs.model_config  || 'esm2_native_te' }}
+          CONFIG_OVERRIDE: ${{ github.event.inputs.config_override || '' }}
         run: |
           set -euo pipefail
           lep login -c "$LEP_LOGIN_CREDENTIALS" || true
 
           # Map GPU type to node group
-          if [ "${{ inputs.gpu_type }}" = "h200" ]; then
+          if [ "$GPU_TYPE" = "h200" ]; then
             NODE_GROUP="nv-int-multiteam-nebius-h200-01"
-          elif [ "${{ inputs.gpu_type }}" = "h100-sxm" ]; then
+          elif [ "$GPU_TYPE" = "h100-sxm" ]; then
             NODE_GROUP="yo-bom-lepton-001"
           else
-            echo "Error: Unknown GPU type: ${{ inputs.gpu_type }}"
+            echo "Error: Unknown GPU type: $GPU_TYPE"
             exit 1
           fi
 
           RUN_ONLY_ARGS=""
-          if [ -n "${{ inputs.config_override }}" ]; then
-            # Users can type: 10m  or  10m,4b
-            RUN_ONLY_ARGS="+run_only=${{ inputs.config_override }}"
+          if [ -n "$CONFIG_OVERRIDE" ]; then
+            RUN_ONLY_ARGS="+run_only=$CONFIG_OVERRIDE"
           fi
 
           python ci/lepton/model_convergence/scripts/launch_job.py \
-            --config-name recipes/${{ inputs.model_config }} \
+            --config-name "recipes/$MODEL_CONFIG" \
             $RUN_ONLY_ARGS \
-            branch=${{ inputs.branch }} \
-            commit_sha=${{ inputs.commit_sha }} \
+            branch=$"BRANCH" \
+            commit_sha=$COMMIT_SHA \
             node_group=$NODE_GROUP \
-            gpu_type=${{ inputs.gpu_type }}
+            gpu_type=$"GPU_TYPE"


### PR DESCRIPTION
Update `convergence-tests` action:
- Refactor to add default values schedule can use.
- Add schedule so it runs every morning at 4am, using default values.
- Reordered ui options for more coherent selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Convergence tests are scheduled to run daily and can still be manually triggered with branch/commit selection.

* **Chores**
  * Standardized environment-variable inputs for test runs with sensible defaults and an override option.
  * Improved GPU-type handling with clearer mappings and explicit error for unsupported types.
  * Streamlined parameter passing to the test launch for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->