### PR TITLE
fix(geneformer): resolve protobuf conflict with nvidia-resiliency-ext>=0.6.0

### DIFF
--- a/bionemo-recipes/models/geneformer/.ci_build.sh
+++ b/bionemo-recipes/models/geneformer/.ci_build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# nvidia-resiliency-ext>=0.6.0 is required at runtime by megatron-core==0.17.1,
+# but it depends on grpcio-tools>=1.76.0 which requires protobuf>=6.30.0,
+# conflicting with nemo-toolkit==2.4.0 (protobuf~=5.29.5).
+# Install it without deps to avoid the protobuf conflict, then install
+# its safe transitive deps separately.
+pip install --no-deps "nvidia-resiliency-ext>=0.6.0"
+pip install "defusedxml" "httpx>=0.24.0" "nvidia-ml-py>=12.570.86"
+
+# Install the package itself
+PIP_CONSTRAINT= pip install -e .


### PR DESCRIPTION
## Problem

The geneformer nightly CI fails because megatron-core==0.17.1 asserts nvidia-resiliency-ext>=0.6.0 at import time, but that version isn't installed in the CI container.

Simply adding nvidia-resiliency-ext>=0.6.0 to pyproject.toml creates an unresolvable pip conflict:
- nvidia-resiliency-ext 0.6.0 → grpcio-tools>=1.76.0 → protobuf>=6.30.0
- nemo-toolkit==2.4.0 → protobuf~=5.29.5

## Fix

Add a `.ci_build.sh` that installs nvidia-resiliency-ext>=0.6.0 with `--no-deps` (skipping grpcio-tools which is not needed for test execution), then installs the package normally.

The CI workflow already supports `.ci_build.sh` as a hook — if the file exists, it runs that instead of the default `pip install -e .`.

## Root Cause

nvidia-resiliency-ext 0.6.0 added grpcio/grpcio-tools as hard dependencies (for its new gRPC-based fault tolerance features), but these are incompatible with nemo-toolkit 2.4.0's protobuf pin. This will resolve when nemo-toolkit relaxes its protobuf constraint.