### PR TITLE
evo2 SAE recipe: streaming extract + train (7B layer-26)

### DIFF
--- a/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/pyproject.toml
+++ b/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "evo2-sae"
+version = "0.1.0"
+description = "Sparse Autoencoders for the Evo2 DNA language model"
+requires-python = ">=3.10"
+
+dependencies = [
+    "sae",
+    "torch>=2.0",
+    "numpy>=1.20",
+    "pyarrow>=23.0.0",
+]
+
+# No package code lives here yet — the recipe is just an entry-point for
+# scripts/ that depends on the shared `sae` workspace package. Declare no
+# packages so setuptools doesn't try to discover anything.
+[tool.setuptools]
+packages = []
+
+[tool.uv.sources]
+sae = { workspace = true }

--- a/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/7b.sh
+++ b/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/7b.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Evo2 7B layer-26 SAE recipe: chunk FASTA -> stream-extract activations -> train SAE.
+# This reproduces the layer26_7B (normalize_input) run.
+#
+# Prerequisites (this recipe does NOT download or convert the model):
+#   - An Evo2 7B *MBridge* checkpoint directory (CKPT_DIR). Obtain it from NGC, e.g.:
+#         ngc registry model download-version "nvidia/clara/evo2:7b_<ver>" --dest "${WORK_ROOT}/checkpoints"
+#     (or convert a nemo2 checkpoint to MBridge with the evo2_megatron converter).
+#   - bionemo-recipes/recipes/evo2_megatron built (.ci_build.sh) with its .venv active,
+#     providing `predict_evo2`.
+#   - The `sae` workspace package importable in that same venv.
+#
+# Override any of these by exporting before invocation.
+
+set -euo pipefail
+
+EVO2_MEGATRON_DIR="${EVO2_MEGATRON_DIR:-/workspace/bionemo-framework/bionemo-recipes/recipes/evo2_megatron}"
+RECIPE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+LAYER="${LAYER:-26}"
+# Context length the activations were extracted at (the model is context-extended; we
+# trained the SAE on 8192-bp chunks).
+CHUNK_BP="${CHUNK_BP:-8192}"
+
+# An Evo2 7B MBridge checkpoint directory (see prerequisites above).
+CKPT_DIR="${CKPT_DIR:?Set CKPT_DIR to an Evo2 7B MBridge checkpoint directory (see header)}"
+FASTA="${FASTA:?Set FASTA to the (prok+euk) input sequences}"
+WORK_ROOT="${WORK_ROOT:-/data/interp/evo2}"
+
+NPROC="${NPROC:-8}"            # GPUs / DP ranks
+MAX_TOKENS="${MAX_TOKENS:-1000000000}"
+
+PARQUET_DIR="${WORK_ROOT}/activations/evo2_7b_layer${LAYER}_parquet"
+OUTPUT_DIR="${WORK_ROOT}/sae/evo2_7b_layer${LAYER}"
+
+source "${EVO2_MEGATRON_DIR}/.venv/bin/activate"
+
+echo "============================================================"
+echo "STEP 0: Chunk FASTA to <=${CHUNK_BP} bp"
+echo "============================================================"
+INPUT_STEM="$(basename "$FASTA")"; INPUT_STEM="${INPUT_STEM%.gz}"; INPUT_STEM="${INPUT_STEM%.fasta}"
+CHUNKED_FASTA="${WORK_ROOT}/scratch/${INPUT_STEM}_chunked${CHUNK_BP}.fasta"
+if [[ -f "$CHUNKED_FASTA" ]]; then
+    echo "Reusing existing chunked FASTA: $CHUNKED_FASTA"
+else
+    python "${RECIPE_DIR}/scripts/chunk_fasta.py" --input "$FASTA" --output "$CHUNKED_FASTA" --window "$CHUNK_BP"
+fi
+
+echo "============================================================"
+echo "STEP 1: Stream-extract layer-${LAYER} activations -> parquet ActivationStore (no .pt)"
+echo "============================================================"
+if [[ -f "${PARQUET_DIR}/metadata.json" ]]; then
+    echo "Reusing existing parquet shards at $PARQUET_DIR"
+else
+    torchrun --nproc_per_node="$NPROC" "${RECIPE_DIR}/scripts/extract.py" \
+        --ckpt-dir "$CKPT_DIR" \
+        --embedding-layer "$LAYER" \
+        --fasta "$CHUNKED_FASTA" \
+        --activation-store-dir "$PARQUET_DIR" \
+        --max-tokens "$MAX_TOKENS" \
+        --micro-batch-size 4 \
+        --dtype fp32
+fi
+
+echo "============================================================"
+echo "STEP 2: Train TopK SAE (layer26_7B normalize_input config)"
+echo "============================================================"
+# unset a leaked key so ~/.netrc wins; clara-discovery is the wandb entity.
+unset WANDB_API_KEY || true
+export WANDB_ENTITY="${WANDB_ENTITY:-clara-discovery}"
+torchrun --nproc_per_node="$NPROC" "${RECIPE_DIR}/scripts/train.py" \
+    --cache-dir "$PARQUET_DIR" \
+    --model-path "$CKPT_DIR" \
+    --layer "$LAYER" \
+    --model-type topk \
+    --expansion-factor 16 --top-k 128 \
+    --normalize-input \
+    --auxk 2048 --auxk-coef 0.03125 \
+    --dead-tokens-threshold 10000000 \
+    --init-pre-bias \
+    --n-epochs 1 \
+    --batch-size 1024 \
+    --lr 1e-4 --lr-schedule cosine --lr-min 1e-5 --warmup-steps 1000 \
+    --max-grad-norm 1.0 \
+    --mix-shards 10 \
+    --dp-size "$NPROC" \
+    --log-interval 100 \
+    --wandb --wandb-project evo2-sae-v2-diverse --wandb-run-name "layer${LAYER}_7B_normalize_input" \
+    --output-dir "$OUTPUT_DIR" \
+    --checkpoint-dir "${OUTPUT_DIR}/checkpoints" \
+    --checkpoint-steps 2000
+
+echo "============================================================"
+echo "DONE: SAE checkpoint at ${OUTPUT_DIR}/checkpoints/checkpoint_final.pt"
+echo "============================================================"

--- a/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/chunk_fasta.py
+++ b/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/chunk_fasta.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Chunk a FASTA into <=N-bp windows so predict_evo2 stays inside the model's trained context.
+
+Evo2 1B was trained with seq_length=8192; longer inputs OOM in the Hyena
+fftconv path (intermediates scale super-linearly with L). For 7B/40B raise
+--window to whatever those checkpoints were context-extended to.
+
+Non-overlapping windows by default. Each chunk gets a header of the form
+">{orig_id}:{start}-{end}" so downstream parquet can be back-mapped.
+"""
+
+import argparse
+import gzip
+from pathlib import Path
+
+
+def parse_fasta(path: Path):
+    """Yield (seq_id, sequence) tuples from a FASTA file (transparently handles .gz)."""
+    opener = gzip.open if path.suffix == ".gz" else open
+    seq_id, parts = None, []
+    with opener(path, "rt") as f:
+        for line in f:
+            line = line.rstrip()
+            if line.startswith(">"):
+                if seq_id is not None:
+                    yield seq_id, "".join(parts)
+                seq_id = line[1:].split()[0]
+                parts = []
+            else:
+                parts.append(line)
+        if seq_id is not None:
+            yield seq_id, "".join(parts)
+
+
+def main():
+    """Read input FASTA, write non-overlapping <=window-bp chunks to output FASTA."""
+    p = argparse.ArgumentParser()
+    p.add_argument("--input", type=Path, required=True)
+    p.add_argument("--output", type=Path, required=True)
+    p.add_argument("--window", type=int, default=8192)
+    args = p.parse_args()
+    if args.window <= 0:
+        p.error("--window must be a positive integer")
+    if args.input.resolve() == args.output.resolve():
+        p.error("--input and --output must be different files")
+
+    n_in = n_out = bp_out = 0
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w") as out:
+        for seq_id, seq in parse_fasta(args.input):
+            n_in += 1
+            for start in range(0, len(seq), args.window):
+                end = min(start + args.window, len(seq))
+                chunk = seq[start:end]
+                out.write(f">{seq_id}:{start}-{end}\n{chunk}\n")
+                n_out += 1
+                bp_out += len(chunk)
+
+    print(f"Chunked {n_in} sequences -> {n_out} chunks ({bp_out:,} bp) at window={args.window}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/extract.py
+++ b/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/extract.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Streaming Evo2 activation extractor (with merge + crash recovery).
+
+Pass an Evo2 MBridge checkpoint + a layer + a FASTA; under torchrun this streams
+that layer's residual-stream activations into an SAE ActivationStore (parquet
+shards), one data-parallel rank per GPU, merged at the end. Model-size-agnostic
+(1B/7B/40B). It reuses bionemo.evo2.run.predict for the Megatron inference path
+and only swaps predict's per-batch .pt writer for an in-process store (no .pt).
+
+    torchrun --nproc_per_node 8 extract.py --ckpt-dir CKPT --embedding-layer 26 \
+        --fasta SEQS.fasta --activation-store-dir OUT --max-tokens 500000000 \
+        --micro-batch-size 4 --dtype fp32
+
+Recovery (no GPU, no Megatron): if a run dies after writing some shards, merge
+the surviving per-rank dirs into a usable store:
+
+    python extract.py --recover --activation-store-dir OUT --layer 26
+
+predict/sae are imported lazily on the extract path, so --recover only needs
+pyarrow. --activation-store-dir/--max-tokens/--model-name/--dtype/--recover/
+--layer are consumed here; all other flags forward verbatim to predict.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import torch
+
+
+SHARD_SIZE = 100_000
+# bf16 excluded: NumPy/Arrow have no bfloat16, so ActivationStore.append (-> .numpy())
+# can't write it. train.py upcasts to fp32 on load, so fp16 is lossless and halves disk.
+_DTYPES = {"fp32": torch.float32, "fp16": torch.float16}
+
+# Per-rank state. Each torchrun rank is its own process, so this is rank-local.
+_state: dict = {
+    "store": None,  # ActivationStore for this rank
+    "n_tokens": 0,  # tokens appended on this rank
+    "n_sequences": 0,  # raw sequences seen
+    "budget": 0,  # per-rank token cap (0 = no cap)
+    "store_root": None,  # final output dir; per-rank tmp is <root>.tmp_rank_<i>
+    "cast": torch.float32,  # dtype activations are stored as
+}
+
+
+# --- per-rank shard merge (pyarrow only; used by rank-0 finalize and --recover) ---
+
+
+def _merge_temp_stores(tmp_dirs, store_root: Path, model_name: str, layer: int) -> Path:
+    """Fold per-rank tmp dirs into one store at store_root.
+
+    Shards are MOVED (rename within the same filesystem) — never copied. Each
+    shard's parquet footer is validated first; a shard truncated mid-write when
+    the run died (no footer) is skipped rather than moved, so recovery is robust
+    to a crash. Counts come from the shards actually merged, so they are correct
+    whether or not a per-rank metadata.json was written.
+    """
+    store_root = Path(store_root)
+    store_root.mkdir(parents=True, exist_ok=True)
+    # Resume-safe: metadata.json is written last, so if a prior merge moved some
+    # shards before crashing, continue past them instead of overwriting.
+    existing = sorted(store_root.glob("shard_*.parquet"))
+    idx = len(existing)
+    total_samples = sum(pq.read_metadata(s).num_rows for s in existing)
+    total_sequences = 0
+    hidden_dim = pq.read_metadata(existing[0]).num_columns if existing else None
+    for d in map(Path, tmp_dirs):
+        mp = d / "metadata.json"  # best-effort sequence count (lost if the rank crashed pre-finalize)
+        if mp.exists():
+            try:
+                total_sequences += int(json.load(open(mp)).get("n_sequences", 0))
+            except (OSError, ValueError):
+                pass
+        for shard in sorted(d.glob("shard_*.parquet")):
+            try:
+                md = pq.read_metadata(shard)
+            except Exception:
+                print(f"[merge] skipping unreadable shard (truncated mid-write?): {shard}")
+                continue
+            hidden_dim = hidden_dim or md.num_columns
+            shutil.move(str(shard), str(store_root / f"shard_{idx:05d}.parquet"))
+            idx += 1
+            total_samples += md.num_rows
+    with open(store_root / "metadata.json", "w") as f:
+        json.dump(
+            {
+                "n_samples": total_samples,
+                "hidden_dim": hidden_dim,
+                "n_shards": idx,
+                "shard_size": SHARD_SIZE,
+                "model_name": model_name,
+                "layer": layer,
+                "n_sequences": total_sequences,
+            },
+            f,
+            indent=2,
+        )
+    for d in map(Path, tmp_dirs):  # drop now-empty per-rank dirs
+        try:
+            (d / "metadata.json").unlink(missing_ok=True)
+            d.rmdir()
+        except OSError:
+            pass
+    print(f"[merge] {idx} shards, {total_samples:,} samples (hidden_dim={hidden_dim}) -> {store_root}")
+    return store_root
+
+
+def _recover(store_root: Path, model_name: str, layer: int) -> None:
+    """Merge a crashed run's surviving per-rank shards into a usable store."""
+    store_root = Path(store_root)
+    if (store_root / "metadata.json").exists():
+        print(f"{store_root}/metadata.json exists — store looks complete; refusing to clobber.")
+        return
+    tmp_dirs = sorted(
+        p
+        for p in store_root.parent.glob(store_root.name + ".tmp_rank_*")
+        if p.is_dir() and any(p.glob("shard_*.parquet"))
+    )
+    if not tmp_dirs:
+        print(f"No per-rank shards under {store_root.parent} matching {store_root.name}.tmp_rank_*")
+        return
+    print(f"Recovering {len(tmp_dirs)} rank dir(s): {[d.name for d in tmp_dirs]}")
+    _merge_temp_stores(tmp_dirs, store_root, model_name, layer)
+
+
+# --- streaming writer (monkeypatched into predict) ---
+
+
+def _store_writer(
+    predictions,
+    output_dir,
+    batch_idx,
+    global_rank,
+    dp_rank,
+    files_per_subdir=None,
+    num_files_written=0,
+    data_parallel_world_size=1,
+):
+    """Replacement for predict._write_predictions_batch — append to ActivationStore.
+
+    Signature matches the original; returns (path, updated_count, 0).
+    """
+    if not predictions:
+        return output_dir, num_files_written, 0
+    # Once we've hit the per-rank budget, skip writes (forward passes still run;
+    # cheap relative to the I/O we're skipping).
+    if _state["budget"] and _state["n_tokens"] >= _state["budget"]:
+        return output_dir, num_files_written, 0
+
+    hidden = predictions["hidden_embeddings"]  # [B, S, H]
+    mask = predictions["pad_mask"].bool()
+    # Cast before the device->host copy: Evo2 runs bf16, which NumPy/Arrow can't store.
+    flat = hidden[mask].to(_state["cast"]).cpu()  # [N_unpadded_tokens, H]
+
+    if _state["store"] is None:
+        from sae.activation_store import ActivationStore, ActivationStoreConfig  # lazy: keeps --recover sae-free
+
+        rank_tmp = _state["store_root"].with_name(_state["store_root"].name + f".tmp_rank_{dp_rank}")
+        rank_tmp.mkdir(parents=True, exist_ok=True)
+        _state["store"] = ActivationStore(rank_tmp, ActivationStoreConfig(shard_size=SHARD_SIZE))
+
+    _state["store"].append(flat)
+    _state["n_tokens"] += flat.shape[0]
+    _state["n_sequences"] += hidden.shape[0]
+    return output_dir, num_files_written + 1, 0
+
+
+def _finalize_and_maybe_merge(model_name: str, layer: int) -> None:
+    """Finalize this rank's store, then rank 0 waits for all ranks and merges.
+
+    File-based wait (poll for sibling metadata.json), not dist.barrier():
+    predict.main() tears down the process group before this hook runs, so a
+    barrier silently no-ops and rank 0 would race ahead of slower ranks
+    (observed in the prok+euk run — 18M tokens orphaned before this fix).
+    """
+    if _state["store"] is not None:
+        _state["store"].finalize(metadata={"n_sequences": _state["n_sequences"]})
+    if int(os.environ.get("RANK", "0")) != 0:
+        return
+
+    import time
+
+    store_root: Path = _state["store_root"]
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+
+    def _ready() -> int:
+        return sum(
+            (store_root.with_name(store_root.name + f".tmp_rank_{r}") / "metadata.json").exists()
+            for r in range(world_size)
+        )
+
+    deadline = time.time() + 600  # 10 min cap
+    while time.time() < deadline and _ready() < world_size:
+        time.sleep(2)
+    if _ready() < world_size:
+        print(
+            f"[extract] WARN: only {_ready()}/{world_size} ranks finalized in 10 min; --recover can fold in the rest"
+        )
+
+    tmp_dirs = sorted(
+        p
+        for p in store_root.parent.glob(store_root.name + ".tmp_rank_*")
+        if p.is_dir() and (p / "metadata.json").exists()
+    )
+    if tmp_dirs:
+        _merge_temp_stores(tmp_dirs, store_root, model_name, layer)
+    else:
+        print(f"[extract] no rank tmp dirs under {store_root.parent} — nothing to merge")
+
+
+def main() -> None:
+    """Run recovery (--recover) or, under torchrun, stream-extract activations."""
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--activation-store-dir", type=Path, required=True, help="Output ActivationStore directory.")
+    parser.add_argument("--max-tokens", type=int, default=0, help="Cap total tokens across DP ranks (0 = no cap).")
+    parser.add_argument(
+        "--model-name",
+        type=str,
+        default="arcinstitute/savanna_evo2_1b_base",
+        help="Stamped into store metadata (provenance).",
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=list(_DTYPES),
+        default="fp32",
+        help="Stored precision. fp16 halves disk; train.py upcasts on load.",
+    )
+    parser.add_argument("--recover", action="store_true", help="Merge a crashed run's shards and exit (no GPU).")
+    parser.add_argument(
+        "--layer",
+        type=int,
+        default=0,
+        help="Layer index, for --recover metadata (extract reads it from the forwarded --embedding-layer).",
+    )
+    args, remaining = parser.parse_known_args()
+
+    if args.recover:
+        _recover(args.activation_store_dir, args.model_name, args.layer)
+        return
+
+    _state["store_root"] = args.activation_store_dir
+    # max(1, ...): a small --max-tokens (< world_size) floors to 0, which would be
+    # read as "no cap"; clamp so a positive cap is always enforced.
+    _state["budget"] = max(1, args.max_tokens // int(os.environ.get("WORLD_SIZE", "1"))) if args.max_tokens else 0
+    _state["cast"] = _DTYPES[args.dtype]
+
+    # Force batch write-interval so our writer runs every iteration (epoch mode
+    # would buffer everything in memory). predict requires --output-dir; give it
+    # a throwaway (our writer never writes there).
+    if "--write-interval" not in remaining:
+        remaining += ["--write-interval", "batch"]
+    if "--output-dir" not in remaining:
+        scratch = _state["store_root"].with_name(_state["store_root"].name + ".predict_unused")
+        scratch.mkdir(parents=True, exist_ok=True)
+        remaining += ["--output-dir", str(scratch)]
+
+    layer = args.layer
+    for i, a in enumerate(remaining):
+        if a == "--embedding-layer":
+            layer = int(remaining[i + 1])
+        elif a.startswith("--embedding-layer="):
+            layer = int(a.split("=", 1)[1])
+
+    from bionemo.evo2.run import predict as predict_mod  # lazy: the heavy Megatron import
+
+    predict_mod._write_predictions_batch = _store_writer  # module-attr swap (predict calls the bare name)
+    sys.argv = [sys.argv[0]] + remaining
+    try:
+        predict_mod.main()
+    finally:
+        _finalize_and_maybe_merge(args.model_name, layer)
+
+
+if __name__ == "__main__":
+    main()

--- a/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/train.py
+++ b/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/train.py
@@ -1,0 +1,363 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Step 2: Train an SAE from cached Evo2 activations.
+
+Loads pre-extracted layer-L activations from an ActivationStore cache directory
+(produced by ``extract.py``) and trains a Sparse Autoencoder. The model itself is
+never loaded here — only the activation cache is read — so this step is GPU-light
+and model-format-agnostic (``--model-path``/``--layer`` are used only to validate
+the cache metadata).
+
+Single-GPU:
+    python scripts/train.py \
+        --cache-dir /data/.../evo2_7b_layer26_parquet \
+        --model-path <evo2-mbridge-ckpt-dir> --layer 26 \
+        --expansion-factor 16 --top-k 128 --batch-size 1024 --n-epochs 1
+
+Multi-GPU DDP (see 7b.sh for the full layer-26 7B run):
+    torchrun --nproc_per_node=8 scripts/train.py \
+        --cache-dir /data/.../evo2_7b_layer26_parquet \
+        --model-path <evo2-mbridge-ckpt-dir> --layer 26 \
+        --expansion-factor 16 --top-k 128 --batch-size 1024 --n-epochs 1 \
+        --dp-size 8
+
+Opt-in training-quality fixes (see the ``sae`` package; all default to the previous
+behavior, so omitting them reproduces a baseline run exactly):
+    --aggregate-loss      batch-level FVU + AuxK loss instead of the per-token ratio
+    --dead-count-global   count dead-latent inactivity in total tokens (x world_size) under DDP
+    --mix-shards N         shuffle + blend N shards per batch (N>1; was --shards-per-buffer)
+    --presample-shards N   spread the pre-bias-init sample across N shards (N>1)
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.distributed as dist
+from sae.activation_store import load_activations
+from sae.architectures import ReLUSAE, TopKSAE
+from sae.perf_logger import PerfLogger
+from sae.training import ParallelConfig, Trainer, TrainingConfig, WandbConfig
+from sae.utils import get_device, set_seed
+
+
+def parse_args():  # noqa: D103
+    p = argparse.ArgumentParser(
+        description="Train an SAE from cached Evo2 activations",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Required
+    p.add_argument("--cache-dir", type=str, required=True, help="Path to activation cache (from extract.py)")
+    p.add_argument("--model-path", type=str, required=True, help="Evo2 MBridge checkpoint dir (cache validation only)")
+    p.add_argument("--layer", type=int, required=True, help="Layer index (for cache validation)")
+
+    # SAE architecture
+    sae_group = p.add_argument_group("SAE model")
+    sae_group.add_argument("--model-type", type=str, default="topk", choices=["topk", "relu"])
+    sae_group.add_argument("--expansion-factor", type=int, default=8)
+    sae_group.add_argument("--top-k", type=int, default=32)
+    sae_group.add_argument("--normalize-input", action=argparse.BooleanOptionalAction, default=False)
+    sae_group.add_argument("--auxk", type=int, default=None)
+    sae_group.add_argument("--auxk-coef", type=float, default=1 / 32)
+    sae_group.add_argument("--dead-tokens-threshold", type=int, default=10_000_000)
+    sae_group.add_argument("--init-pre-bias", action=argparse.BooleanOptionalAction, default=False)
+    sae_group.add_argument("--l1-coeff", type=float, default=1e-2, help="L1 coefficient (relu only)")
+    # Opt-in training-quality fixes (sae package). Defaults reproduce previous behavior.
+    sae_group.add_argument(
+        "--aggregate-loss",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Batch-level FVU + AuxK loss instead of the per-token ratio (topk only).",
+    )
+    sae_group.add_argument(
+        "--dead-count-global",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Count dead-latent inactivity in total tokens (x world_size) under DDP (topk only).",
+    )
+
+    # Training
+    train_group = p.add_argument_group("Training")
+    train_group.add_argument("--lr", type=float, default=3e-4)
+    train_group.add_argument("--n-epochs", type=int, default=3)
+    train_group.add_argument("--batch-size", type=int, default=4096)
+    train_group.add_argument("--log-interval", type=int, default=50)
+    train_group.add_argument("--shuffle", action=argparse.BooleanOptionalAction, default=True)
+    train_group.add_argument("--num-workers", type=int, default=0)
+    train_group.add_argument("--pin-memory", action=argparse.BooleanOptionalAction, default=False)
+    train_group.add_argument("--max-grad-norm", type=float, default=None)
+    train_group.add_argument("--lr-scale-with-latents", action=argparse.BooleanOptionalAction, default=False)
+    train_group.add_argument("--lr-reference-hidden-dim", type=int, default=2048)
+    train_group.add_argument("--warmup-steps", type=int, default=0, help="Linear LR warmup steps")
+    train_group.add_argument(
+        "--lr-schedule",
+        type=str,
+        default="constant",
+        choices=["constant", "cosine", "linear"],
+        help="LR schedule after warmup",
+    )
+    train_group.add_argument("--lr-min", type=float, default=0.0, help="Minimum LR for decay schedules")
+    train_group.add_argument(
+        "--lr-decay-steps",
+        type=int,
+        default=None,
+        help="Total steps for LR decay (None = full training)",
+    )
+    # Streaming activation-store options (sae package). Defaults reproduce previous behavior.
+    train_group.add_argument(
+        "--mix-shards",
+        type=int,
+        default=1,
+        help="Shuffle + blend this many shards per batch (>1). Replaces the old --shards-per-buffer.",
+    )
+    train_group.add_argument(
+        "--presample-shards",
+        type=int,
+        default=1,
+        help="Spread the pre-bias-init sample across this many shards (>1; needs --init-pre-bias).",
+    )
+
+    # W&B
+    wb_group = p.add_argument_group("Weights & Biases")
+    wb_group.add_argument("--wandb", action=argparse.BooleanOptionalAction, default=False, dest="wandb_enabled")
+    wb_group.add_argument("--wandb-project", type=str, default="evo2-sae-v2-diverse")
+    wb_group.add_argument("--wandb-run-name", type=str, default=None)
+    wb_group.add_argument("--wandb-group", type=str, default=None)
+    wb_group.add_argument("--wandb-job-type", type=str, default=None)
+
+    # Checkpointing
+    ckpt_group = p.add_argument_group("Checkpointing")
+    ckpt_group.add_argument("--checkpoint-dir", type=str, default=None)
+    ckpt_group.add_argument("--checkpoint-steps", type=int, default=None)
+    ckpt_group.add_argument("--resume-from", type=str, default=None)
+
+    # Infrastructure
+    p.add_argument("--dp-size", type=int, default=1)
+    p.add_argument("--output-dir", type=str, default="./outputs")
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--device", type=str, default=None)
+    p.add_argument(
+        "--num-sequences",
+        type=int,
+        default=None,
+        help="Subset cached activations to this many sequences' worth of shards",
+    )
+
+    return p.parse_args()
+
+
+def build_sae(args, input_dim: int) -> torch.nn.Module:  # noqa: D103
+    hidden_dim = input_dim * args.expansion_factor
+
+    if args.model_type == "topk":
+        return TopKSAE(
+            input_dim=input_dim,
+            hidden_dim=hidden_dim,
+            top_k=args.top_k,
+            normalize_input=args.normalize_input,
+            auxk=args.auxk,
+            auxk_coef=args.auxk_coef,
+            dead_tokens_threshold=args.dead_tokens_threshold,
+            aggregate_loss=args.aggregate_loss,
+            dead_count_global=args.dead_count_global,
+        )
+    elif args.model_type == "relu":
+        return ReLUSAE(
+            input_dim=input_dim,
+            hidden_dim=hidden_dim,
+            l1_coeff=args.l1_coeff,
+        )
+    else:
+        raise ValueError(f"Unknown model type: {args.model_type}")
+
+
+def build_training_config(args, device: str) -> TrainingConfig:  # noqa: D103
+    return TrainingConfig(
+        lr=args.lr,
+        n_epochs=args.n_epochs,
+        batch_size=args.batch_size,
+        device=device,
+        log_interval=args.log_interval,
+        shuffle=args.shuffle,
+        num_workers=args.num_workers,
+        pin_memory=args.pin_memory,
+        checkpoint_dir=args.checkpoint_dir,
+        checkpoint_steps=args.checkpoint_steps,
+        lr_scale_with_latents=args.lr_scale_with_latents,
+        lr_reference_hidden_dim=args.lr_reference_hidden_dim,
+        warmup_steps=args.warmup_steps,
+        max_grad_norm=args.max_grad_norm,
+        lr_schedule=args.lr_schedule,
+        lr_min=args.lr_min,
+        lr_decay_steps=args.lr_decay_steps,
+    )
+
+
+def build_wandb_config(args) -> WandbConfig:  # noqa: D103
+    return WandbConfig(
+        enabled=args.wandb_enabled,
+        project=args.wandb_project,
+        run_name=args.wandb_run_name,
+        group=args.wandb_group,
+        job_type=args.wandb_job_type,
+        config=vars(args),
+    )
+
+
+def build_parallel_config(args) -> ParallelConfig:  # noqa: D103
+    return ParallelConfig(dp_size=args.dp_size)
+
+
+def main():  # noqa: D103
+    args = parse_args()
+
+    set_seed(args.seed)
+    device = args.device or get_device()
+    print(f"Using device: {device}")
+    print(f"Config: {vars(args)}")
+
+    # Load cached activations
+    cache_path = Path(args.cache_dir)
+    if not (cache_path / "metadata.json").exists():
+        raise FileNotFoundError(f"No cache found at {cache_path}. Run extract.py first.")
+
+    store = load_activations(cache_path)
+    meta = store.metadata
+
+    # Validate cache matches config
+    cached_model = meta.get("model_path", meta.get("model_name", ""))
+    if cached_model and cached_model != args.model_path:
+        print(f"WARNING: Cache model '{cached_model}' != '{args.model_path}'")
+    if meta.get("layer") != args.layer:
+        raise ValueError(f"Cache layer mismatch: {meta['layer']} vs {args.layer}")
+
+    # Compute subsetting
+    cached_sequences = meta.get("n_sequences", None)
+    max_shards = None
+    if args.num_sequences and cached_sequences and args.num_sequences < cached_sequences:
+        keep_ratio = args.num_sequences / cached_sequences
+        max_shards = max(1, int(np.ceil(keep_ratio * meta["n_shards"])))
+        print(
+            f"Subsetting: {args.num_sequences}/{cached_sequences} sequences "
+            f"-> using {max_shards}/{meta['n_shards']} shards (~{keep_ratio:.1%})"
+        )
+
+    # Estimate memory
+    n_shards_to_use = max_shards or meta["n_shards"]
+    shard_size = meta.get("shard_size", 100_000)
+    est_tokens = n_shards_to_use * shard_size
+    est_gb = est_tokens * meta["hidden_dim"] * 4 / (1024**3)
+    use_streaming = est_gb > 50
+
+    input_dim = meta["hidden_dim"]
+    sae = build_sae(args, input_dim)
+    print(f"SAE: {args.model_type}, input_dim={input_dim}, hidden_dim={sae.hidden_dim}")
+
+    # Initialize pre_bias from the geometric median of a sample of activations. With
+    # --presample-shards N>1, draw the sample across N shards spanning the store (avoids
+    # biasing the init toward whatever is first in corpus order); else use the first shard.
+    if args.init_pre_bias and hasattr(sae, "init_pre_bias_from_data"):
+        print("Initializing pre_bias from geometric median of data...")
+        if args.presample_shards > 1:
+            sample = store.sample(32768, seed=args.seed, num_shards=args.presample_shards).float()
+        else:
+            first_shard = torch.from_numpy(store._load_shard(0)).float()
+            sample = first_shard[: min(32768, len(first_shard))]
+        sae.init_pre_bias_from_data(sample)
+        print(f"  pre_bias initialized (mean={sae.pre_bias.mean().item():.4f})")
+        del sample
+
+    # Build configs
+    training_config = build_training_config(args, device)
+    wandb_config = build_wandb_config(args)
+    parallel_config = build_parallel_config(args)
+
+    perf_logger = PerfLogger(
+        log_interval=args.log_interval,
+        use_wandb=args.wandb_enabled,
+        print_logs=True,
+        device=device,
+    )
+
+    # Train
+    trainer = Trainer(
+        sae,
+        training_config,
+        wandb_config=wandb_config,
+        perf_logger=perf_logger,
+        parallel_config=parallel_config,
+    )
+
+    if use_streaming:
+        rank = int(os.environ.get("RANK", 0))
+        world_size = int(os.environ.get("WORLD_SIZE", 1))
+        print(
+            f"Streaming from disk (~{est_gb:.0f}GB). "
+            f"Peak RAM: ~{args.mix_shards * shard_size * meta['hidden_dim'] * 4 / (1024**3):.1f}GB/process"
+        )
+
+        dataloader = store.get_streaming_dataloader(
+            batch_size=args.batch_size,
+            shuffle=args.shuffle,
+            seed=args.seed,
+            rank=rank,
+            world_size=world_size,
+            max_shards=max_shards,
+            mix_shards=args.mix_shards,
+        )
+        # Cap every rank to the global-min batch count so DDP stays in sync. Compute each
+        # rank's own batch count from its assigned shards (dataset.shard_indices already
+        # reflects any mix_shards>1 shuffle), then all_reduce(MIN) — correct regardless of
+        # how shards were assigned. Parquet footers are a few KB each (no data load).
+        if world_size > 1 and dist.is_available() and dist.is_initialized():
+            import pyarrow.parquet as pq_meta
+
+            dataset = dataloader.dataset
+            my_rows = sum(
+                pq_meta.read_metadata(store.path / f"shard_{idx:05d}.parquet").num_rows
+                for idx in dataset.shard_indices
+            )
+            t = torch.tensor([my_rows // args.batch_size], device=device)
+            dist.all_reduce(t, op=dist.ReduceOp.MIN)
+            dataset.max_batches = int(t.item())
+            print(f"[rank {rank}] capped to {dataset.max_batches} batches/epoch for DDP sync")
+        trainer.fit(
+            dataloader,
+            resume_from=args.resume_from,
+            data_sharded=True,
+        )
+    else:
+        shards = []
+        for i, shard in enumerate(store.iter_shards(shuffle_shards=False)):
+            if max_shards is not None and i >= max_shards:
+                break
+            shards.append(torch.from_numpy(shard).float())
+        activations_flat = torch.cat(shards)
+        print(f"Loaded {activations_flat.shape[0]:,} cached activations into memory")
+
+        trainer.fit(
+            activations_flat,
+            resume_from=args.resume_from,
+        )
+
+    print("Training complete.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds the **Evo2 SAE recipe** under `recipes/evo2/` — the runnable pipeline that turns Evo2 activations into a trained SAE:

```
chunk FASTA  →  stream-extract (extract.py)  →  train (train.py)
```

`scripts/7b.sh` runs all three and reproduces our **layer-26 7B (`normalize_input`)** run.

## Contents
- **`extract.py`** — streaming activation extractor: reuses `predict_evo2` for the Megatron forward but writes layer-L activations **directly to a parquet `ActivationStore`** (no intermediate `.pt`). Model-agnostic (1B/7B/40B).
- **`train.py`** — trains a TopK/ReLU SAE from the activation cache. Never loads the model (reads only the cache; `--model-path`/`--layer` validate metadata only).
- **`chunk_fasta.py`**, **`7b.sh`** (orchestrator), **`pyproject.toml`**.

_(README/usage docs deferred to a follow-up, once the pipeline is merged and exercised end-to-end.)_

## Opt-in training fixes (from the merged `sae` PR #1619)
All default to the **previous behavior** — omit them to reproduce a baseline run exactly:

| flag | effect |
|---|---|
| `--aggregate-loss` | batch-level FVU + AuxK loss vs the per-token ratio |
| `--dead-count-global` | count dead-latent inactivity in total tokens (× world_size) under DDP |
| `--mix-shards N` | shuffle + blend N shards/batch (replaces the old `--shards-per-buffer`) |
| `--presample-shards N` | spread the pre-bias-init sample across N shards |

The DDP per-epoch batch cap is computed from each rank's assigned shards + `all_reduce(MIN)`, so it stays correct when `mix_shards>1` shuffles the shard list.

## Model format
Assumes a local **Evo2 MBridge checkpoint** (`--ckpt-dir`, loaded by `predict_evo2`). Getting it — **NGC pull** or nemo2→MBridge convert — is a documented **prerequisite**, not recipe code (no Savanna conversion baked in). (Contrast CodonFM, whose Encodon model is an HF/TransformerEngine `.safetensors` — different model family + runtime, hence the different extractor.)

## Duplicate code & planned consolidation
This recipe deliberately **mirrors the existing CodonFM recipe** rather than deduplicating now:

- **`train.py` is essentially the same file as `codonfm/scripts/train.py`** — byte-identical before the Evo2 skin + the four opt-in flags. Both are thin wrappers over the shared `sae.training.Trainer`.
- **`extract.py` shares its skeleton with `codonfm/scripts/extract.py`** — both run a model forward and stream into a `sae.ActivationStore`, including a near-identical **per-rank shard merge** (`_merge_temp_stores` ≈ CodonFM's `_merge_rank_stores`). Only the model-loading differs (Evo2 via Megatron `predict_evo2` vs CodonFM's HF/TE loader).

Consolidating either means factoring the shared **train-CLI** and the **parquet-shard merge** into the `sae` package **and migrating CodonFM onto them** — a cross-recipe refactor touching another recipe. To keep this PR single-concern (and avoid re-tangling, which this PR stack exists to undo), that dedup is a **planned follow-up** (alongside the duplicated-dashboard-component dedup), not part of this PR.

## Tests
Following the existing recipes' convention (CodonFM, ESM2 ship **no recipe-level tests**), the tested logic lives in the **`sae` package** — e.g. the opt-in flags' config round-trip is covered by `sae/tests/test_topk.py` (#1619). This recipe is a thin driver over that tested package. The streaming `extract.py` and the DDP shard-count path need a multi-GPU run to verify.

## Supersedes
Replaces #1579 (recipe) and #1583 (tangled extract+recipe), which also smuggled the now-merged `evo2_megatron` (#1618) and `sae` (#1619) changes. Closed both in favor of this clean, single-concern recipe carved off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
