### PR TITLE
turn off torch compile by default

### DIFF
--- a/bionemo-recipes/recipes/esm2_native_te/hydra_config/L0_sanity.yaml
+++ b/bionemo-recipes/recipes/esm2_native_te/hydra_config/L0_sanity.yaml
@@ -6,6 +6,9 @@ defaults:
 model_tag: nvidia/esm2_t6_8M_UR50D
 num_train_steps: 250
 
+# We want this on in CI/CD to validate that the script runs successfully with torch.compile.
+use_torch_compile: true
+
 dataset:
   tokenizer_name: ${model_tag}
   micro_batch_size: 2

--- a/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
+++ b/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
@@ -8,7 +8,8 @@ save_every_n_steps: 50
 use_meta_device: false
 
 # Whether to wrap the model in torch.compile. Note, this is currently not supported with mfsdp (BIONEMO-2977).
-use_torch_compile: true
+# We leave this off by default since we don't see much of a performance improvement with TE layers.
+use_torch_compile: false
 
 dataset:
   tokenizer_name: ${model_tag}


### PR DESCRIPTION
We don't see a speed improvement with torch.compile and TE layers, so we can leave this off by default to speed up run launches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a configurable use_torch_compile option to toggle torch.compile during runs.

* **Chores**
  * Updated default behavior: use_torch_compile is now disabled by default, reflecting current performance characteristics while remaining available for opt-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->