### PR TITLE
add transformer_engine[torch] to recipe requirements

### DIFF
--- a/bionemo-recipes/recipes/esm2_accelerate_te/requirements.txt
+++ b/bionemo-recipes/recipes/esm2_accelerate_te/requirements.txt
@@ -4,4 +4,5 @@ deepspeed
 hydra-core
 torchmetrics
 transformers
+transformer_engine[pytorch]
 wandb

--- a/bionemo-recipes/recipes/esm2_native_te/requirements.txt
+++ b/bionemo-recipes/recipes/esm2_native_te/requirements.txt
@@ -5,6 +5,6 @@ torch
 torchmetrics
 torchdata
 tqdm
-transformer_engine
+transformer_engine[pytorch]
 transformers
 wandb


### PR DESCRIPTION
Adds transformer_engine[torch] to recipe requirements to simply install outside the torch base container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to enable PyTorch backend support for transformer engine across recipes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->