### PR TITLE
fix(recipes): remove deprecated fully_shard kwargs (check_for_nan_in_grad, grad_reduce_in_fp32)

### DIFF
--- a/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
+++ b/bionemo-recipes/recipes/esm2_native_te/hydra_config/defaults.yaml
@@ -34,8 +34,6 @@ fully_shard_kwargs:
   zero_dp_strategy: "optim_grads_params"
   calculate_per_token_loss: false
   init_model_with_meta_device: ${use_meta_device}
-  check_for_nan_in_grad: true
-  grad_reduce_in_fp32: false
   preserve_fp32_weights: true
   overlap_grad_reduce: true
   overlap_param_gather: true

--- a/bionemo-recipes/recipes/geneformer_native_te_mfsdp_fp8/hydra_config/defaults.yaml
+++ b/bionemo-recipes/recipes/geneformer_native_te_mfsdp_fp8/hydra_config/defaults.yaml
@@ -31,8 +31,6 @@ training:
     zero_dp_strategy: "optim_grads_params"
     calculate_per_token_loss: false
     init_model_with_meta_device: true
-    check_for_nan_in_grad: true
-    grad_reduce_in_fp32: false
     preserve_fp32_weights: true
     overlap_grad_reduce: true
     overlap_param_gather: true

--- a/bionemo-recipes/recipes/vit/config/defaults.yaml
+++ b/bionemo-recipes/recipes/vit/config/defaults.yaml
@@ -55,7 +55,6 @@ fsdp:
     - torch.nn.LayerNorm
     - torch.nn.Linear
   outer_dp_sharding_strategy: "optim"
-  grad_reduce_in_fp32: false
   preserve_fp32_weights: true
 
 training:

--- a/bionemo-recipes/recipes/vit/config/vit_base_patch16_224.yaml
+++ b/bionemo-recipes/recipes/vit/config/vit_base_patch16_224.yaml
@@ -53,7 +53,6 @@ fsdp:
     - torch.nn.LayerNorm
     - torch.nn.Linear
   outer_dp_sharding_strategy: 1
-  grad_reduce_in_fp32: false
   preserve_fp32_weights: true
 
 training:

--- a/bionemo-recipes/recipes/vit/train.py
+++ b/bionemo-recipes/recipes/vit/train.py
@@ -95,8 +95,6 @@ def main(cfg) -> None:
             hybrid_fsdp_group=device_mesh["hsdp"].get_group(),
             # Load the model on device in shards to avoid OOM. Requires device("meta")-init for model.
             init_model_with_meta_device=cfg.fsdp.init_model_with_meta_device,
-            # Reduce gradients in FP32.
-            grad_reduce_in_fp32=cfg.fsdp.grad_reduce_in_fp32,
             # Store distributed optimization state in FP32.
             preserve_fp32_weights=cfg.fsdp.preserve_fp32_weights,
             # Sync model parameters and gradients each step. Allows for param and gradient mods after BWD


### PR DESCRIPTION
## Summary

Fixes nightly CI failures caused by updated `megatron-fsdp` package that removed the `check_for_nan_in_grad` and `grad_reduce_in_fp32` keyword arguments from `fully_shard()`.

## Failures Fixed

- **recipes/geneformer_native_te_mfsdp_fp8** (3 tests): `TypeError: fully_shard() got an unexpected keyword argument 'check_for_nan_in_grad'`
- **recipes/esm2_native_te** (8 tests): `TypeError: fully_shard() got an unexpected keyword argument 'check_for_nan_in_grad'`
- **recipes/vit** (3 tests): `TypeError: fully_shard() got an unexpected keyword argument 'grad_reduce_in_fp32'`

## Changes

- Removed `check_for_nan_in_grad` and `grad_reduce_in_fp32` from `fully_shard_kwargs` in geneformer and esm2 hydra configs
- Removed `grad_reduce_in_fp32` from vit config files and `train.py`

## Not Fixed (infrastructure issue)

- **models/geneformer** (4 tests): `AssertionError: Minimum required nvidia-resiliency-ext package version is 0.6.0.` — This is a container image issue requiring `nvidia-resiliency-ext>=0.6.0` to be installed.

## CI Run

https://github.com/NVIDIA-BioNeMo/bionemo-framework/actions/runs/26814311142