### PR TITLE
chore: update pytorch base container from 26.03-py3 to 26.04-py3

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # Uncomment to use the latest TE from the NGC registry for debugging changes with latest TE.
 # FROM gitlab-master.nvidia.com/dl/transformerengine/transformerengine:main-pytorch-py3-base
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 
 # FIXME: Fix for "No such file or directory: /workspace/TransformerEngine"
 #  Remove once bug has been addressed in the nvidia/pytorch container.

--- a/.github/workflows/unit-tests-framework.yml
+++ b/.github/workflows/unit-tests-framework.yml
@@ -232,7 +232,7 @@ jobs:
       )
     name: "unit-tests (${{ matrix.pkg.name }})"
     container:
-      image: svcbionemo023/bionemo-framework:pytorch26.03-py3-squashed
+      image: svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed
       options: --shm-size=16G
       env:
         CI: true
@@ -329,7 +329,7 @@ jobs:
         )
     name: "slow-tests (${{ matrix.pkg.name }})"
     container:
-      image: svcbionemo023/bionemo-framework:pytorch26.03-py3-squashed
+      image: svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed
       options: --shm-size=16G
       env:
         CI: true
@@ -405,7 +405,7 @@ jobs:
         )
     name: "notebook-tests (${{ matrix.pkg.name }})"
     container:
-      image: svcbionemo023/bionemo-framework:pytorch26.03-py3-squashed
+      image: svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed
       options: --shm-size=16G
       env:
         CI: true

--- a/.github/workflows/unit-tests-mbridge-recipes.yaml
+++ b/.github/workflows/unit-tests-mbridge-recipes.yaml
@@ -113,7 +113,7 @@ jobs:
             map({
               dir: .,
               name: (. | sub("^bionemo-recipes/"; "")),
-              image: "svcbionemo023/bionemo-framework:pytorch26.03-py3-squashed"
+              image: "svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed"
             })
           ')
           echo "dirs=$DIRS_WITH_IMAGES" >> $GITHUB_OUTPUT

--- a/.github/workflows/unit-tests-recipes.yml
+++ b/.github/workflows/unit-tests-recipes.yml
@@ -95,8 +95,8 @@ jobs:
           # Currently, AMPLIFY is the only folder that needs a custom base image, since we have to support both TE and
           # xformers-based models for golden value testing. The rest of the models use the default pytorch image.
 
-          # This uses a squashed version of the pytorch:26.03-py3 image, generated with `docker-squash
-          # nvcr.io/nvidia/pytorch:26.03-py3 -t svcbionemo023/bionemo-framework:pytorch26.03-py3-squashed --output
+          # This uses a squashed version of the pytorch:26.04-py3 image, generated with `docker-squash
+          # nvcr.io/nvidia/pytorch:26.04-py3 -t svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed --output
           # type=registry,compression=zstd,force-compression=true,oci-mediatypes=true,compression-level=15` and pushed
           # to the dockerhub registry. Our github actions are able to cache image pulls from dockerhub but not nvcr, so
           # hopefully this cuts down slightly on CI time at the expense of having a slightly in-directed image location.
@@ -109,8 +109,8 @@ jobs:
                 if . == "bionemo-recipes/models/amplify" then
                   "svcbionemo023/bionemo-framework:amplify-model-devcontainer-082025"
                 else
-                  # "nvcr.io/nvidia/pytorch:26.03-py3"
-                  "svcbionemo023/bionemo-framework:pytorch26.03-py3-squashed"
+                  # "nvcr.io/nvidia/pytorch:26.04-py3"
+                  "svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed"
                 end
               )
             })

--- a/bionemo-recipes/models/codonfm/requirements.txt
+++ b/bionemo-recipes/models/codonfm/requirements.txt
@@ -1,3 +1,4 @@
 torch
 transformer_engine[pytorch]
 transformers
+pytest

--- a/bionemo-recipes/models/esm2/Dockerfile
+++ b/bionemo-recipes/models/esm2/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 WORKDIR /workspace/bionemo
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/bionemo-recipes/models/esm2/requirements.txt
+++ b/bionemo-recipes/models/esm2/requirements.txt
@@ -9,3 +9,4 @@ torch
 torchao!=0.14.0
 transformer_engine[pytorch]
 transformers
+pytest

--- a/bionemo-recipes/models/geneformer/Dockerfile
+++ b/bionemo-recipes/models/geneformer/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 WORKDIR /workspace/bionemo
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/bionemo-recipes/models/llama3/requirements.txt
+++ b/bionemo-recipes/models/llama3/requirements.txt
@@ -3,3 +3,4 @@ torch
 torchao!=0.14.0
 transformer_engine[pytorch]
 transformers
+pytest

--- a/bionemo-recipes/models/mixtral/requirements.txt
+++ b/bionemo-recipes/models/mixtral/requirements.txt
@@ -3,3 +3,4 @@ torch
 torchao!=0.14.0
 transformer_engine[pytorch]
 transformers
+pytest

--- a/bionemo-recipes/models/qwen/Dockerfile
+++ b/bionemo-recipes/models/qwen/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 WORKDIR /workspace/bionemo
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/bionemo-recipes/models/qwen/requirements.txt
+++ b/bionemo-recipes/models/qwen/requirements.txt
@@ -3,3 +3,4 @@ torch
 torchao!=0.14.0
 transformer_engine[pytorch]
 transformers
+pytest

--- a/bionemo-recipes/recipes/README.md
+++ b/bionemo-recipes/recipes/README.md
@@ -85,7 +85,7 @@ recipes/{recipe_name}/
 Your `Dockerfile` should create a complete, reproducible training environment:
 
 ```dockerfile
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 
 # Install dependencies with caching for faster builds
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/bionemo-recipes/recipes/codonfm_native_te/Dockerfile
+++ b/bionemo-recipes/recipes/codonfm_native_te/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/bionemo-recipes/recipes/eden_megatron/Dockerfile
+++ b/bionemo-recipes/recipes/eden_megatron/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 
 # uv is pre-installed in the nvcr.io/nvidia/pytorch base image.
 # If using a base image without uv, uncomment the following line:

--- a/bionemo-recipes/recipes/esm2_accelerate_te/Dockerfile
+++ b/bionemo-recipes/recipes/esm2_accelerate_te/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/bionemo-recipes/recipes/esm2_accelerate_te/requirements.txt
+++ b/bionemo-recipes/recipes/esm2_accelerate_te/requirements.txt
@@ -7,3 +7,4 @@ torchmetrics
 transformer_engine[pytorch]
 transformers
 wandb
+pytest

--- a/bionemo-recipes/recipes/esm2_native_te/Dockerfile
+++ b/bionemo-recipes/recipes/esm2_native_te/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/bionemo-recipes/recipes/esm2_peft_te/Dockerfile
+++ b/bionemo-recipes/recipes/esm2_peft_te/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/bionemo-recipes/recipes/esm2_peft_te/requirements.txt
+++ b/bionemo-recipes/recipes/esm2_peft_te/requirements.txt
@@ -8,3 +8,4 @@ tqdm
 transformer_engine[pytorch]
 transformers
 wandb
+pytest

--- a/bionemo-recipes/recipes/evo2_megatron/.ci_build.sh
+++ b/bionemo-recipes/recipes/evo2_megatron/.ci_build.sh
@@ -10,11 +10,14 @@ uv venv --system-site-packages
 # 2. Activate the environment
 source .venv/bin/activate
 
-# 3. Install build requirements and pin transformer_engine
+# 3. Pin warp-lang<1.13.0 (subquadratic-ops-torch 0.2.0 uses wp.context removed in 1.13)
+uv pip install 'warp-lang<1.13.0'
+
+# 4. Install build requirements and pin transformer_engine
 pip freeze | grep transformer_engine > pip-constraints.txt
 uv pip install -r build_requirements.txt --no-build-isolation
 
-# 4. Pre-install local sub-packages if checked out by CI.
+# 5. Pre-install local sub-packages if checked out by CI.
 #    pyproject.toml references bionemo-recipeutils and bionemo-core from git (main).
 #    In CI, the workflow sparse-checks them out alongside this recipe so we can test
 #    against the PR's changes. But if the sub-packages don't exist on main yet (e.g.
@@ -35,8 +38,8 @@ for pkg_dir in "$RECIPE_ROOT/../../../sub-packages/bionemo-recipeutils" "$RECIPE
     fi
 done
 
-# 5. Install the recipe with all remaining dependencies
+# 6. Install the recipe with all remaining dependencies
 uv pip install -c pip-constraints.txt -e . --no-build-isolation
 
-# 6. Restore original pyproject.toml (the edit was only needed for uv resolution)
+# 7. Restore original pyproject.toml (the edit was only needed for uv resolution)
 mv pyproject.toml.ci_bak pyproject.toml

--- a/bionemo-recipes/recipes/evo2_megatron/Dockerfile
+++ b/bionemo-recipes/recipes/evo2_megatron/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 
 # uv is pre-installed in the nvcr.io/nvidia/pytorch base image.
 # If using a base image without uv, uncomment the following line:

--- a/bionemo-recipes/recipes/fp8_analysis/requirements.txt
+++ b/bionemo-recipes/recipes/fp8_analysis/requirements.txt
@@ -2,3 +2,4 @@ matplotlib==3.10.1
 numpy==1.26.4
 pandas==2.2.3
 seaborn==0.13.2
+pytest

--- a/bionemo-recipes/recipes/geneformer_native_te_mfsdp_fp8/Dockerfile
+++ b/bionemo-recipes/recipes/geneformer_native_te_mfsdp_fp8/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 
 RUN apt-get update && apt-get install -y git
 

--- a/bionemo-recipes/recipes/geneformer_native_te_mfsdp_fp8/requirements.txt
+++ b/bionemo-recipes/recipes/geneformer_native_te_mfsdp_fp8/requirements.txt
@@ -8,3 +8,4 @@ tqdm
 transformer_engine
 transformers<5.0
 wandb
+pytest

--- a/bionemo-recipes/recipes/llama3_native_te/Dockerfile
+++ b/bionemo-recipes/recipes/llama3_native_te/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/bionemo-recipes/recipes/llama3_native_te/requirements.txt
+++ b/bionemo-recipes/recipes/llama3_native_te/requirements.txt
@@ -10,3 +10,4 @@ transformers
 wandb
 zstandard
 nvdlfw_inspect @ git+https://github.com/NVIDIA/nvidia-dlfw-inspect
+pytest

--- a/bionemo-recipes/recipes/opengenome2_llama_native_te/Dockerfile
+++ b/bionemo-recipes/recipes/opengenome2_llama_native_te/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/bionemo-recipes/recipes/opengenome2_llama_native_te/requirements.txt
+++ b/bionemo-recipes/recipes/opengenome2_llama_native_te/requirements.txt
@@ -10,3 +10,4 @@ transformers
 wandb
 zstandard
 nvdlfw_inspect @ git+https://github.com/NVIDIA/nvidia-dlfw-inspect
+pytest

--- a/bionemo-recipes/recipes/vit/Dockerfile
+++ b/bionemo-recipes/recipes/vit/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 
 RUN --mount=type=secret,id=netrc,target=/root/.netrc \
     --mount=type=cache,target=/root/.cache/pip \

--- a/bionemo-recipes/recipes/vit/requirements.txt
+++ b/bionemo-recipes/recipes/vit/requirements.txt
@@ -7,3 +7,4 @@ einops
 wandb
 tqdm
 datasets
+pytest

--- a/bionemo-recipes/recipes/vllm_inference/esm2/Dockerfile
+++ b/bionemo-recipes/recipes/vllm_inference/esm2/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:26.03-py3
+FROM nvcr.io/nvidia/pytorch:26.04-py3
 WORKDIR /workspace/bionemo
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/sub-packages/bionemo-scdl/tests/bionemo/scdl/conftest.py
+++ b/sub-packages/bionemo-scdl/tests/bionemo/scdl/conftest.py
@@ -139,8 +139,12 @@ def make_two_datasets(make_random_csr):
 
         h1 = tmp_path / "var1.h5ad"
         h2 = tmp_path / "var2.h5ad"
-        ad.AnnData(X=None, var=pd.DataFrame(index=np.arange(X1.shape[1])), raw={"X": X1}).write_h5ad(h1)
-        ad.AnnData(X=None, var=pd.DataFrame(index=np.arange(X2.shape[1])), raw={"X": X2}).write_h5ad(h2)
+        ad.AnnData(
+            obs=pd.DataFrame(index=range(X1.shape[0])), var=pd.DataFrame(index=np.arange(X1.shape[1])), raw={"X": X1}
+        ).write_h5ad(h1)
+        ad.AnnData(
+            obs=pd.DataFrame(index=range(X2.shape[0])), var=pd.DataFrame(index=np.arange(X2.shape[1])), raw={"X": X2}
+        ).write_h5ad(h2)
 
         ds1 = SingleCellMemMapDataset(tmp_path / "var_ds1", h5ad_path=h1, data_dtype=dtype1)
         ds2 = SingleCellMemMapDataset(tmp_path / "var_ds2", h5ad_path=h2, data_dtype=dtype2)
@@ -164,6 +168,7 @@ def make_small_and_large_h5ads():
         indices_small_vals = np.array([0, 11, 5, 7], dtype=np.int64)
         indptr_small_vals = np.array([0, 0, 2, 2, 4], dtype=np.int64)
         X_small = ad.AnnData(
+            obs=pd.DataFrame(index=range(n_rows_small)),
             var=pd.DataFrame(index=np.arange(n_cols_small)),
             raw={
                 "X": sp.csr_matrix(
@@ -180,6 +185,7 @@ def make_small_and_large_h5ads():
         indices_large_vals = np.array([10, 65_537], dtype=np.int64)
         indptr_large_vals = np.array([0, 1, 1, 2], dtype=np.int64)
         X_large = ad.AnnData(
+            obs=pd.DataFrame(index=range(n_rows_large)),
             var=pd.DataFrame(index=np.arange(n_cols_large)),
             raw={
                 "X": sp.csr_matrix(

--- a/sub-packages/bionemo-scdl/tests/bionemo/scdl/io/test_single_cell_memmap_dataset.py
+++ b/sub-packages/bionemo-scdl/tests/bionemo/scdl/io/test_single_cell_memmap_dataset.py
@@ -17,6 +17,7 @@ from typing import Tuple
 
 import anndata as ad
 import numpy as np
+import pandas as pd
 import pytest
 import scipy.sparse as sp
 
@@ -112,7 +113,7 @@ def big_int_h5ad(tmp_path, big_h5ad_data):
     """Create and return the path to an h5ad with large values/columns for dtype promotion tests."""
     d = big_h5ad_data
     X = sp.csr_matrix((d["data"].astype(np.uint32), d["indices"], d["indptr"]), shape=(d["n_rows"], d["n_cols"]))
-    a = ad.AnnData(X=None, raw={"X": X})
+    a = ad.AnnData(obs=pd.DataFrame(index=range(d["n_rows"])), raw={"X": X})
     h5ad_path = tmp_path / "big_dtype.h5ad"
     a.write_h5ad(h5ad_path)
     return h5ad_path
@@ -123,7 +124,7 @@ def big_float_h5ad(tmp_path, big_h5ad_data):
     """Create and return the path to an h5ad with large values/columns for dtype promotion tests."""
     d = big_h5ad_data
     X = sp.csr_matrix((d["data"].astype("float32"), d["indices"], d["indptr"]), shape=(d["n_rows"], d["n_cols"]))
-    a = ad.AnnData(X=None, raw={"X": X})
+    a = ad.AnnData(obs=pd.DataFrame(index=range(d["n_rows"])), raw={"X": X})
     h5ad_path = tmp_path / "big_dtype.h5ad"
     a.write_h5ad(h5ad_path)
     return h5ad_path


### PR DESCRIPTION
## Summary

Update PyTorch base container from `26.03-py3` to `26.04-py3` across all Dockerfiles and CI workflows.

## Changes

- Updated all `nvcr.io/nvidia/pytorch:26.03-py3` references to `26.04-py3`
- Updated CI workflow container references to `svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed`
- Squashed image pushed to DockerHub: `svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed` (zstd compressed)

## Testing

CI will validate all recipes against the new container.

Resolves BIO-405.