### PR TITLE
Fix codonfm recipe for 26.02 base image

### DIFF
--- a/bionemo-recipes/recipes/codonfm_ptl_te/requirements.txt
+++ b/bionemo-recipes/recipes/codonfm_ptl_te/requirements.txt
@@ -194,7 +194,7 @@ pycparser==2.22
 pydantic_core==2.33.2
 pydantic==2.11.7
 pyfaidx==0.9.0.3
-Pygments==2.19.2
+Pygments
 PyNaCl==1.6.0
 pynndescent==0.5.13
 pyparsing==3.2.3
@@ -211,7 +211,7 @@ python-hostlist==2.2.2
 python-json-logger==3.3.0
 python-multipart==0.0.20
 pytorch-lightning==2.5.5
-PyYAML==6.0.2
+PyYAML
 pyzmq==27.0.1
 ray==2.49.2
 referencing==0.36.2
@@ -278,7 +278,7 @@ webcolors==24.11.1
 webencodings==0.5.1
 websocket-client==1.8.0
 Werkzeug==3.1.3
-wheel==0.45.1
+wheel
 wrapt==1.17.2
 xdoctest==1.0.2
 xxhash==3.5.0


### PR DESCRIPTION
Fixes 
```
× Cannot uninstall wheel 0.42.0
╰─> The package's contents are unknown: no RECORD file was found for wheel.

hint: The package was installed by debian. You should check if it can uninstall the package.
```
errors for packages that are pinned to versions that differ from apt-installed packages in the base image