### PR TITLE
fix(esm2_accelerate_te): skip GPU-dependent tests when CUDA is unavailable

### DIFF
--- a/bionemo-recipes/recipes/esm2_accelerate_te/tests/launch.py
+++ b/bionemo-recipes/recipes/esm2_accelerate_te/tests/launch.py
@@ -25,6 +25,11 @@ import torch
 import train
 
 
+requires_gpu = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="Test requires a GPU",
+)
+
 requires_multi_gpu = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.device_count() < 2,
     reason="Test requires at least 2 GPUs",

--- a/bionemo-recipes/recipes/esm2_accelerate_te/tests/test_accelerate_esm2.py
+++ b/bionemo-recipes/recipes/esm2_accelerate_te/tests/test_accelerate_esm2.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Local helper function import, resolved in conftest.py
-from launch import launch_accelerate, requires_multi_gpu
+from launch import launch_accelerate, requires_gpu, requires_multi_gpu
 
 
 def test_te_with_default_config(tmp_path):
@@ -37,16 +37,19 @@ def test_te_with_dynamo_config(tmp_path):
     assert train_loss < 3.0, f"Final train_loss {train_loss} should be less than 3.0"
 
 
+@requires_gpu
 def test_te_with_fp8_config(tmp_path):
     train_loss = launch_accelerate("fp8.yaml", tmp_path, 1, "L0_sanity", "model_tag=./example_8m_checkpoint")
     assert train_loss < 3.0, f"Final train_loss {train_loss} should be less than 3.0"
 
 
+@requires_gpu
 def test_hf_with_default_config(tmp_path):
     train_loss = launch_accelerate("default.yaml", tmp_path, 1, "L0_sanity", "model_tag=facebook/esm2_t6_8M_UR50D")
     assert train_loss < 3.0, f"Final train_loss {train_loss} should be less than 3.0"
 
 
+@requires_gpu
 def test_hf_with_fsdp2_config(tmp_path):
     train_loss = launch_accelerate("fsdp2_hf.yaml", tmp_path, 1, "L0_sanity", "model_tag=facebook/esm2_t6_8M_UR50D")
     assert train_loss < 3.0, f"Final train_loss {train_loss} should be less than 3.0"

--- a/bionemo-recipes/recipes/esm2_accelerate_te/tests/test_train_resume.py
+++ b/bionemo-recipes/recipes/esm2_accelerate_te/tests/test_train_resume.py
@@ -18,11 +18,20 @@ import re
 import shutil
 from pathlib import Path
 
+import pytest
+import torch
 from hydra import compose, initialize_config_dir
 
 import train
 
 
+requires_gpu = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="Test requires a GPU",
+)
+
+
+@requires_gpu
 def test_train_can_resume_from_checkpoint(monkeypatch, tmp_path: Path):
     """Test that train.py runs successfully with sanity config and creates expected outputs."""
 


### PR DESCRIPTION
## Problem

Nightly CI run [#25158764339](https://github.com/NVIDIA/bionemo-framework/actions/runs/25158764339) failed because the runner's GPU was unavailable (CUDA error 101: invalid device ordinal). This caused 4 tests to fail:

1. `test_te_with_fp8_config` — TransformerEngine asserts CUDA availability for FP8
2. `test_hf_with_default_config` — `TrainingArguments(bf16=True)` requires GPU
3. `test_hf_with_fsdp2_config` — same bf16 validation
4. `test_train_can_resume_from_checkpoint` — calls `cuda_setDevice(0)` directly

Meanwhile, TE-model tests that can run on CPU (default, fsdp1, fsdp2, dynamo configs with local checkpoint) passed fine.

## Fix

Add `requires_gpu` skip marker (analogous to existing `requires_multi_gpu`) so these tests skip gracefully when CUDA is unavailable instead of failing with errors.

## Testing

- Pre-commit passes
- Tests will skip on CPU-only runners, pass on GPU runners (same behavior as `requires_multi_gpu` tests)
- No functional change to tests when GPU is available