### PR TITLE
revert meta device for esm2

### DIFF
--- a/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
+++ b/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
@@ -2,7 +2,7 @@
 model_tag: ??? # E.g., nvidia/esm2_t6_8M_UR50D, facebook/esm2_t6_8M_UR50D, or a local path (e.g ./example_8m_checkpoint)
 num_train_steps: ???
 
-use_meta_device: true
+use_meta_device: false  # meta-device init is still not converging
 
 # Whether to wrap the model in torch.compile. Note, this is currently not supported with mfsdp (BIONEMO-2977).
 # We leave this off by default since we don't see much of a performance improvement with TE layers.


### PR DESCRIPTION
Reverts meta device init for esm-2 after large-scale convergence tests showed issues