### PR TITLE
update KRATOS env var names

### DIFF
--- a/ci/lepton/model_convergence/configs/base.yaml
+++ b/ci/lepton/model_convergence/configs/base.yaml
@@ -28,7 +28,7 @@ environment_variables:
   - name: KRATOS_SSA_CLIENT_ID
     value_from: KRATOS_SSA_CLIENT_ID
   - name: KRATOS_SSA_SECRET
-    value_from: KRATOS_SSA_SECRET
+    value_from: KRATOS_SSA_SECRET.jwilber
   - name: LEP_LOGIN_CREDENTIALS
     value_from: LEP_LOGIN_CREDENTIALS
   - name: HF_HOME

--- a/ci/lepton/scdl_performance/configs/scdl.yaml
+++ b/ci/lepton/scdl_performance/configs/scdl.yaml
@@ -29,7 +29,7 @@ environment_variables:
   - name: KRATOS_SSA_CLIENT_ID
     value_from: KRATOS_SSA_CLIENT_ID
   - name: KRATOS_SSA_SECRET
-    value_from: KRATOS_SSA_SECRET
+    value_from: KRATOS_SSA_SECRET.jwilber
   - name: LEP_LOGIN_CREDENTIALS
     value_from: LEP_LOGIN_CREDENTIALS
 


### PR DESCRIPTION
Update variable names for lepton ci jobs.
The SSA credentials expired, and updating them forced the username suffix.