### PR TITLE
add esm-2 hf native training command

### DIFF
--- a/bionemo-recipes/recipes/esm2_native_te/README.md
+++ b/bionemo-recipes/recipes/esm2_native_te/README.md
@@ -83,6 +83,15 @@ python train_fsdp2.py --config-name L0_sanity \
   dataset.sequence_packing_pad_to_multiple_of=16
 ```
 
+### Comparing Against the HF Transformers Reference Implementation
+
+To launch training with the ESM-2 model as implemented in HF Transformers, pass a `facebook/esm2` checkpoint as the
+model tag:
+
+```bash
+python train_fsdp2.py --config-name L0_sanity model_tag=facebook/esm2_t6_8M_UR50D
+```
+
 ## Saving and Loading Checkpoints
 
 To enable checkpoint saving, ensure that `checkpoint.ckpt_dir` is set to a writable directory. Checkpointing frequency is


### PR DESCRIPTION
Adds command for launching ESM-2 training with the transformers reference model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new subsection, “Comparing Against the HF Transformers Reference Implementation,” to the training recipe README.
  * Provides a clear example command to launch training using a HF Transformers ESM-2 checkpoint via a configurable model tag.
  * Clarifies placement relative to FP8/Sequence Packing and Saving/Loading Checkpoints sections for easier navigation.
  * No behavioral changes; content is informational only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->