### PR TITLE
fix: guard division-by-zero and uninitialized state in metrics/masking code

### DIFF
--- a/bionemo-recipes/interpretability/sparse_autoencoders/sae/src/sae/eval/dead_latents.py
+++ b/bionemo-recipes/interpretability/sparse_autoencoders/sae/src/sae/eval/dead_latents.py
@@ -67,6 +67,7 @@ class DeadLatentTracker:
 
         # Tracks activity since last reset
         self.recently_active = torch.zeros(hidden_dim, dtype=torch.bool, device=device)
+        self._last_avg_nonzero: float = 0.0
 
     @torch.no_grad()
     def update(self, codes: torch.Tensor) -> None:

--- a/bionemo-recipes/recipes/codonfm_ptl_te/src/data/preprocess/mlm_memmap.py
+++ b/bionemo-recipes/recipes/codonfm_ptl_te/src/data/preprocess/mlm_memmap.py
@@ -66,7 +66,9 @@ def process_item(  # noqa: D417
         prob_input_sequence = np.ones_like(input_sequence_toks) * mlm_probability
         if codon_weights is not None:
             pos_weight = codon_weights[input_sequence_toks]
-            pos_weight[1:-1] = pos_weight[1:-1] / pos_weight[1:-1].mean()
+            mean_weight = pos_weight[1:-1].mean()
+            if mean_weight > 0:
+                pos_weight[1:-1] = pos_weight[1:-1] / mean_weight
             prob_input_sequence = prob_input_sequence * pos_weight
             prob_input_sequence = np.clip(prob_input_sequence, 0.05, 0.4)
         mask_indices = np.random.binomial(1, prob_input_sequence).astype(bool)  # noqa: NPY002
@@ -82,10 +84,13 @@ def process_item(  # noqa: D417
         masked_input_sequence_toks[indices_replaced] = tokenizer.mask_token_id
 
     if random_replace_prob > 0.0:
+        remaining_prob = 1.0 - mask_replace_prob
+        # Conditional probability of random replacement given the token was not replaced by [MASK].
+        # Guard against mask_replace_prob == 1.0 (no remaining positions) or rounding above 1.0.
+        conditional_prob = min(random_replace_prob / remaining_prob, 1.0) if remaining_prob > 0.0 else 0.0
         indices_random = np.random.binomial(  # noqa: NPY002
             1,
-            (np.ones_like(mask_indices).astype(bool) & mask_indices & ~indices_replaced)
-            * (random_replace_prob / (1 - mask_replace_prob)),
+            (np.ones_like(mask_indices).astype(bool) & mask_indices & ~indices_replaced) * conditional_prob,
         ).astype(bool)
         valid_tokens = np.setdiff1d(
             np.arange(tokenizer.vocab_size),

--- a/bionemo-recipes/recipes/evo2_megatron/src/bionemo/evo2/data/megatron/hyena/evo2_dataset.py
+++ b/bionemo-recipes/recipes/evo2_megatron/src/bionemo/evo2/data/megatron/hyena/evo2_dataset.py
@@ -39,7 +39,6 @@ class Evo2Dataset(GPTDataset):
 
     VALID_DNA_AND_DEGENERATE: ClassVar[set[int]] = {
         45,
-        45,
         65,
         66,
         67,


### PR DESCRIPTION
- mlm_memmap.py: normalize codon weights only when mean > 0 to prevent NaN propagating into np.random.binomial when all token weights are zero
- mlm_memmap.py: clamp conditional random-replace probability to [0, 1] and guard against mask_replace_prob == 1.0 causing ZeroDivisionError
- dead_latents.py: initialize _last_avg_nonzero in __init__ so get_stats() is safe to call before the first update()
- evo2_dataset.py: remove duplicate ASCII 45 ('-') entry in VALID_DNA_AND_DEGENERATE

### Description

Four defensive bug fixes across the codon MLM preprocessing pipeline and SAE evaluation utilities.

#### Usage

**mlm_memmap.py — codon weight normalization:** Previously, passing a `codon_weights` array where all weights for the sequence tokens were zero caused division-by-zero → NaN → crash inside `np.random.binomial`. No API change; the normalization is simply skipped when the mean is zero and masking proceeds with the flat `mlm_probability`.

**mlm_memmap.py — random replacement probability:** Calling `process_item` with `mask_replace_prob=1.0` (or any combo where `random_replace_prob / (1 - mask_replace_prob) > 1.0`) raised `ZeroDivisionError` or `ValueError`. Now guarded with a zero-denominator check and clamped to [0, 1].

**dead_latents.py — pre-update get_stats():** `DeadLatentTracker().get_stats()` now works immediately after construction without needing a prior `update()` call.

```python
tracker = DeadLatentTracker(hidden_dim=4096)
stats = tracker.get_stats()  # previously AttributeError, now returns 0.0 avg_nonzero