### PR TITLE
Add CP support to modeling_llama_te.py

### DIFF
--- a/bionemo-recipes/models/llama3/tests/test_lm_eval.py
+++ b/bionemo-recipes/models/llama3/tests/test_lm_eval.py
@@ -29,7 +29,10 @@ from modeling_llama_te import AUTO_MAP, NVLlamaConfig, NVLlamaForCausalLM
 def model_checkpoint(tmp_path: Path):
     tokenizer = AutoTokenizer.from_pretrained("nvidia/Llama-3.1-8B-Instruct-FP8")
     config = NVLlamaConfig.from_pretrained(
-        "nvidia/Llama-3.1-8B-Instruct-FP8", num_hidden_layers=2, attn_input_format="bshd"
+        "nvidia/Llama-3.1-8B-Instruct-FP8",
+        num_hidden_layers=2,
+        attn_input_format="bshd",
+        self_attn_mask_type="causal",
     )
     model = NVLlamaForCausalLM(config)
     model.save_pretrained(tmp_path / "checkpoint")

--- a/bionemo-recipes/models/llama3/tests/test_modeling_llama_te.py
+++ b/bionemo-recipes/models/llama3/tests/test_modeling_llama_te.py
@@ -69,7 +69,10 @@ def test_llama_model_forward_pass(input_text, attn_input_format):
 def test_llama_model_forward_pass_no_attention_mask():
     tokenizer = AutoTokenizer.from_pretrained("nvidia/Llama-3.1-8B-Instruct-FP8")
     config = NVLlamaConfig.from_pretrained(
-        "nvidia/Llama-3.1-8B-Instruct-FP8", num_hidden_layers=2, attn_input_format="bshd"
+        "nvidia/Llama-3.1-8B-Instruct-FP8",
+        num_hidden_layers=2,
+        attn_input_format="bshd",
+        self_attn_mask_type="causal",
     )
     model = NVLlamaForCausalLM(config)
 
@@ -269,7 +272,7 @@ def test_hf_llama_model_generate_bshd():
 def test_te_llama_model_generate_with_cache():
     tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-3.1-8B-Instruct")
     model_hf = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-3.1-8B-Instruct", dtype=torch.bfloat16)
-    model_te = convert_llama_hf_to_te(model_hf)
+    model_te = convert_llama_hf_to_te(model_hf, self_attn_mask_type="padding_causal")
 
     prompt = """
    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
* Makes the attention_mask type more easily controllable through a config kwarg
* passes the additional `_padded` kwargs through to the TE layers
* simplifies some of the pre-processing logic and adds comments as to why they're needed

Fixes BIO-12