### PR TITLE
ensure NVEsmEmbeddings uses TE layernorm

### DIFF
--- a/bionemo-recipes/models/esm2/src/esm/modeling_esm_te.py
+++ b/bionemo-recipes/models/esm2/src/esm/modeling_esm_te.py
@@ -526,7 +526,9 @@ class NVEsmEmbeddings(nn.Module):
         )
 
         self.layer_norm = (
-            nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps) if config.emb_layer_norm_before else None
+            transformer_engine.pytorch.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+            if config.emb_layer_norm_before
+            else None
         )
 
         if config.position_embedding_type != "rotary":

--- a/bionemo-recipes/recipes/esm2_accelerate_te/example_8m_checkpoint/esm_nv.py
+++ b/bionemo-recipes/recipes/esm2_accelerate_te/example_8m_checkpoint/esm_nv.py
@@ -526,7 +526,9 @@ class NVEsmEmbeddings(nn.Module):
         )
 
         self.layer_norm = (
-            nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps) if config.emb_layer_norm_before else None
+            transformer_engine.pytorch.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+            if config.emb_layer_norm_before
+            else None
         )
 
         if config.position_embedding_type != "rotary":

--- a/bionemo-recipes/recipes/esm2_native_te/example_8m_checkpoint/esm_nv.py
+++ b/bionemo-recipes/recipes/esm2_native_te/example_8m_checkpoint/esm_nv.py
@@ -526,7 +526,9 @@ class NVEsmEmbeddings(nn.Module):
         )
 
         self.layer_norm = (
-            nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps) if config.emb_layer_norm_before else None
+            transformer_engine.pytorch.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+            if config.emb_layer_norm_before
+            else None
         )
 
         if config.position_embedding_type != "rotary":


### PR DESCRIPTION
I don't think we use this layernorm with our default config, but we should still make sure it uses the TE layernorm class