### PR TITLE
Fix ESM2 tokenizer export: use PreTrainedTokenizerFast instead of TokenizersBackend

### DIFF
--- a/bionemo-recipes/models/esm2/export.py
+++ b/bionemo-recipes/models/esm2/export.py
@@ -81,6 +81,16 @@ def export_hf_checkpoint(tag: str, export_path: Path):
     tokenizer = AutoTokenizer.from_pretrained("esm_fast_tokenizer")  # Use our PreTrainedTokenizerFast implementation.
     tokenizer.save_pretrained(export_path / tag)
 
+    # Patch tokenizer_config.json: transformers 5.x saves "TokenizersBackend" which AutoTokenizer cannot resolve.
+    tokenizer_config_path = export_path / tag / "tokenizer_config.json"
+    with open(tokenizer_config_path, "r") as f:
+        tokenizer_config = json.load(f)
+    tokenizer_config["tokenizer_class"] = "PreTrainedTokenizerFast"
+    tokenizer_config.pop("backend", None)
+    tokenizer_config.pop("is_local", None)
+    with open(tokenizer_config_path, "w") as f:
+        json.dump(tokenizer_config, f, indent=2, sort_keys=True)
+
     # Patch the config
     with open(export_path / tag / "config.json", "r") as f:
         config = json.load(f)

--- a/bionemo-recipes/recipes/vllm_inference/esm2/export.py
+++ b/bionemo-recipes/recipes/vllm_inference/esm2/export.py
@@ -87,6 +87,16 @@ def export_hf_checkpoint(tag: str, export_path: Path):
     tokenizer = AutoTokenizer.from_pretrained("esm_fast_tokenizer")  # Use our PreTrainedTokenizerFast implementation.
     tokenizer.save_pretrained(export_path / tag)
 
+    # Patch tokenizer_config.json: transformers 5.x saves "TokenizersBackend" which AutoTokenizer cannot resolve.
+    tokenizer_config_path = export_path / tag / "tokenizer_config.json"
+    with open(tokenizer_config_path, "r") as f:
+        tokenizer_config = json.load(f)
+    tokenizer_config["tokenizer_class"] = "PreTrainedTokenizerFast"
+    tokenizer_config.pop("backend", None)
+    tokenizer_config.pop("is_local", None)
+    with open(tokenizer_config_path, "w") as f:
+        json.dump(tokenizer_config, f, indent=2, sort_keys=True)
+
     # Patch the config
     with open(export_path / tag / "config.json", "r") as f:
         config = json.load(f)


### PR DESCRIPTION
## Problem

The ESM2 export script produces a `tokenizer_config.json` with `"tokenizer_class": "TokenizersBackend"` when run with transformers 5.x (26.03 container). This class name is not in the `AutoTokenizer` registry, so loading exported models fails:

```
ValueError: Tokenizer class TokenizersBackend does not exist or is not currently imported.
```

This affects both the repo exports and the models already on the HF Hub (e.g. `nvidia/esm2_t6_8M_UR50D`).

## Root Cause

Transformers 5.x renamed the internal fast tokenizer backend class to `TokenizersBackend`, but this name is not registered in `TOKENIZER_MAPPING_NAMES`. When `save_pretrained()` is called, it serializes this unresolvable class name.

## Fix

After `tokenizer.save_pretrained()`, patch the saved `tokenizer_config.json` to:
1. Set `tokenizer_class` to `"PreTrainedTokenizerFast"` (universally resolvable)
2. Remove non-standard fields (`backend`, `is_local`) that transformers 5.x adds

Applied to both `bionemo-recipes/models/esm2/export.py` and its copy at `bionemo-recipes/recipes/vllm_inference/esm2/export.py`.

## Note

The existing Hub models (`nvidia/esm2_*`) also need their `tokenizer_config.json` patched — this PR fixes the export script so future exports are correct.