### PR TITLE
re-enable esm2 meta device

### DIFF
--- a/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
+++ b/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
@@ -2,7 +2,7 @@
 model_tag: ??? # E.g., nvidia/esm2_t6_8M_UR50D, facebook/esm2_t6_8M_UR50D, or a local path (e.g ./example_8m_checkpoint)
 num_train_steps: ???
 
-use_meta_device: false  # meta-device init is still not converging
+use_meta_device: true
 
 # Whether to wrap the model in torch.compile. Note, this is currently not supported with mfsdp (BIONEMO-2977).
 # We leave this off by default since we don't see much of a performance improvement with TE layers.


### PR DESCRIPTION
Well this was a dumb mistake, esm2 meta-device init is working, we just never pushed new models to the HF hub. 

https://huggingface.co/nvidia/esm2_t6_8M_UR50D/commit/c977d28e46627fa645ba421614bf7f37bd488330

<img width="2528" height="1328" alt="W B Chart Dec 24 2025" src="https://github.com/user-attachments/assets/25fe9894-07d9-427b-a618-d571af55ec73" />
