### PR TITLE
fix(amplify): cap setuptools<82 to preserve pkg_resources

### DIFF
--- a/bionemo-recipes/models/amplify/pyproject.toml
+++ b/bionemo-recipes/models/amplify/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0,<82"]
 build-backend = "setuptools.build_meta"
 
 
@@ -16,6 +16,7 @@ dependencies = [
     "nvidia_resiliency_ext",
     "omegaconf",
     "pytest",
+    "setuptools<82",
     "torch==2.6.0a0+ecf3bae40a.nv25.01",
     "transformer_engine[pytorch]",
     "transformers<5.0",                  # TODO(BIO-143): update AMPLIFY to support Transformers v5


### PR DESCRIPTION
## Description

Fixes nightly CI failure in `unit-tests (models/amplify)` ([run #25911784459](https://github.com/NVIDIA/bionemo-framework/actions/runs/25911784459)).

### Root Cause

When `pip install -e .` runs for the amplify recipe, pip resolves `setuptools>=61.0` to v82.0.1. In setuptools 82+, `pkg_resources` was removed as a bundled module. The `hypothesis` testing library (installed in the base container image) imports `pkg_resources` in its `entry_points.py`, causing pytest to crash at startup:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

### Fix

- Cap `setuptools>=61.0,<82` in `[build-system].requires`
- Add `setuptools<82` to `[project].dependencies` to prevent runtime upgrade

This preserves backward compatibility until either the base image is updated with a newer hypothesis that does not use `pkg_resources`, or setuptools-pkg-resources is added.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

Signed-off-by: svc-bionemo <267129667+svc-bionemo@users.noreply.github.com>