### PR TITLE
fix(ci): use gitleaks dir mode so pre-commit catches secrets in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,8 +44,12 @@ repos:
     rev: v8.24.2
     hooks:
       - id: gitleaks
-        # Override default entry: `gitleaks git --pre-commit --staged` only
-        # scans staged commits, which is a no-op in CI (`pre-commit run
-        # --all-files`).  `gitleaks dir` scans file contents directly, so it
-        # catches secrets both locally and in CI.
-        entry: gitleaks dir --redact --verbose
+        # Override upstream `gitleaks git --pre-commit --staged`, which scans
+        # staged git diffs and is a no-op in CI (`pre-commit run --all-files`
+        # has nothing staged).  Instead, scan the files pre-commit passes in:
+        # staged files on `git commit`, tracked files on `--all-files`.
+        # `gitleaks dir` only accepts one path per invocation, so fan out via
+        # xargs -P for parallelism; xargs returns 123 if any child exits
+        # non-zero, which pre-commit surfaces as a hook failure.
+        entry: sh -c 'printf "%s\0" "$@" | xargs -0 -n1 -P"$(getconf _NPROCESSORS_ONLN)" gitleaks dir --redact --verbose --no-banner' --
+        pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,8 @@ repos:
     rev: v8.24.2
     hooks:
       - id: gitleaks
+        # Override default entry: `gitleaks git --pre-commit --staged` only
+        # scans staged commits, which is a no-op in CI (`pre-commit run
+        # --all-files`).  `gitleaks dir` scans file contents directly, so it
+        # catches secrets both locally and in CI.
+        entry: gitleaks dir --redact --verbose


### PR DESCRIPTION
## Problem

The gitleaks pre-commit hook is silently passing in CI, even when secrets are present. See [#1551](https://github.com/NVIDIA/bionemo-framework/pull/1551) which includes a hardcoded `WANDB_API_KEY` that gitleaks did not flag.

**Root cause:** The default gitleaks hook entry is:
```
gitleaks git --pre-commit --redact --staged --verbose
```

This scans **staged git changes** — it works during an actual `git commit`. But in CI, `static_checks.sh` runs:
```
pre-commit run --all-files
```

With `--all-files`, there are no staged files and no commit context, so gitleaks scans **0 commits** and reports "no leaks found":
```
7:02PM INF 0 commits scanned.
7:02PM INF scanned ~0 bytes (0) in 28.9ms
7:02PM INF no leaks found
```

## Fix

Override the hook entry to use `gitleaks dir --redact --verbose`, which scans **file contents** directly. This works correctly both:
- Locally during `git commit` (pre-commit hook)
- In CI with `pre-commit run --all-files`

## Testing

After this change, running `pre-commit run gitleaks --all-files` on the repo will scan actual file contents instead of scanning 0 commits.