### PR TITLE
Add initial gh action (so can edit afterwards)

### DIFF
--- a/.github/workflows/scdl-performance-tests.yml
+++ b/.github/workflows/scdl-performance-tests.yml
@@ -1,0 +1,11 @@
+name: SCDL Performance Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-performance-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run performance benchmarks
+        run: echo "running performance benchmarks"


### PR DESCRIPTION
This creates a gh action for manual trigger of the scdl performance tests.
These tests will be hosted on cpu nodes in Lepton.
This action isn't fleshed out yet, because we first need to create it so that we can edit/trigger it later (in the #1224 branch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced a manual CI workflow for performance testing to run basic benchmarks and validate performance health.
  - Can be triggered by maintainers on demand and runs on the standard Linux environment.
  - Lays groundwork for future automated performance checks and reporting.
  - No user-facing changes or API updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->