### PR TITLE
Fix HFInferenceParams missing is_compileable for transformers 5.x compatibility

### DIFF
--- a/bionemo-recipes/models/llama3/modeling_llama_te.py
+++ b/bionemo-recipes/models/llama3/modeling_llama_te.py
@@ -591,3 +591,8 @@ class HFInferenceParams(InferenceParams):
             updated_key_cache = key_cache.index_select(0, beam_idx)
             updated_value_cache = value_cache.index_select(0, beam_idx)
             self.cache_manager.cache[layer_number] = (updated_key_cache, updated_value_cache)
+
+    @property
+    def is_compileable(self) -> bool:
+        """Return False as this cache is not compatible with torch.compile."""
+        return False

--- a/bionemo-recipes/models/mixtral/modeling_mixtral_te.py
+++ b/bionemo-recipes/models/mixtral/modeling_mixtral_te.py
@@ -876,6 +876,11 @@ class HFInferenceParams(InferenceParams):
             updated_value_cache = value_cache.index_select(0, beam_idx)
             self.cache_manager.cache[layer_number] = (updated_key_cache, updated_value_cache)
 
+    @property
+    def is_compileable(self) -> bool:
+        """Return False as this cache is not compatible with torch.compile."""
+        return False
+
 
 @torch.compile(fullgraph=True)
 def _build_expert_sort_indices(recv_counts: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:

--- a/bionemo-recipes/models/qwen/modeling_qwen2_te.py
+++ b/bionemo-recipes/models/qwen/modeling_qwen2_te.py
@@ -576,3 +576,8 @@ class HFInferenceParams(InferenceParams):
             updated_key_cache = key_cache.index_select(0, beam_idx)
             updated_value_cache = value_cache.index_select(0, beam_idx)
             self.cache_manager.cache[layer_number] = (updated_key_cache, updated_value_cache)
+
+    @property
+    def is_compileable(self) -> bool:
+        """Return False as this cache is not compatible with torch.compile."""
+        return False

--- a/bionemo-recipes/models/qwen/modeling_qwen3_te.py
+++ b/bionemo-recipes/models/qwen/modeling_qwen3_te.py
@@ -586,3 +586,8 @@ class HFInferenceParams(InferenceParams):
             updated_key_cache = key_cache.index_select(0, beam_idx)
             updated_value_cache = value_cache.index_select(0, beam_idx)
             self.cache_manager.cache[layer_number] = (updated_key_cache, updated_value_cache)
+
+    @property
+    def is_compileable(self) -> bool:
+        """Return False as this cache is not compatible with torch.compile."""
+        return False

--- a/bionemo-recipes/recipes/llama3_native_te/modeling_llama_te.py
+++ b/bionemo-recipes/recipes/llama3_native_te/modeling_llama_te.py
@@ -597,3 +597,8 @@ class HFInferenceParams(InferenceParams):
             updated_key_cache = key_cache.index_select(0, beam_idx)
             updated_value_cache = value_cache.index_select(0, beam_idx)
             self.cache_manager.cache[layer_number] = (updated_key_cache, updated_value_cache)
+
+    @property
+    def is_compileable(self) -> bool:
+        """Return False as this cache is not compatible with torch.compile."""
+        return False

--- a/bionemo-recipes/recipes/opengenome2_llama_native_te/modeling_llama_te.py
+++ b/bionemo-recipes/recipes/opengenome2_llama_native_te/modeling_llama_te.py
@@ -597,3 +597,8 @@ class HFInferenceParams(InferenceParams):
             updated_key_cache = key_cache.index_select(0, beam_idx)
             updated_value_cache = value_cache.index_select(0, beam_idx)
             self.cache_manager.cache[layer_number] = (updated_key_cache, updated_value_cache)
+
+    @property
+    def is_compileable(self) -> bool:
+        """Return False as this cache is not compatible with torch.compile."""
+        return False


### PR DESCRIPTION
## Problem

Nightly CI has been failing for 7 consecutive days (4/11–4/17) across `models/mixtral`, `models/llama3`, `models/qwen`, and `verify-recipe-tests`.

All failures share the same root cause:
```
AttributeError: 'HFInferenceParams' object has no attribute 'is_compileable'
```

The 26.03 PyTorch container update (#1540) brought `transformers==5.5.4`, which added an `is_compileable` property check on cache objects during `generate()`. The custom `HFInferenceParams` class does not implement this property.

## Fix

Added `is_compileable` property returning `False` to `HFInferenceParams` in all 6 affected files (4 model sources + 2 recipe copies). The property returns `False` since this custom TE-based cache wrapper is not compatible with `torch.compile`.

## Failing CI run
https://github.com/NVIDIA/bionemo-framework/actions/runs/24558420210

## Testing
- Pre-commit checks pass
- `check_copied_files.py` confirms all copies are in sync
- Fix is minimal and targeted (5 lines per file)