### PR TITLE
fix(geneformer): add nvidia-resiliency-ext>=0.6.0 dependency

### DIFF
--- a/bionemo-recipes/models/geneformer/pyproject.toml
+++ b/bionemo-recipes/models/geneformer/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "nemo_toolkit[lightning]==2.4.0",
     "fiddle",
     "megatron-core",
+    "nvidia-resiliency-ext>=0.6.0",
     "pytest",
     "requests",
     "hydra-core",


### PR DESCRIPTION
## Problem

The nightly CI run for `models/geneformer` fails with:
```
AssertionError: Minimum required nvidia-resiliency-ext package version is 0.6.0.
```

All 4 failing tests (`test_geneformer_checkpoint_loss`, `test_geneformer_checkpoint_weight_compatibility`, `test_te_bert_layer_and_hf_bert_layer_similar_output_values_random_inputs`, `test_geneformer_model_loss_validity`) hit this at import time through the chain:
`geneformer.convert` → `nemo.lightning` → `megatron.core` → `dist_checkpointing.strategies.nvrx.has_nvrx_async_support()`

## Root Cause

`megatron-core` now requires `nvidia-resiliency-ext >= 0.6.0` at import time, but the base container image (`nvcr.io/nvidia/pytorch:26.04-py3`) ships an older version. Since the geneformer `pyproject.toml` did not pin this transitive dependency, `pip install` during Docker build did not upgrade it.

## Fix

Add `nvidia-resiliency-ext>=0.6.0` as an explicit dependency in `bionemo-recipes/models/geneformer/pyproject.toml`.

## CI Run
https://github.com/NVIDIA-BioNeMo/bionemo-framework/actions/runs/26945822391