### PR TITLE
Add kratos subject

### DIFF
--- a/ci/lepton/model_convergence/configs/recipes/codonfm_ptl_te.yaml
+++ b/ci/lepton/model_convergence/configs/recipes/codonfm_ptl_te.yaml
@@ -28,7 +28,7 @@ container:
 ############################################################
 # kratos info: where to log data
 ############################################################
-kratos_subject: "codonfm_test"
+kratos_subject: "convergence_tests_v0.0.3"
 
 ############################################################
 # recipe identifiers


### PR DESCRIPTION
Add kratos subject to support logging codonfm results to kratos/dashboard.