### PR TITLE
dont autocast rope embeddings

### DIFF
--- a/bionemo-recipes/models/esm2/src/esm/modeling_esm_te.py
+++ b/bionemo-recipes/models/esm2/src/esm/modeling_esm_te.py
@@ -214,7 +214,7 @@ class NVEsmEncoder(nn.Module):
                     te_rope_emb = self.rotary_embeddings(max_seq_len=hidden_states.shape[1])
                 elif self.config.attn_input_format == "thd":
                     te_rope_emb = self.rotary_embeddings(max_seq_len=kwargs["cu_seq_lens_q"][-1])
-            te_rope_emb = te_rope_emb.to(hidden_states.device, dtype=hidden_states.dtype, non_blocking=True)
+            te_rope_emb = te_rope_emb.to(hidden_states.device, non_blocking=True)
 
         for layer_module in self.layers:
             if kwargs.get("output_hidden_states", False):

--- a/bionemo-recipes/models/llama3/modeling_llama_te.py
+++ b/bionemo-recipes/models/llama3/modeling_llama_te.py
@@ -269,4 +269,4 @@ class NVLlamaRotaryEmbedding(LlamaRotaryEmbedding):
             freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
             emb = torch.cat((freqs, freqs), dim=-1)
 
-        return emb.to(dtype=x.dtype).transpose(0, 1).unsqueeze(1)
+        return emb.transpose(0, 1).unsqueeze(1)

--- a/bionemo-recipes/models/llama3/tests/test_modeling_llama_te.py
+++ b/bionemo-recipes/models/llama3/tests/test_modeling_llama_te.py
@@ -70,7 +70,7 @@ def test_llama_model_golden_values(input_text):
     with torch.no_grad():
         outputs_te = model_te(**inputs, labels=inputs["input_ids"], output_hidden_states=True)
 
-    torch.testing.assert_close(outputs_te.loss, outputs_hf.loss, atol=2e-3, rtol=2e-3)
+    torch.testing.assert_close(outputs_te.loss, outputs_hf.loss, atol=5e-3, rtol=2e-3)
     torch.testing.assert_close(outputs_te.logits, outputs_hf.logits, atol=1.0, rtol=0.01)
 
 

--- a/bionemo-recipes/recipes/esm2_accelerate_te/example_8m_checkpoint/esm_nv.py
+++ b/bionemo-recipes/recipes/esm2_accelerate_te/example_8m_checkpoint/esm_nv.py
@@ -214,7 +214,7 @@ class NVEsmEncoder(nn.Module):
                     te_rope_emb = self.rotary_embeddings(max_seq_len=hidden_states.shape[1])
                 elif self.config.attn_input_format == "thd":
                     te_rope_emb = self.rotary_embeddings(max_seq_len=kwargs["cu_seq_lens_q"][-1])
-            te_rope_emb = te_rope_emb.to(hidden_states.device, dtype=hidden_states.dtype, non_blocking=True)
+            te_rope_emb = te_rope_emb.to(hidden_states.device, non_blocking=True)
 
         for layer_module in self.layers:
             if kwargs.get("output_hidden_states", False):

--- a/bionemo-recipes/recipes/esm2_native_te/example_8m_checkpoint/esm_nv.py
+++ b/bionemo-recipes/recipes/esm2_native_te/example_8m_checkpoint/esm_nv.py
@@ -214,7 +214,7 @@ class NVEsmEncoder(nn.Module):
                     te_rope_emb = self.rotary_embeddings(max_seq_len=hidden_states.shape[1])
                 elif self.config.attn_input_format == "thd":
                     te_rope_emb = self.rotary_embeddings(max_seq_len=kwargs["cu_seq_lens_q"][-1])
-            te_rope_emb = te_rope_emb.to(hidden_states.device, dtype=hidden_states.dtype, non_blocking=True)
+            te_rope_emb = te_rope_emb.to(hidden_states.device, non_blocking=True)
 
         for layer_module in self.layers:
             if kwargs.get("output_hidden_states", False):

--- a/bionemo-recipes/recipes/esm2_peft_te/example_8m_checkpoint/esm_nv.py
+++ b/bionemo-recipes/recipes/esm2_peft_te/example_8m_checkpoint/esm_nv.py
@@ -214,7 +214,7 @@ class NVEsmEncoder(nn.Module):
                     te_rope_emb = self.rotary_embeddings(max_seq_len=hidden_states.shape[1])
                 elif self.config.attn_input_format == "thd":
                     te_rope_emb = self.rotary_embeddings(max_seq_len=kwargs["cu_seq_lens_q"][-1])
-            te_rope_emb = te_rope_emb.to(hidden_states.device, dtype=hidden_states.dtype, non_blocking=True)
+            te_rope_emb = te_rope_emb.to(hidden_states.device, non_blocking=True)
 
         for layer_module in self.layers:
             if kwargs.get("output_hidden_states", False):


### PR DESCRIPTION
The TE rope kernels can accept an fp32 rope embedding input, so we don't have to cast these to the hidden state's input dtype