### PR TITLE
Updates to ESM-2 for better THD input support

### DIFF
--- a/bionemo-recipes/models/esm2/tests/conftest.py
+++ b/bionemo-recipes/models/esm2/tests/conftest.py
@@ -75,7 +75,7 @@ def input_data(tokenizer, tokenized_proteins):
     data_collator = DataCollatorForLanguageModeling(
         tokenizer=tokenizer,
         mlm_probability=0.15,
-        pad_to_multiple_of=256,
+        pad_to_multiple_of=32,
         seed=42,
     )
 

--- a/bionemo-recipes/models/esm2/tests/test_thd.py
+++ b/bionemo-recipes/models/esm2/tests/test_thd.py
@@ -13,12 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import pytest
 import torch
 from transformer_engine.pytorch.attention.dot_product_attention import _attention_backends
 
 from esm.collator import MLMDataCollatorWithFlattening
-from esm.modeling_esm_te import NVEsmForMaskedLM
+from esm.modeling_esm_te import NVEsmConfig, NVEsmEmbeddings, NVEsmForMaskedLM
+
+
+compute_capability = torch.cuda.get_device_capability()
 
 
 @pytest.fixture
@@ -28,9 +33,52 @@ def input_data_thd(tokenizer, tokenized_proteins):
         mlm_probability=0.15,
         seed=42,
         bshd_equivalent=True,
-        bshd_pad_to_multiple_of=256,
+        bshd_pad_to_multiple_of=32,
     )
     return data_collator(tokenized_proteins)
+
+
+@pytest.mark.parametrize("use_token_dropout", [True, False])
+def test_nv_esm_embeddings_random_init(te_model_checkpoint, input_data_thd, input_data, use_token_dropout):
+    config = NVEsmConfig.from_pretrained(te_model_checkpoint)
+    assert config.token_dropout is True
+    embedding = NVEsmEmbeddings(config)
+    embedding.token_dropout = use_token_dropout
+    embedding.to("cuda")
+
+    input_data_thd = {k: v.to("cuda") if isinstance(v, torch.Tensor) else v for k, v in input_data_thd.items()}
+    input_data_thd.pop("labels")
+    outputs_thd = embedding(**input_data_thd)
+
+    input_data_bshd = {k: v.to("cuda") for k, v in input_data.items()}
+    input_data_bshd.pop("labels")
+    outputs_bshd = embedding(**input_data_bshd)
+
+    # Reshape outputs_bshd to match outputs_thd
+    outputs_bshd = outputs_bshd[input_data_bshd["attention_mask"].to(bool)].unsqueeze(0)
+    torch.testing.assert_close(outputs_thd, outputs_bshd, atol=1e-8, rtol=1e-8)
+
+
+@pytest.mark.parametrize("use_token_dropout", [True, False])
+def test_nv_esm_embeddings_from_model(te_model_checkpoint, input_data_thd, input_data, use_token_dropout):
+    model = NVEsmForMaskedLM.from_pretrained(
+        te_model_checkpoint, attn_input_format="thd", dtype=torch.bfloat16, token_dropout=use_token_dropout
+    )
+    embedding = model.esm.embeddings
+    assert embedding.token_dropout == use_token_dropout
+    embedding.to("cuda")
+
+    input_data_thd = {k: v.to("cuda") if isinstance(v, torch.Tensor) else v for k, v in input_data_thd.items()}
+    input_data_thd.pop("labels")
+    outputs_thd = embedding(**input_data_thd)
+
+    input_data_bshd = {k: v.to("cuda") for k, v in input_data.items()}
+    input_data_bshd.pop("labels")
+    outputs_bshd = embedding(**input_data_bshd)
+
+    # Reshape outputs_bshd to match outputs_thd
+    outputs_bshd = outputs_bshd[input_data_bshd["attention_mask"].to(bool)].unsqueeze(0)
+    torch.testing.assert_close(outputs_thd, outputs_bshd, atol=1e-8, rtol=1e-8)
 
 
 def test_thd_from_collator_output(te_model_checkpoint, input_data_thd):
@@ -43,7 +91,25 @@ def test_thd_from_collator_output(te_model_checkpoint, input_data_thd):
     assert outputs.loss < 3.0
 
 
-def test_thd_values_match(te_model_checkpoint, input_data, input_data_thd):
+@pytest.fixture(params=["flash_attn", "fused_attn"])
+def attn_impl(request, monkeypatch):
+    if request.param == "flash_attn":
+        os.environ["NVTE_FUSED_ATTN"] = "0"
+        os.environ["NVTE_FLASH_ATTN"] = "1"
+        _attention_backends["backend_selection_requires_update"] = True
+
+    else:
+        os.environ["NVTE_FUSED_ATTN"] = "1"
+        os.environ["NVTE_FLASH_ATTN"] = "0"
+        _attention_backends["backend_selection_requires_update"] = True
+
+    return request.param
+
+
+def test_thd_losses_match(te_model_checkpoint, input_data, input_data_thd, attn_impl):
+    if attn_impl == "fused_attn" and torch.cuda.get_device_capability()[0] == 8:
+        pytest.xfail("On Ada and Ampere, no THD implementation is available for fused attn.")
+
     torch.testing.assert_close(
         input_data["input_ids"][input_data["attention_mask"].to(bool)],
         input_data_thd["input_ids"].flatten(0),
@@ -67,20 +133,110 @@ def test_thd_values_match(te_model_checkpoint, input_data, input_data_thd):
 
     torch.testing.assert_close(bshd_outputs.loss, thd_outputs.loss)
 
-    # bshd_logits = bshd_outputs.logits[input_data_bshd["attention_mask"].to(bool)]
-    # TODO(BIONEMO-2801): Investigate why these are not close on sm89 but pass on sm120.
-    # torch.testing.assert_close(bshd_logits, thd_outputs.logits)
+
+def test_thd_logits_match_with_bf16_autocast(te_model_checkpoint, input_data, input_data_thd, attn_impl):
+    if attn_impl == "fused_attn" and torch.cuda.get_device_capability()[0] == 8:
+        pytest.xfail("On Ada and Ampere, no THD implementation is available for fused attn.")
+    elif attn_impl == "flash_attn" and torch.cuda.get_device_capability()[0] == 8:
+        pytest.xfail("BIONEMO-2801: On Ada and Ampere, the flash attention logits don't seem to match.")
+
+    # Ensure the input data is the same
+    torch.testing.assert_close(
+        input_data["input_ids"][input_data["attention_mask"].to(bool)],
+        input_data_thd["input_ids"].flatten(0),
+    )
+
+    torch.testing.assert_close(
+        input_data["labels"][input_data["attention_mask"].to(bool)],
+        input_data_thd["labels"].flatten(0),
+    )
+
+    # Create models
+    model_bshd = NVEsmForMaskedLM.from_pretrained(te_model_checkpoint, dtype=torch.bfloat16)
+    model_thd = NVEsmForMaskedLM.from_pretrained(te_model_checkpoint, attn_input_format="thd", dtype=torch.bfloat16)
+
+    model_bshd.to("cuda")
+    model_thd.to("cuda")
+
+    input_data_bshd = {k: v.to("cuda") for k, v in input_data.items()}
+    input_data_thd = {k: v.to("cuda") if isinstance(v, torch.Tensor) else v for k, v in input_data_thd.items()}
+
+    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+        thd_outputs = model_thd(**input_data_thd, output_hidden_states=True)
+        bshd_outputs = model_bshd(**input_data_bshd, output_hidden_states=True)
+
+    for i, (bshd_hidden, thd_hidden) in enumerate(zip(bshd_outputs.hidden_states, thd_outputs.hidden_states)):
+        torch.testing.assert_close(
+            bshd_hidden[input_data_bshd["attention_mask"].to(bool)],
+            thd_hidden.squeeze(0),
+            msg=lambda msg: "Hidden states do not match going into layer " + str(i + 1) + ": " + msg,
+            atol=1e-1 if compute_capability[0] == 8 else 1e-5,
+            rtol=1.6e-2,
+        )
+
+        if compute_capability[0] == 8:
+            break  # On Ada and Ampere, we see much larger numerical errors so we stop after the first layer
+
+    bshd_logits = bshd_outputs.logits[input_data_bshd["attention_mask"].to(bool)]
+    torch.testing.assert_close(bshd_logits, thd_outputs.logits, atol=1e-8, rtol=1e-8)
 
 
-def test_thd_backwards(te_model_checkpoint, input_data_thd, monkeypatch):
-    if torch.cuda.get_device_capability() == (12, 0):
-        # TODO(BIONEMO-2840): On sm120, we need to set NVTE_FUSED_ATTN to 0 since TE will choose fused attn by default,
-        # but it's missing this THD implementation.
-        monkeypatch.setenv("NVTE_FUSED_ATTN", "0")
-        _attention_backends["backend_selection_requires_update"] = True
+def test_thd_backwards_works(te_model_checkpoint, input_data_thd, attn_impl):
+    if attn_impl == "fused_attn" and torch.cuda.get_device_capability() == (12, 0):
+        pytest.xfail("BIONEMO-2840: On sm120 the THD backwards implementation is not available for fused attn.")
+    elif attn_impl == "fused_attn" and torch.cuda.get_device_capability()[0] == 8:
+        pytest.xfail("On Ada and Ampere, no THD implementation is available for fused attn.")
 
     model_thd = NVEsmForMaskedLM.from_pretrained(te_model_checkpoint, attn_input_format="thd", dtype=torch.bfloat16)
     model_thd.to("cuda")
     input_data = {k: v.to("cuda") if isinstance(v, torch.Tensor) else v for k, v in input_data_thd.items()}
     outputs = model_thd(**input_data)
     outputs.loss.backward()
+
+
+def test_thd_backwards_passes_match(te_model_checkpoint, input_data, input_data_thd, attn_impl):
+    if attn_impl == "fused_attn" and torch.cuda.get_device_capability() == (12, 0):
+        pytest.xfail("BIONEMO-2840: On sm120 the THD backwards implementation is not available for fused attn.")
+    elif attn_impl == "fused_attn" and torch.cuda.get_device_capability()[0] == 8:
+        pytest.xfail("On Ada and Ampere, no THD implementation is available for fused attn.")
+
+    torch.testing.assert_close(
+        input_data["input_ids"][input_data["attention_mask"].to(bool)],
+        input_data_thd["input_ids"].flatten(0),
+    )
+
+    torch.testing.assert_close(
+        input_data["labels"][input_data["attention_mask"].to(bool)],
+        input_data_thd["labels"].flatten(0),
+    )
+
+    model_bshd = NVEsmForMaskedLM.from_pretrained(te_model_checkpoint, dtype=torch.bfloat16)
+    model_thd = NVEsmForMaskedLM.from_pretrained(te_model_checkpoint, attn_input_format="thd", dtype=torch.bfloat16)
+    model_bshd.to("cuda")
+    model_thd.to("cuda")
+
+    input_data_bshd = {k: v.to("cuda") for k, v in input_data.items()}
+    input_data_thd = {k: v.to("cuda") if isinstance(v, torch.Tensor) else v for k, v in input_data_thd.items()}
+
+    bshd_outputs = model_bshd(**input_data_bshd)
+    thd_outputs = model_thd(**input_data_thd)
+
+    thd_outputs.loss.backward()
+    bshd_outputs.loss.backward()
+
+    thd_grads = {name: p.grad for name, p in model_thd.named_parameters() if p.grad is not None}
+    bshd_grads = {name: p.grad for name, p in model_bshd.named_parameters() if p.grad is not None}
+
+    # max_diff_by_layer = {key: (thd_grads[key] - bshd_grads[key]).abs().max().item() for key in thd_grads.keys()}
+
+    # For some reason, the word embeddings grads have a slightly higher numerical error.
+    thd_word_embeddings_grad = thd_grads.pop("esm.embeddings.word_embeddings.weight")
+    bshd_word_embeddings_grad = bshd_grads.pop("esm.embeddings.word_embeddings.weight")
+    torch.testing.assert_close(
+        thd_grads,
+        bshd_grads,
+        atol=1e-2 if compute_capability[0] == 8 else 1e-5,
+        rtol=1.6e-2,
+    )
+
+    torch.testing.assert_close(thd_word_embeddings_grad, bshd_word_embeddings_grad, atol=1e-2, rtol=1e-5)


### PR DESCRIPTION
Fixes a number of small issues with ESM-2 identified after THD convergence testing at scale:

1. fixes the "token dropout" logic to correctly handle THD batches and numbers of tokens per batch
2. ensures that we don't use torch.amp.autocast when calculating rope embeddings during the forward pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Embeddings now support high-throughput input formats and rotary position embeddings.
  - Token dropout (masking/scale), optional layer normalization, and attention masking added.
  - Position-embedding computation moved to a runtime path with correct device/dtype and autocast handling.

- Tests
  - Expanded THD vs non-THD coverage for outputs, hidden states, logits, and gradients across backends and autocast.
  - Added backend-switching fixture and new embedding tests; test padding changed to multiples of 32.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->