### PR TITLE
fix flow of branch selection in scdl ci action

### DIFF
--- a/.github/workflows/scdl-performance-tests.yml
+++ b/.github/workflows/scdl-performance-tests.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commit_sha || github.event.inputs.branch || 'main' }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Without the ref parameter, the checkout step defaults to using the "Use workflow from" branch, causing `launch_job.py` to load Hydra configs from that branch instead of the intended branch from the input parameter. This fix ensures the workflow branch only controls the YAML logic, while the input branch parameter correctly controls which configs and code are used.