### PR TITLE
FP8 model initialization (only keep fp8 versions of parameters)

### DIFF
--- a/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
+++ b/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
@@ -47,9 +47,9 @@ fp8_config:
   enabled: false
   fp8_recipe: transformer_engine.common.recipe.DelayedScaling
   fp8_format: "HYBRID"
-  fp8_recipe_kwargs:
-    amax_history_len: 16
-    amax_compute_algo: "max"
+  fp8_recipe_kwargs: {}
+  fp8_model_init_kwargs:
+    enabled: false # If this is set to true, fp8_config.enabled must also be set to true.
 
 # Optimizer config
 adamw_kwargs:

--- a/bionemo-recipes/recipes/esm2_native_te/train_ddp.py
+++ b/bionemo-recipes/recipes/esm2_native_te/train_ddp.py
@@ -37,8 +37,8 @@ logger.setLevel(logging.INFO)
 
 
 @hydra.main(config_path="hydra_config", config_name="L0_sanity", version_base="1.2")
-def main(args: DictConfig) -> float | None:  # noqa: C901
-    """Train ESM-2 with TE layers using ddp.
+def main(args: DictConfig) -> float | None:
+    """Train ESM-2 with TE layers using DDP.
 
     Returns:
         float: The loss value for the final batch.
@@ -54,12 +54,23 @@ def main(args: DictConfig) -> float | None:  # noqa: C901
     # and MFSDP.
     device_mesh = init_device_mesh("cuda", mesh_shape=(dist_config.world_size,), mesh_dim_names=("ddp",))
 
+    # Create an FP8 recipe -- this is only used if FP8 is enabled in the config.
+    fp8_recipe = hydra.utils.get_class(args.fp8_config.fp8_recipe)(
+        fp8_format=Format[args.fp8_config.fp8_format], **args.fp8_config.fp8_recipe_kwargs
+    )
+
     # Create an empty ESM-2 model with a masked language model head, e.g. "nvidia/esm2_t6_8M_UR50D".
     config = AutoConfig.from_pretrained(args.model_tag, trust_remote_code=True, dtype=torch.bfloat16)
     # If we're using sequence packing with TE layers, we need to pass the `attn_input_format` argument.
     if args.dataset.use_sequence_packing:
         config.attn_input_format = "thd"
-    model = AutoModelForMaskedLM.from_config(config, trust_remote_code=True)
+
+    # Optionally use transformer engine to initialize only fp8 versions of weights by setting
+    # `fp8_config.fp8_model_init_kwargs.enabled` to `True`, as opposed to using the default where both bfloat16 and fp8
+    # versions of weights are kept.
+    with transformer_engine.pytorch.fp8_model_init(recipe=fp8_recipe, **args.fp8_config.fp8_model_init_kwargs):
+        model = AutoModelForMaskedLM.from_config(config, trust_remote_code=True)
+
     logger.info("Initialized Model:\n%s", model)
 
     # The huggingface model has a contact head that we don't use in masked language pre-training, so we delete it to
@@ -80,14 +91,6 @@ def main(args: DictConfig) -> float | None:  # noqa: C901
         output_device=dist_config.local_rank,
         device_mesh=device_mesh["ddp"],
     )
-
-    # Create an FP8 recipe
-    if args.fp8_config.enabled:
-        fp8_recipe = hydra.utils.get_class(args.fp8_config.fp8_recipe)(
-            fp8_format=Format[args.fp8_config.fp8_format], **args.fp8_config.fp8_recipe_kwargs
-        )
-    else:
-        fp8_recipe = None
 
     # Create a dataloader that just infinitely loops over the dataset.
     train_dataloader, dataset_or_sampler = create_dataloader(dist_config, **args.dataset)

--- a/bionemo-recipes/recipes/esm2_native_te/train_fsdp2.py
+++ b/bionemo-recipes/recipes/esm2_native_te/train_fsdp2.py
@@ -61,12 +61,23 @@ def main(args: DictConfig) -> float | None:  # noqa: C901
         mesh_dim_names=("dp",),
     )
 
+    # Create an FP8 recipe -- this is only used if FP8 is enabled in the config.
+    fp8_recipe = hydra.utils.get_class(args.fp8_config.fp8_recipe)(
+        fp8_format=Format[args.fp8_config.fp8_format], **args.fp8_config.fp8_recipe_kwargs
+    )
+
     # Create an empty ESM-2 model with a masked language model head, e.g. "nvidia/esm2_t6_8M_UR50D".
     config = AutoConfig.from_pretrained(args.model_tag, trust_remote_code=True, dtype=torch.bfloat16)
     # If we're using sequence packing with TE layers, we need to pass the `attn_input_format` argument.
     if args.dataset.use_sequence_packing:
         config.attn_input_format = "thd"
-    model = AutoModelForMaskedLM.from_config(config, trust_remote_code=True)
+
+    # Optionally use transformer engine to initialize only fp8 versions of weights by setting
+    # `fp8_config.fp8_model_init_kwargs.enabled` to `True`, as opposed to using the default where both bfloat16 and fp8
+    # versions of weights are kept.
+    with transformer_engine.pytorch.fp8_model_init(recipe=fp8_recipe, **args.fp8_config.fp8_model_init_kwargs):
+        model = AutoModelForMaskedLM.from_config(config, trust_remote_code=True)
+
     logger.info("Initialized Model:\n%s", model)
 
     # We call the transformer stack "layers" in our TE models, but it's called "layer" in the original ESM-2 models.
@@ -84,14 +95,6 @@ def main(args: DictConfig) -> float | None:  # noqa: C901
         for module in model.modules():
             if hasattr(module, "reset_parameters"):
                 module.reset_parameters()
-
-    # Create an FP8 recipe
-    if args.fp8_config.enabled:
-        fp8_recipe = hydra.utils.get_class(args.fp8_config.fp8_recipe)(
-            fp8_format=Format[args.fp8_config.fp8_format], **args.fp8_config.fp8_recipe_kwargs
-        )
-    else:
-        fp8_recipe = None
 
     # Create a dataloader that just infinitely loops over the dataset.
     train_dataloader, dataset_or_sampler = create_dataloader(dist_config, **args.dataset)


### PR DESCRIPTION
Support FP8 model initialization (e.g., only storing FP8 weights) with TE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FP8 model-initialization support added across MFSDP, DDP, and FSDP2 training flows and model initialization, plus broader FP8/dtype-aware initialization for model components.

* **Tests**
  * New sanity and unit tests covering FP8 model-init, forward/backward behavior, pretrained load, and checkpoint save across strategies.

* **Chores**
  * Reworked FP8 configuration structure with a dedicated model-init enable flag and simplified initialization sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->