### PR TITLE
Add split_samples functionality to TokenPackingDataset

### DIFF
--- a/bionemo-recipes/recipes/llama3_native_te/dataset.py
+++ b/bionemo-recipes/recipes/llama3_native_te/dataset.py
@@ -219,6 +219,7 @@ def create_thd_dataloader(
     text_column: str = "text",
     uppercase_labels: bool = False,
     mask_degenerate_bases: bool = True,
+    split_samples_in_token_packing: bool = True,
 ):
     """Create a dataloader that packs up to the maximum number of tokens per batch.
 
@@ -240,6 +241,8 @@ def create_thd_dataloader(
         text_column: Name of the column containing genomic sequences (default: "text").
         uppercase_labels: Whether to uppercase labels (genomic masking). Default: False.
         mask_degenerate_bases: Whether to mask degenerate bases (genomic masking). Default: True.
+        split_samples_in_token_packing: Whether to split samples to form batches with exactly token_micro_batch_size
+            tokens. Default: True.
 
     Returns:
         A dataloader that can be used for training.
@@ -279,7 +282,11 @@ def create_thd_dataloader(
     # TODO(BIONEMO-3246) - remove the pin_memory=False once StatefulDataLoader supports pin_memory again.
     dataloader_class = StatefulDataLoader if use_stateful_dataloader else DataLoader
     train_dataloader = dataloader_class(
-        TokenPackingDataset(tokenized_dataset, max_tokens_per_batch=token_micro_batch_size),
+        TokenPackingDataset(
+            tokenized_dataset,
+            max_tokens_per_batch=token_micro_batch_size,
+            split_samples=split_samples_in_token_packing,
+        ),
         batch_size=None,  # The TokenPackingDataset will handle the batching.
         collate_fn=data_collator,
         num_workers=num_workers,

--- a/bionemo-recipes/recipes/llama3_native_te/tests/test_dataset.py
+++ b/bionemo-recipes/recipes/llama3_native_te/tests/test_dataset.py
@@ -414,12 +414,7 @@ def test_batching_produces_correct_batch_size(tokenizer_path, tmp_path):
 
 
 def test_batching_produces_correct_batch_size_sequence_packing(tokenizer_path, tmp_path):
-    """Test that batching combines multiple sequences correctly with exact batch counts.
-
-    Creates 5 short sequences (no windowing) with micro_batch_size=2.
-    Should produce exactly 3 batches with shapes: [2, 2, 1].
-    """
-    # Create 5 sequences that won't trigger windowing (all very short)
+    """Test that batching combines multiple sequences correctly with exact batch counts"""
     parquet_path = tmp_path / "five_sequences.parquet"
     sequences = ["A"] * 20
     table = pa.table({"text": sequences})
@@ -442,6 +437,7 @@ def test_batching_produces_correct_batch_size_sequence_packing(tokenizer_path, t
         max_seq_length=15,
         stride=10,
         use_lazy_tokenization=False,  # Use eager to ensure predictable batching
+        split_samples_in_token_packing=False,
     )
 
     batches = list(dataloader)
@@ -449,6 +445,7 @@ def test_batching_produces_correct_batch_size_sequence_packing(tokenizer_path, t
     assert len(batches) > 0
 
     for batch in batches:
+        # BOS, 'A', 'EOS' * 5
         torch.testing.assert_close(batch["input_ids"].squeeze(0), torch.tensor([[2, 65, 0] * 5]).flatten())
 
 


### PR DESCRIPTION
This update introduces a new parameter, split_samples, to the TokenPackingDataset class, allowing for the splitting of samples to ensure batches contain exactly max_tokens_per_batch tokens. A new utility function, split_sample_by_num_tokens, is also added to facilitate this feature by splitting sample dictionaries at a specified number of tokens.

This will help auto-regressive models where we want to ensure the entire batch is filled for optimal token throughput
