### PR TITLE
add token packing dataset

### DIFF
--- a/bionemo-recipes/recipes/esm2_native_te/README.md
+++ b/bionemo-recipes/recipes/esm2_native_te/README.md
@@ -64,23 +64,22 @@ python train_fsdp2.py --config-name L0_sanity fp8_config.enabled=true
 ### Sequence Packing (THD input format)
 
 Sequence packing is handled via a padding-free collator (in `collator.py`) that provides input arguments (e.g.
-`cu_seq_lens_q`) needed for padding-free attention. To enable sequence packing, set `dataset.use_sequence_packing=true`
+`cu_seq_lens_q`) needed for padding-free attention. To enable sequence packing, set `use_sequence_packing=true`
 in the hydra configuration.
 
 ```bash
-python train_fsdp2.py --config-name L0_sanity dataset.use_sequence_packing=true
+python train_fsdp2.py --config-name L0_sanity use_sequence_packing=true
 ```
 
 ### FP8 and Sequence Packing
 
-To combine FP8 training with sequence packing, the number of unpadded input tokens must be a multiple of 16. This can be
-set via the `dataset.sequence_packing_pad_to_multiple_of=16` configuration parameter.
+To combine FP8 training with sequence packing, the number of unpadded input tokens must be a multiple of 16. The data
+collator will automatically pad packed sequences to the maximum number of tokens per batch.
 
 ```bash
 python train_fsdp2.py --config-name L0_sanity \
   fp8_config.enabled=true \
-  dataset.use_sequence_packing=true \
-  dataset.sequence_packing_pad_to_multiple_of=16
+  use_sequence_packing=true
 ```
 
 ### Comparing Against the HF Transformers Reference Implementation

--- a/bionemo-recipes/recipes/esm2_native_te/dataset.py
+++ b/bionemo-recipes/recipes/esm2_native_te/dataset.py
@@ -22,47 +22,22 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 from transformers import AutoTokenizer
 from transformers.data.data_collator import DataCollatorForLanguageModeling
 
-from collator import MLMDataCollatorWithFlattening
+from collator import MLMDataCollatorWithFlattening, TokenPackingDataset
 from distributed_config import DistributedConfig
 
 
 logger = logging.getLogger(__name__)
 
 
-def create_dataloader(
+def create_tokenized_dataset(
     distributed_config: DistributedConfig,
     tokenizer_name: str,
     load_dataset_kwargs: dict,
-    micro_batch_size: int,
-    num_workers: int,
     max_seq_length: int = 1024,
-    seed: int = 42,
-    use_sequence_packing: bool = False,
-    sequence_packing_pad_to_multiple_of: int | None = None,
     buffer_size: int = 10_000,
     use_lazy_tokenization: bool = True,
-    mlm_probability: float = 0.15,
 ):
-    """Create a dataloader for the dataset.
-
-    Args:
-        distributed_config: The distributed configuration.
-        tokenizer_name: The name of the tokenizer to pull from the HuggingFace Hub.
-        load_dataset_kwargs: Keyword arguments to pass to `load_dataset` for the train dataset.
-        micro_batch_size: The batch size per device.
-        num_workers: The number of workers to use for the dataloader.
-        max_seq_length: The maximum length of the protein sequences.
-        seed: The seed to use for the distributed sampler and data collator.
-        use_sequence_packing: Whether to use sequence packing.
-        sequence_packing_pad_to_multiple_of: The padding to use for the sequence packing collator, for fp8 support.
-        buffer_size: The buffer size to use for the distributed sampler.
-        use_lazy_tokenization: Whether to use datasets.set_transform for tokenization if the dataset is a
-            non-streaming datasets.Dataset. Defaults to True.
-        mlm_probability: The probability of masking tokens for MLM (default 0.15). Set to 0 for no masking.
-
-    Returns:
-        A dataloader that can be used for training.
-    """
+    """Create a tokenized dataset."""
     logger.info(f"Loading dataset with kwargs: {load_dataset_kwargs}")
     dataset = datasets.load_dataset(**load_dataset_kwargs)
     logger.info(f"Loaded dataset: {dataset}")
@@ -74,14 +49,6 @@ def create_dataloader(
             world_size=distributed_config.world_size,
         )
         dataset = dataset.shuffle(seed=42, buffer_size=buffer_size)
-        sampler = None
-    else:
-        sampler = DistributedSampler(
-            dataset,
-            rank=distributed_config.rank,
-            num_replicas=distributed_config.world_size,
-            seed=seed,
-        )
 
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
 
@@ -105,20 +72,65 @@ def create_dataloader(
             remove_columns=dataset.column_names,
         )
 
-    if use_sequence_packing:
-        data_collator = MLMDataCollatorWithFlattening(
-            tokenizer=tokenizer,
-            mlm_probability=mlm_probability,
-            pad_to_multiple_of=sequence_packing_pad_to_multiple_of,
-            seed=seed,
-        )
+    return tokenized_dataset, tokenizer
+
+
+def create_bshd_dataloader(
+    distributed_config: DistributedConfig,
+    tokenizer_name: str,
+    load_dataset_kwargs: dict,
+    micro_batch_size: int,
+    num_workers: int,
+    max_seq_length: int = 1024,
+    seed: int = 42,
+    buffer_size: int = 10_000,
+    use_lazy_tokenization: bool = True,
+    mlm_probability: float = 0.15,
+):
+    """Create a dataloader for the dataset.
+
+    Args:
+        distributed_config: The distributed configuration.
+        tokenizer_name: The name of the tokenizer to pull from the HuggingFace Hub.
+        load_dataset_kwargs: Keyword arguments to pass to `load_dataset` for the train dataset.
+        micro_batch_size: The batch size (number of sequences) per device.
+        num_workers: The number of workers to use for the dataloader.
+        max_seq_length: The maximum length of the protein sequences.
+        seed: The seed to use for the distributed sampler and data collator.
+        buffer_size: The buffer size to use for the distributed sampler.
+        use_lazy_tokenization: Whether to use datasets.set_transform for tokenization if the dataset is a
+            non-streaming datasets.Dataset. Defaults to True.
+        mlm_probability: The probability of masking tokens for MLM (default 0.15). Set to 0 for no masking.
+        **kwargs: Unused, here to enable kwargs to match the signature of create_thd_dataloader.
+
+    Returns:
+        A dataloader that can be used for training.
+    """
+    tokenized_dataset, tokenizer = create_tokenized_dataset(
+        distributed_config=distributed_config,
+        tokenizer_name=tokenizer_name,
+        load_dataset_kwargs=load_dataset_kwargs,
+        max_seq_length=max_seq_length,
+        buffer_size=buffer_size,
+        use_lazy_tokenization=use_lazy_tokenization,
+    )
+
+    if isinstance(tokenized_dataset, datasets.IterableDataset):
+        sampler = None
     else:
-        data_collator = DataCollatorForLanguageModeling(
-            tokenizer=tokenizer,
-            mlm_probability=mlm_probability,
-            pad_to_multiple_of=max_seq_length,
+        sampler = DistributedSampler(
+            tokenized_dataset,
+            rank=distributed_config.rank,
+            num_replicas=distributed_config.world_size,
             seed=seed,
         )
+
+    data_collator = DataCollatorForLanguageModeling(
+        tokenizer=tokenizer,
+        mlm_probability=mlm_probability,
+        pad_to_multiple_of=max_seq_length,
+        seed=seed,
+    )
 
     train_dataloader = StatefulDataLoader(
         tokenized_dataset,
@@ -130,4 +142,72 @@ def create_dataloader(
         persistent_workers=True,
     )
 
-    return train_dataloader, dataset if sampler is None else sampler
+    return train_dataloader, tokenized_dataset if sampler is None else sampler
+
+
+def create_thd_dataloader(
+    distributed_config: DistributedConfig,
+    tokenizer_name: str,
+    load_dataset_kwargs: dict,
+    micro_batch_size: int | None = None,
+    token_micro_batch_size: int | None = None,
+    num_workers: int = 1,
+    max_seq_length: int = 1024,
+    seed: int = 42,
+    buffer_size: int = 10_000,
+    mlm_probability: float = 0.15,
+):
+    """Create a dataloader that packs up to the maximum number of tokens per batch.
+
+    Args:
+        distributed_config: The distributed configuration.
+        tokenizer_name: The name of the tokenizer to pull from the HuggingFace Hub.
+        load_dataset_kwargs: Keyword arguments to pass to `load_dataset` for the train dataset.
+        micro_batch_size: The batch size (number of sequences) per device. This will set the token_micro_batch_size to
+            micro_batch_size * max_seq_length. Defaults to None.
+        token_micro_batch_size: The maximum number of tokens per batch. If None, the micro_batch_size * max_seq_length
+            will be used. Defaults to None.
+        num_workers: The number of workers to use for the dataloader. For iterable datasets, this should be 1.
+        max_seq_length: The maximum length of the protein sequences.
+        seed: The seed to use for the distributed sampler and data collator.
+        buffer_size: The buffer size to use for the distributed sampler.
+        mlm_probability: The probability of masking tokens for MLM (default 0.15). Set to 0 for no masking.
+        **kwargs: Unused, here to enable kwargs to match the signature of create_bshd_dataloader.
+
+    Returns:
+        A dataloader that can be used for training.
+    """
+    tokenized_dataset, tokenizer = create_tokenized_dataset(
+        distributed_config=distributed_config,
+        tokenizer_name=tokenizer_name,
+        load_dataset_kwargs=load_dataset_kwargs,
+        max_seq_length=max_seq_length,
+        buffer_size=buffer_size,
+    )
+
+    assert isinstance(tokenized_dataset, datasets.IterableDataset), "THD token packing requires a streaming dataset."
+    if token_micro_batch_size is None:
+        assert micro_batch_size is not None, "Only one of micro_batch_size or token_micro_batch_size can be provided."
+        token_micro_batch_size = micro_batch_size * max_seq_length
+    else:
+        assert micro_batch_size is None, "Only one of micro_batch_size or token_micro_batch_size can be provided."
+        assert token_micro_batch_size >= max_seq_length, "token_micro_batch_size must be greater than max_seq_length."
+
+    # For THD, we pad out to the maximum number of tokens per batch for consistent array shapes.
+    data_collator = MLMDataCollatorWithFlattening(
+        tokenizer=tokenizer,
+        mlm_probability=mlm_probability,
+        pad_to_multiple_of=token_micro_batch_size,
+        seed=seed,
+    )
+
+    train_dataloader = StatefulDataLoader(
+        TokenPackingDataset(tokenized_dataset, max_tokens_per_batch=token_micro_batch_size),
+        batch_size=None,  # The TokenPackingDataset will handle the batching.
+        collate_fn=data_collator,
+        num_workers=num_workers,
+        pin_memory=True,
+        persistent_workers=True,
+    )
+
+    return train_dataloader, tokenized_dataset

--- a/bionemo-recipes/recipes/esm2_native_te/hydra_config/L0_sanity.yaml
+++ b/bionemo-recipes/recipes/esm2_native_te/hydra_config/L0_sanity.yaml
@@ -9,13 +9,12 @@ num_train_steps: 250
 # We want this on in CI/CD to validate that the script runs successfully with torch.compile.
 use_torch_compile: true
 
+use_sequence_packing: false
 dataset:
   tokenizer_name: ${model_tag}
   micro_batch_size: 2
   num_workers: 1
   max_seq_length: 1024
-  use_sequence_packing: false
-  sequence_packing_pad_to_multiple_of: null
   load_dataset_kwargs:
     path: "parquet"
     split: "train"

--- a/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
+++ b/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
@@ -10,13 +10,12 @@ use_meta_device: false
 # We leave this off by default since we don't see much of a performance improvement with TE layers.
 use_torch_compile: false
 
+use_sequence_packing: false
 dataset:
   tokenizer_name: ${model_tag}
   micro_batch_size: ???
   num_workers: 1
   max_seq_length: 1024
-  use_sequence_packing: false
-  sequence_packing_pad_to_multiple_of: null
   mlm_probability: 0.15
   load_dataset_kwargs:
     path: "nvidia/esm2_uniref_pretraining_data"

--- a/bionemo-recipes/recipes/esm2_native_te/tests/test_dataset.py
+++ b/bionemo-recipes/recipes/esm2_native_te/tests/test_dataset.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 import torch
 
 from checkpoint import load_dataloader, save_dataloader
-from dataset import create_dataloader
+from dataset import create_bshd_dataloader, create_thd_dataloader
 
 
 @dataclass
@@ -51,7 +51,7 @@ def test_load_dataset_state_from_latest_checkpoint(tmp_path):
         world_size=1,
     )
 
-    reference_dataloader, _ = create_dataloader(
+    reference_dataloader, _ = create_bshd_dataloader(
         distributed_config=dist_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -72,7 +72,7 @@ def test_load_dataset_state_from_latest_checkpoint(tmp_path):
         if i == 9:
             break
 
-    new_dataloader, _ = create_dataloader(
+    new_dataloader, _ = create_bshd_dataloader(
         distributed_config=dist_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -114,7 +114,7 @@ def test_map_style_stateful_dataloader_resumption_multi_process(tmp_path):
 
     # Based on local rank.
     # Create dataloader for process 0
-    rank0_dataloader, _ = create_dataloader(
+    rank0_dataloader, _ = create_bshd_dataloader(
         distributed_config=rank0_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -123,7 +123,7 @@ def test_map_style_stateful_dataloader_resumption_multi_process(tmp_path):
         mlm_probability=0,
     )
 
-    rank1_dataloader, _ = create_dataloader(
+    rank1_dataloader, _ = create_bshd_dataloader(
         distributed_config=rank1_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -165,7 +165,7 @@ def test_map_style_stateful_dataloader_resumption_multi_process(tmp_path):
             break
 
     # Load rank0 dataloader state at step 5
-    rank0_dataloader_info_reloaded, _ = create_dataloader(
+    rank0_dataloader_info_reloaded, _ = create_bshd_dataloader(
         distributed_config=rank0_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -181,7 +181,7 @@ def test_map_style_stateful_dataloader_resumption_multi_process(tmp_path):
     )
 
     # Load rank1 dataloader state at step 4
-    rank1_dataloader_info_reloaded, _ = create_dataloader(
+    rank1_dataloader_info_reloaded, _ = create_bshd_dataloader(
         distributed_config=rank1_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -245,21 +245,19 @@ def test_iterable_stateful_dataloader_resumption_multi_process(tmp_path):
 
     # Based on local rank.
     # Create dataloader for process 0
-    rank0_dataloader_info, _ = create_dataloader(
+    rank0_dataloader_info, _ = create_thd_dataloader(
         distributed_config=rank0_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
         micro_batch_size=4,
-        num_workers=1,
         mlm_probability=0,
     )
 
-    rank1_dataloader_info, _ = create_dataloader(
+    rank1_dataloader_info, _ = create_thd_dataloader(
         distributed_config=rank1_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
         micro_batch_size=4,
-        num_workers=1,
         mlm_probability=0,
     )
     dataloader_path_step_4 = dataloader_path / "step_4"
@@ -295,12 +293,11 @@ def test_iterable_stateful_dataloader_resumption_multi_process(tmp_path):
             break
 
     # Load rank0 dataloader state at step 5
-    rank0_dataloader_reloaded, _ = create_dataloader(
+    rank0_dataloader_reloaded, _ = create_thd_dataloader(
         distributed_config=rank0_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
         micro_batch_size=4,
-        num_workers=1,
         mlm_probability=0,
     )
 
@@ -311,12 +308,11 @@ def test_iterable_stateful_dataloader_resumption_multi_process(tmp_path):
     )
 
     # Load rank1 dataloader state at step 4
-    rank1_dataloader_reloaded, _ = create_dataloader(
+    rank1_dataloader_reloaded, _ = create_thd_dataloader(
         distributed_config=rank1_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
         micro_batch_size=4,
-        num_workers=1,
         mlm_probability=0,
     )
 
@@ -370,7 +366,7 @@ def test_stateful_dataloader_works_save_dataloader_and_load_dataloader_single_pr
     )
 
     # First, collect reference batches from a fresh dataloader
-    reference_dataloader_info, _ = create_dataloader(
+    reference_dataloader_info, _ = create_bshd_dataloader(
         distributed_config=dist_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -394,7 +390,7 @@ def test_stateful_dataloader_works_save_dataloader_and_load_dataloader_single_pr
             break
 
     # Now test checkpoint/restore
-    new_dataloader_info, _ = create_dataloader(
+    new_dataloader_info, _ = create_bshd_dataloader(
         distributed_config=dist_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -448,7 +444,7 @@ def test_stateful_dataloader():
     )
 
     # First, collect reference batches from a fresh dataloader
-    reference_dataloader_info, _ = create_dataloader(
+    reference_dataloader_info, _ = create_bshd_dataloader(
         distributed_config=dist_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -468,7 +464,7 @@ def test_stateful_dataloader():
             break
 
     # Now test checkpoint/restore
-    new_dataloader_info, _ = create_dataloader(
+    new_dataloader_info, _ = create_bshd_dataloader(
         distributed_config=dist_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -516,7 +512,7 @@ def test_stateful_dataloader_with_multiple_workers(tmp_path):
     )
 
     # First, collect reference batches from a fresh dataloader
-    reference_dataloader, _ = create_dataloader(
+    reference_dataloader, _ = create_bshd_dataloader(
         distributed_config=dist_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -542,7 +538,7 @@ def test_stateful_dataloader_with_multiple_workers(tmp_path):
             break
 
     # Now test checkpoint/restore
-    new_dataloader, _ = create_dataloader(
+    new_dataloader, _ = create_bshd_dataloader(
         distributed_config=dist_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -588,7 +584,7 @@ def test_iterable_dataloader_yields_different_values_per_rank():
         world_size=2,
     )
 
-    rank1_dataloader, _ = create_dataloader(
+    rank1_dataloader, _ = create_bshd_dataloader(
         distributed_config=rank1_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -596,7 +592,7 @@ def test_iterable_dataloader_yields_different_values_per_rank():
         num_workers=1,
     )
 
-    rank1_duplicate_dataloader, _ = create_dataloader(
+    rank1_duplicate_dataloader, _ = create_bshd_dataloader(
         distributed_config=rank1_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -610,7 +606,7 @@ def test_iterable_dataloader_yields_different_values_per_rank():
         world_size=2,
     )
 
-    rank2_dataloader, _ = create_dataloader(
+    rank2_dataloader, _ = create_bshd_dataloader(
         distributed_config=rank2_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -645,7 +641,7 @@ def test_map_dataset_dataloader_yields_different_values_per_rank():
         world_size=2,
     )
 
-    rank1_dataloader, _ = create_dataloader(
+    rank1_dataloader, _ = create_bshd_dataloader(
         distributed_config=rank1_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -653,7 +649,7 @@ def test_map_dataset_dataloader_yields_different_values_per_rank():
         num_workers=1,
     )
 
-    rank1_duplicate_dataloader, _ = create_dataloader(
+    rank1_duplicate_dataloader, _ = create_bshd_dataloader(
         distributed_config=rank1_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -667,7 +663,7 @@ def test_map_dataset_dataloader_yields_different_values_per_rank():
         world_size=2,
     )
 
-    rank2_dataloader, _ = create_dataloader(
+    rank2_dataloader, _ = create_bshd_dataloader(
         distributed_config=rank2_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -701,7 +697,7 @@ def test_lazy_tokenization_returns_batch():
         world_size=2,
     )
 
-    dataloader, _ = create_dataloader(
+    dataloader, _ = create_bshd_dataloader(
         distributed_config=config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -732,7 +728,7 @@ def test_stateful_dataloader_load_fails_if_num_workers_mismatch(tmp_path, caplog
         world_size=1,
     )
 
-    reference_dataloader, _ = create_dataloader(
+    reference_dataloader, _ = create_bshd_dataloader(
         distributed_config=rank0_dist_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -749,7 +745,7 @@ def test_stateful_dataloader_load_fails_if_num_workers_mismatch(tmp_path, caplog
 
     del reference_dataloader
 
-    reference_dataloader, _ = create_dataloader(
+    reference_dataloader, _ = create_bshd_dataloader(
         distributed_config=rank0_dist_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -789,7 +785,7 @@ def test_stateful_dataloader_load_fails_if_num_ranks_mismatch(tmp_path, caplog):
         world_size=1,
     )
 
-    reference_dataloader, _ = create_dataloader(
+    reference_dataloader, _ = create_bshd_dataloader(
         distributed_config=rank0_dist_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -813,7 +809,7 @@ def test_stateful_dataloader_load_fails_if_num_ranks_mismatch(tmp_path, caplog):
         world_size=2,
     )
 
-    reference_dataloader, _ = create_dataloader(
+    reference_dataloader, _ = create_bshd_dataloader(
         distributed_config=rank2_dist_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -833,3 +829,32 @@ def test_stateful_dataloader_load_fails_if_num_ranks_mismatch(tmp_path, caplog):
         "Dataloader num_workers mismatch: 1 != 1 or num_ranks mismatch: 2 != 1, starting dataloader from scratch."
         in caplog.text
     )
+
+
+def test_token_packing_dataloader():
+    """Test that the token packing dataloader works."""
+
+    tokenizer_name = "facebook/esm2_t6_8M_UR50D"
+    load_dataset_kwargs = {
+        "path": "parquet",
+        "split": "train",
+        "data_files": "train.parquet",
+        "streaming": True,
+    }
+
+    dist_config = MockDistributedConfig(
+        rank=0,
+        local_rank=0,
+        world_size=1,
+    )
+
+    dataloader, _ = create_thd_dataloader(
+        distributed_config=dist_config,
+        tokenizer_name=tokenizer_name,
+        load_dataset_kwargs=load_dataset_kwargs,
+        token_micro_batch_size=8 * 1024,
+    )
+
+    batch = next(iter(dataloader))
+    assert batch["input_ids"].shape[1] == 8 * 1024
+    assert batch["labels"].shape[1] == 8 * 1024

--- a/bionemo-recipes/recipes/esm2_native_te/tests/test_stop_and_go.py
+++ b/bionemo-recipes/recipes/esm2_native_te/tests/test_stop_and_go.py
@@ -24,7 +24,7 @@ from torch.optim import AdamW
 from transformers import AutoConfig, AutoModelForMaskedLM
 
 from checkpoint import load_checkpoint_ddp, save_checkpoint_ddp
-from dataset import create_dataloader
+from dataset import create_bshd_dataloader
 from scheduler import get_linear_schedule_with_warmup
 
 
@@ -55,7 +55,7 @@ def test_stop_and_go_checkpointing_and_dataloader_restoration_single_gpu(tmp_pat
     )
 
     # First, collect reference batches from a fresh dataloader
-    reference_dataloader, _ = create_dataloader(
+    reference_dataloader, _ = create_bshd_dataloader(
         distributed_config=dist_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,
@@ -162,7 +162,7 @@ def test_stop_and_go_checkpointing_and_dataloader_restoration_single_gpu(tmp_pat
     resumed_scheduler = get_linear_schedule_with_warmup(resumed_optimizer, **lr_scheduler_kwargs)
 
     # Now make a dataloader brand new and restore the state?
-    new_dataloader, _ = create_dataloader(
+    new_dataloader, _ = create_bshd_dataloader(
         distributed_config=dist_config,
         tokenizer_name=tokenizer_name,
         load_dataset_kwargs=load_dataset_kwargs,

--- a/bionemo-recipes/recipes/esm2_native_te/tests/test_train.py
+++ b/bionemo-recipes/recipes/esm2_native_te/tests/test_train.py
@@ -265,7 +265,7 @@ def test_sanity_convergence_fsdp2_thd(tmp_path, monkeypatch, recipe_path):
             overrides=[
                 f"+wandb_init_args.dir={tmp_path}",
                 f"checkpoint.ckpt_dir={tmp_path}",
-                "dataset.use_sequence_packing=true",
+                "use_sequence_packing=true",
             ],
         )
 
@@ -287,8 +287,7 @@ def test_sanity_convergence_fsdp2_thd_fp8(tmp_path, monkeypatch, recipe_path):
             overrides=[
                 f"+wandb_init_args.dir={tmp_path}",
                 f"checkpoint.ckpt_dir={tmp_path}",
-                "dataset.use_sequence_packing=true",
-                "dataset.sequence_packing_pad_to_multiple_of=16",
+                "use_sequence_packing=true",
                 "fp8_config.enabled=true",
             ],
         )
@@ -310,7 +309,7 @@ def test_sanity_ddp_thd(tmp_path, monkeypatch, recipe_path):
             overrides=[
                 f"+wandb_init_args.dir={tmp_path}",
                 f"checkpoint.ckpt_dir={tmp_path}",
-                "dataset.use_sequence_packing=true",
+                "use_sequence_packing=true",
                 "num_train_steps=4",
             ],
         )
@@ -331,7 +330,7 @@ def test_sanity_mfsdp_thd(tmp_path, monkeypatch, recipe_path):
             overrides=[
                 f"+wandb_init_args.dir={tmp_path}",
                 f"checkpoint.ckpt_dir={tmp_path}",
-                "dataset.use_sequence_packing=true",
+                "use_sequence_packing=true",
                 "num_train_steps=4",
             ],
         )
@@ -352,10 +351,9 @@ def test_sanity_ddp_thd_fp8(tmp_path, monkeypatch, recipe_path):
             config_name="L0_sanity",
             overrides=[
                 f"+wandb_init_args.dir={tmp_path}",
-                "dataset.use_sequence_packing=true",
+                "use_sequence_packing=true",
                 "num_train_steps=4",
                 "fp8_config.enabled=true",
-                "dataset.sequence_packing_pad_to_multiple_of=16",
                 "checkpoint.resume_from_checkpoint=false",
             ],
         )
@@ -376,10 +374,9 @@ def test_sanity_mfsdp_thd_fp8(tmp_path, monkeypatch, recipe_path):
             config_name="L0_sanity",
             overrides=[
                 f"+wandb_init_args.dir={tmp_path}",
-                "dataset.use_sequence_packing=true",
+                "use_sequence_packing=true",
                 "num_train_steps=4",
                 "fp8_config.enabled=true",
-                "dataset.sequence_packing_pad_to_multiple_of=16",
             ],
         )
 
@@ -478,3 +475,64 @@ def test_sanity_convergence_fsdp2_eager_meta_device(tmp_path, recipe_path):
 
     final_loss = main_fsdp2(sanity_config)
     assert final_loss < 3.0, f"Final loss {final_loss} is too high"
+
+
+def test_sanity_ddp_thd_token_packing(tmp_path, monkeypatch, recipe_path):
+    if torch.cuda.get_device_capability() == (12, 0):
+        # TODO(BIONEMO-2840): On sm120, we need to set NVTE_FUSED_ATTN to 0 since TE will choose fused attn by default,
+        # but it's missing this THD implementation.
+        monkeypatch.setenv("NVTE_FUSED_ATTN", "0")
+
+    # For DDP, we only check that the script can run successfully with THD, not convergence.
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
+        sanity_config = compose(
+            config_name="L0_sanity",
+            overrides=[
+                f"+wandb_init_args.dir={tmp_path}",
+                f"checkpoint.ckpt_dir={tmp_path}",
+                "use_sequence_packing=true",
+                "num_train_steps=4",
+            ],
+        )
+
+    main_ddp(sanity_config)
+
+
+def test_sanity_mfsdp_thd_token_packing(tmp_path, monkeypatch, recipe_path):
+    if torch.cuda.get_device_capability() == (12, 0):
+        # TODO(BIONEMO-2840): On sm120, we need to set NVTE_FUSED_ATTN to 0 since TE will choose fused attn by default,
+        # but it's missing this THD implementation.
+        monkeypatch.setenv("NVTE_FUSED_ATTN", "0")
+
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
+        sanity_config = compose(
+            config_name="L0_sanity",
+            overrides=[
+                f"+wandb_init_args.dir={tmp_path}",
+                f"checkpoint.ckpt_dir={tmp_path}",
+                "use_sequence_packing=true",
+                "num_train_steps=4",
+            ],
+        )
+
+    main_mfsdp(sanity_config)
+
+
+def test_sanity_fsdp2_thd_token_packing(tmp_path, monkeypatch, recipe_path):
+    if torch.cuda.get_device_capability() == (12, 0):
+        # TODO(BIONEMO-2840): On sm120, we need to set NVTE_FUSED_ATTN to 0 since TE will choose fused attn by default,
+        # but it's missing this THD implementation.
+        monkeypatch.setenv("NVTE_FUSED_ATTN", "0")
+
+    with initialize_config_dir(config_dir=str(recipe_path / "hydra_config"), version_base="1.2"):
+        sanity_config = compose(
+            config_name="L0_sanity",
+            overrides=[
+                f"+wandb_init_args.dir={tmp_path}",
+                f"checkpoint.ckpt_dir={tmp_path}",
+                "use_sequence_packing=true",
+                "num_train_steps=4",
+            ],
+        )
+
+    main_fsdp2(sanity_config)

--- a/bionemo-recipes/recipes/esm2_native_te/train_ddp.py
+++ b/bionemo-recipes/recipes/esm2_native_te/train_ddp.py
@@ -26,7 +26,7 @@ from transformer_engine.common.recipe import Format
 from transformers import AutoConfig, AutoModelForMaskedLM
 
 from checkpoint import load_checkpoint_ddp, save_checkpoint_ddp, save_final_model_ddp, should_save_checkpoint
-from dataset import create_dataloader
+from dataset import create_bshd_dataloader, create_thd_dataloader
 from distributed_config import DistributedConfig
 from perf_logger import PerfLogger
 from scheduler import get_linear_schedule_with_warmup
@@ -62,7 +62,7 @@ def main(args: DictConfig) -> float | None:
     # Create an empty ESM-2 model with a masked language model head, e.g. "nvidia/esm2_t6_8M_UR50D".
     config = AutoConfig.from_pretrained(args.model_tag, trust_remote_code=True, dtype=torch.bfloat16)
     # If we're using sequence packing with TE layers, we need to pass the `attn_input_format` argument.
-    if args.dataset.use_sequence_packing:
+    if args.use_sequence_packing:
         config.attn_input_format = "thd"
 
     # Optionally use transformer engine to initialize only fp8 versions of weights by setting
@@ -92,8 +92,12 @@ def main(args: DictConfig) -> float | None:
         device_mesh=device_mesh["ddp"],
     )
 
-    # Create a dataloader that just infinitely loops over the dataset.
-    train_dataloader, dataset_or_sampler = create_dataloader(dist_config, **args.dataset)
+    # If we're using sequence packing, create a THD dataloader, otherwise create a BSHD dataloader.
+    train_dataloader, dataset_or_sampler = (
+        create_thd_dataloader(dist_config, **args.dataset)
+        if args.use_sequence_packing
+        else create_bshd_dataloader(dist_config, **args.dataset)
+    )
 
     if args.use_torch_compile:
         # If we're using torch.compile, we need to do this before loading the checkpoint to ensure key consistency.

--- a/bionemo-recipes/recipes/esm2_native_te/train_fsdp2.py
+++ b/bionemo-recipes/recipes/esm2_native_te/train_fsdp2.py
@@ -30,7 +30,7 @@ from transformers import AutoConfig, AutoModelForMaskedLM
 from transformers.models.esm.modeling_esm import EsmForMaskedLM  # noqa: F401
 
 from checkpoint import load_checkpoint_fsdp2, save_checkpoint_fsdp2, save_final_model_fsdp2, should_save_checkpoint
-from dataset import create_dataloader
+from dataset import create_bshd_dataloader, create_thd_dataloader
 from distributed_config import DistributedConfig
 from perf_logger import PerfLogger
 from scheduler import get_linear_schedule_with_warmup
@@ -69,7 +69,7 @@ def main(args: DictConfig) -> float | None:  # noqa: C901
     # Create an empty ESM-2 model with a masked language model head, e.g. "nvidia/esm2_t6_8M_UR50D".
     config = AutoConfig.from_pretrained(args.model_tag, trust_remote_code=True, dtype=torch.bfloat16)
     # If we're using sequence packing with TE layers, we need to pass the `attn_input_format` argument.
-    if args.dataset.use_sequence_packing:
+    if args.use_sequence_packing:
         config.attn_input_format = "thd"
 
     # Optionally use transformer engine to initialize only fp8 versions of weights by setting
@@ -96,8 +96,12 @@ def main(args: DictConfig) -> float | None:  # noqa: C901
             if hasattr(module, "reset_parameters"):
                 module.reset_parameters()
 
-    # Create a dataloader that just infinitely loops over the dataset.
-    train_dataloader, dataset_or_sampler = create_dataloader(dist_config, **args.dataset)
+    # If we're using sequence packing, create a THD dataloader, otherwise create a BSHD dataloader.
+    train_dataloader, dataset_or_sampler = (
+        create_thd_dataloader(dist_config, **args.dataset)
+        if args.use_sequence_packing
+        else create_bshd_dataloader(dist_config, **args.dataset)
+    )
 
     if args.use_torch_compile:
         # If we're using torch.compile, we need to do this before loading the checkpoint to ensure key consistency.

--- a/ci/lepton/model_convergence/configs/recipes/esm2_native_te.yaml
+++ b/ci/lepton/model_convergence/configs/recipes/esm2_native_te.yaml
@@ -109,7 +109,7 @@ run_script: |
     wandb_init_args.name=${wandb_name} \
     num_train_steps=${num_train_steps} \
     dataset.micro_batch_size=${micro_batch_size} \
-    dataset.use_sequence_packing=${thd_enabled} \
+    use_sequence_packing=${thd_enabled} \
     dataset.load_dataset_kwargs.path=${load_dataset_kwargs_path} \
     dataset.load_dataset_kwargs.streaming=${load_dataset_kwargs_streaming} \
     +dataset.load_dataset_kwargs.revision=${load_dataset_kwargs_revision} \


### PR DESCRIPTION
Adds the capability to dynamically change the batch size in THD model training, packing batches up to a desired number of total tokens (rather than individual sequences).

Pads up to a total number of tokens for consistent array dimensions rather than splitting partial sequences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional token-packing mode for higher token-per-batch efficiency with a dedicated token-packed data path.

* **Behavior**
  * Data loading supports both standard and token-packed flows and returns tokenized data plus appropriate iterables/samplers.
  * Collator now pads packed sequences to the configured max tokens per batch.
  * Improved handling for distributed vs. streaming datasets.

* **Configuration**
  * Introduced top-level use_sequence_packing flag; CLI/examples updated.

* **Tests**
  * Added unit and sanity tests for token-packing and end-to-end scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->