### PR TITLE
fix: remove wheel/setuptools pins from codonfm_ptl_te requirements

### DIFF
--- a/bionemo-recipes/recipes/codonfm_ptl_te/requirements.txt
+++ b/bionemo-recipes/recipes/codonfm_ptl_te/requirements.txt
@@ -229,7 +229,6 @@ seaborn==0.13.2
 Send2Trash==1.8.3
 sentry-sdk==2.39.0
 session-info2==0.2.2
-setuptools==79.0.1
 sh==2.2.2
 shellingham==1.5.4
 six==1.16.0
@@ -278,7 +277,6 @@ webcolors==24.11.1
 webencodings==0.5.1
 websocket-client==1.8.0
 Werkzeug==3.1.3
-wheel==0.45.1
 wrapt==1.17.2
 xdoctest==1.0.2
 xxhash==3.5.0


### PR DESCRIPTION
## Summary
- Removes `wheel==0.45.1` and `setuptools==79.0.1` pins from `bionemo-recipes/recipes/codonfm_ptl_te/requirements.txt`
- These build tools are pre-installed by Debian in the CI container (`pytorch:26.02-py3`) and cannot be uninstalled by pip (no RECORD file), causing `pip install -e .` to fail

## Failure details
- **Failed run**: https://github.com/NVIDIA/bionemo-framework/actions/runs/22616310020
- **Failed job**: `unit-tests (recipes/codonfm_ptl_te)` at the "Install dependencies" step
- **Error**: `Cannot uninstall wheel 0.42.0 — The package's contents are unknown: no RECORD file was found for wheel. hint: The package was installed by debian.`

## Root cause
The CI container has `wheel==0.42.0` installed via Debian's package manager (no pip RECORD file). When `pip install -e .` tries to upgrade to the pinned `wheel==0.45.1`, it fails because pip cannot uninstall system-installed packages. The same issue would occur with `setuptools` if wheel were resolved first.

Neither `wheel` nor `setuptools` are runtime dependencies — they are build tools already available in the container and listed in `pyproject.toml`'s `build-system.requires`. No other recipe in the repo pins these packages.

## Test plan
- [ ] CI passes for `recipes/codonfm_ptl_te` with this change
- [ ] Verify no other recipes are affected (confirmed: no other recipe pins `wheel` or `setuptools`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)