### PR TITLE
sae eval: feature-probing metrics + Evo2 probe CLI

### DIFF
--- a/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/euk_windows.py
+++ b/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/euk_windows.py
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Build instance-level exon/intron/CDS-labeled windows from a genome FASTA + GFF3.
+
+Eukaryotic gene-structure annotation for SAE feature probing. Unlike the
+sequence-derived labelers, these labels come from real gene models, and crucially
+carry *instance IDs* (which exon / which intron / which gene each position belongs
+to) so domain-adjusted F1 can compute recall PER ANNOTATION INSTANCE (a feature
+"recalls" an exon if it fires anywhere inside it), not per position.
+
+For each protein-coding gene we take a representative transcript (longest by total
+exon length), tile its span ± flank into windows, and label every position:
+  exon / intron / cds / utr / intergenic   (+ per-position instance IDs for
+  exon, intron, gene)
+
+`python euk_windows.py --fasta chr21.fa --gff chr21.gff3 --dry-run` prints
+coverage stats without building sequences.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+from collections import defaultdict
+
+import numpy as np
+
+
+def _attrs(s):
+    return dict(kv.split("=", 1) for kv in s.strip().split(";") if "=" in kv)
+
+
+def parse_gff(gff_path):
+    """Return {gene_id: {strand, tx: {tx_id: {'exon': [(s,e)], 'cds': [(s,e)]}}}} (protein_coding)."""
+    gene_strand, gene_biotype = {}, {}
+    tx_gene, tx_biotype = {}, {}
+    tx_exon = defaultdict(list)
+    tx_cds = defaultdict(list)
+    with open(gff_path) as fh:
+        for line in fh:
+            if line.startswith("#"):
+                continue
+            f = line.rstrip("\n").split("\t")
+            if len(f) < 9:
+                continue
+            typ, s, e, strand, attr = f[2], int(f[3]), int(f[4]), f[6], f[8]
+            a = _attrs(attr)
+            if typ == "gene":
+                gid = a.get("ID", "").replace("gene:", "")
+                gene_strand[gid] = strand
+                gene_biotype[gid] = a.get("biotype", "")
+            elif typ in ("mRNA", "transcript"):
+                tid = a.get("ID", "").replace("transcript:", "")
+                tx_gene[tid] = a.get("Parent", "").replace("gene:", "")
+                tx_biotype[tid] = a.get("biotype", "")
+            elif typ == "exon":
+                tid = a.get("Parent", "").replace("transcript:", "")
+                tx_exon[tid].append((s, e))
+            elif typ == "CDS":
+                tid = a.get("Parent", "").replace("transcript:", "")
+                tx_cds[tid].append((s, e))
+    genes = {}
+    for tid, gid in tx_gene.items():
+        if gene_biotype.get(gid) != "protein_coding" or tx_biotype.get(tid) != "protein_coding":
+            continue
+        if not tx_exon.get(tid):
+            continue
+        genes.setdefault(gid, {"strand": gene_strand.get(gid, "+"), "tx": {}})
+        genes[gid]["tx"][tid] = {"exon": sorted(tx_exon[tid]), "cds": sorted(tx_cds.get(tid, []))}
+    return genes
+
+
+def representative_tx(gene):
+    """Longest transcript by total exon length."""
+    best, best_len = None, -1
+    for tid, t in gene["tx"].items():
+        ln = sum(e - s + 1 for s, e in t["exon"])
+        if ln > best_len:
+            best, best_len = tid, ln
+    return best, gene["tx"][best]
+
+
+def _label_window(chrom, w0, w1, gm, N):
+    """Label a window [w0,w1) using one gene model's intervals (central-gene approx)."""
+    L = w1 - w0
+    pos = np.arange(w0, w1)
+    lab = {k: np.zeros(L, bool) for k in ("exon", "intron", "cds", "utr", "intergenic")}
+    inst = {k: np.full(L, -1, np.int32) for k in ("exon", "intron", "gene")}
+    g_start, g_end = gm["span"]
+    in_tx = (pos >= g_start - 1) & (pos < g_end)
+    lab["intergenic"][~in_tx] = True
+    inst["gene"][in_tx] = gm["gi"]
+    for (s, e), iid in zip(gm["exons"], gm["exon_ids"]):
+        m = (pos >= s - 1) & (pos < e)
+        lab["exon"][m] = True
+        inst["exon"][m] = iid
+    for (s, e), iid in zip(gm["introns"], gm["intron_ids"]):
+        m = (pos >= s - 1) & (pos < e)
+        lab["intron"][m] = True
+        inst["intron"][m] = iid
+    for s, e in gm["cds"]:
+        lab["cds"][(pos >= s - 1) & (pos < e)] = True
+    lab["utr"] = lab["exon"] & ~lab["cds"]
+    return {"dna": chrom[w0:w1], "labels": lab, "instances": inst}
+
+
+def build_windows(  # noqa: D103
+    fasta, gff, seq_len=1024, max_tokens=300_000, flank=300, seed=0, intergenic_frac=0.12, dry_run=False
+):
+    seqs = []
+    with open(fasta) as fh:
+        for line in fh:
+            if not line.startswith(">"):
+                seqs.append(line.strip())
+    chrom = "".join(seqs).upper()
+    N = len(chrom)
+    genes = parse_gff(gff)
+
+    exon_id, intron_id, gene_id = {}, {}, {}
+    stats = defaultdict(int)
+    gene_models, gene_spans = [], []
+    for gid, gene in genes.items():
+        tid, tx = representative_tx(gene)
+        exons, cds = tx["exon"], tx["cds"]
+        if not exons:
+            continue
+        g_start, g_end = exons[0][0], exons[-1][1]
+        introns = [
+            (exons[i][1] + 1, exons[i + 1][0] - 1)
+            for i in range(len(exons) - 1)
+            if exons[i + 1][0] - 1 >= exons[i][1] + 1
+        ]
+        gi = gene_id.setdefault(gid, len(gene_id))
+        eids = [exon_id.setdefault((tid, i), len(exon_id)) for i in range(len(exons))]
+        iids = [intron_id.setdefault((tid, i), len(intron_id)) for i in range(len(introns))]
+        gene_models.append(
+            {
+                "exons": exons,
+                "introns": introns,
+                "cds": cds,
+                "gi": gi,
+                "exon_ids": eids,
+                "intron_ids": iids,
+                "span": (g_start, g_end),
+            }
+        )
+        gene_spans.append((g_start, g_end))
+        stats["genes"] += 1
+        stats["exons"] += len(exons)
+        stats["introns"] += len(introns)
+        stats["exon_bp"] += sum(e - s + 1 for s, e in exons)
+        stats["intron_bp"] += sum(e - s + 1 for s, e in introns)
+        stats["cds_bp"] += sum(e - s + 1 for s, e in cds)
+    if dry_run:
+        return [], dict(stats), 0, N
+
+    rng = random.Random(seed)
+    # exon-centered windows sampled across ALL genes' exons (diverse + exon/intron balanced)
+    exon_refs = [(gi, ei) for gi, gm in enumerate(gene_models) for ei in range(len(gm["exons"]))]
+    rng.shuffle(exon_refs)
+    windows, tot = [], 0
+    budget_genic = int(max_tokens * (1 - intergenic_frac))
+    for gi, ei in exon_refs:
+        if tot >= budget_genic:
+            break
+        gm = gene_models[gi]
+        s, e = gm["exons"][ei]
+        center = (s - 1 + e) // 2
+        w0 = max(0, center - seq_len // 2)
+        w1 = min(N, w0 + seq_len)
+        if w1 - w0 < 60:
+            continue
+        win = _label_window(chrom, w0, w1, gm, N)
+        if win["dna"].count("N") > 0.5 * len(win["dna"]):
+            continue
+        windows.append(win)
+        tot += w1 - w0
+    # intergenic windows: random spots clear of any gene span (+flank)
+    spans = sorted(gene_spans)
+    tries = 0
+    while tot < max_tokens and tries < 20000:
+        tries += 1
+        w0 = rng.randint(0, N - seq_len)
+        w1 = w0 + seq_len
+        if any(not (w1 < gs - flank or w0 > ge + flank) for gs, ge in spans):
+            continue
+        dna = chrom[w0:w1]
+        if dna.count("N") > 0.5 * seq_len:
+            continue
+        lab = {k: np.zeros(seq_len, bool) for k in ("exon", "intron", "cds", "utr", "intergenic")}
+        lab["intergenic"][:] = True
+        inst = {k: np.full(seq_len, -1, np.int32) for k in ("exon", "intron", "gene")}
+        windows.append({"dna": dna, "labels": lab, "instances": inst})
+        tot += seq_len
+    return windows, dict(stats), tot, N
+
+
+def main():  # noqa: D103
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fasta", required=True)
+    ap.add_argument("--gff", required=True)
+    ap.add_argument("--seq-len", type=int, default=1024)
+    ap.add_argument("--max-tokens", type=int, default=300_000)
+    ap.add_argument("--flank", type=int, default=300)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    windows, stats, tot, N = build_windows(
+        args.fasta, args.gff, args.seq_len, args.max_tokens, args.flank, dry_run=args.dry_run
+    )
+    print(f"chromosome length: {N:,} bp")
+    print(f"protein-coding genes used: {stats.get('genes', 0):,}")
+    print(f"exons: {stats.get('exons', 0):,}  introns: {stats.get('introns', 0):,}")
+    if args.dry_run:
+        print(
+            f"exon bp: {stats.get('exon_bp', 0):,}  intron bp: {stats.get('intron_bp', 0):,}  cds bp: {stats.get('cds_bp', 0):,}"
+        )
+        return
+    print(f"windows built: {len(windows):,}  total tokens: {tot:,}")
+    # coverage over built windows
+    cov = defaultdict(int)
+    ninst = {k: set() for k in ("exon", "intron", "gene")}
+    for w in windows:
+        for k, m in w["labels"].items():
+            cov[k] += int(m.sum())
+        for k in ninst:
+            ids = w["instances"][k]
+            ninst[k].update(int(x) for x in np.unique(ids) if x >= 0)
+    print("per-position coverage (of built windows):")
+    for k in ("exon", "intron", "cds", "utr", "intergenic"):
+        print(f"   {k:11s} {cov[k]:>9,} ({100 * cov[k] / max(1, tot):5.1f}%)")
+    print(f"instances: exons={len(ninst['exon']):,}  introns={len(ninst['intron']):,}  genes={len(ninst['gene']):,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/evo2_buffer.py
+++ b/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/evo2_buffer.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Evo2-specific bit: turn DNA sequences into a probing ActivationBuffer.
+
+The only model-touching code in the probing pipeline. Streams sequences through
+the Evo2SAE engine (Evo2 -> layer-L residual -> SAE.encode), keeps the dense
+residual twin, and computes per-token labels (+ instance IDs) from labelers.py.
+All scoring is done elsewhere by the model-agnostic sae.eval.probing metrics.
+"""
+
+from __future__ import annotations
+
+import random
+
+import labelers as L
+import numpy as np
+import torch
+from sae.eval.probing import ActivationBuffer
+
+
+KINGDOM_TAGS = {"prok": "|d__Bacteria|", "euk": "|d__Eukaryota|"}
+
+
+def read_fasta(path):  # noqa: D103
+    header, chunks = None, []
+    with open(path) as fh:
+        for line in fh:
+            line = line.rstrip("\n")
+            if line.startswith(">"):
+                if header is not None:
+                    yield header, "".join(chunks)
+                header, chunks = line[1:], []
+            else:
+                chunks.append(line)
+    if header is not None:
+        yield header, "".join(chunks)
+
+
+def sample_sequences(fasta, max_tokens, seq_len, kingdoms=("prok", "euk"), seed=0):  # noqa: D103
+    from evo2_sae_infer.core import clean_dna
+
+    kingdoms = list(kingdoms)
+    pools = {k: [] for k in kingdoms}
+    need = max_tokens // seq_len + 50
+    for header, seq in read_fasta(fasta):
+        kg = "prok" if header.lower().startswith("prok") else "euk"
+        if kg not in pools:
+            continue
+        dna = clean_dna(seq)[:seq_len]
+        if len(dna) < 60:
+            continue
+        pools[kg].append(dna)
+        if all(len(pools[k]) >= need for k in kingdoms):
+            break
+    rng = random.Random(seed)
+    for k in kingdoms:
+        rng.shuffle(pools[k])
+    out, tok, i = [], 0, 0
+    maxlen = max((len(pools[k]) for k in kingdoms), default=0)
+    while tok < max_tokens and i < maxlen:
+        for k in kingdoms:
+            if i < len(pools[k]):
+                out.append((k, pools[k][i]))
+                tok += len(pools[k][i]) + len(KINGDOM_TAGS[k])
+        i += 1
+    rng.shuffle(out)
+    return out
+
+
+@torch.no_grad()
+def build_buffer(engine, seqs, label_names, *, subsample, auroc_device, annotate_cds=False, batch_size=8, log=print):
+    """Stream seqs through engine -> ActivationBuffer (codes + dense + labels [+ cds instances])."""
+    F = engine.n_features
+    Hd = engine.sae.pre_bias.shape[0]
+    dev = engine.device
+    S = subsample
+    code_buf = torch.zeros(S, F, dtype=torch.float16, device=auroc_device)
+    dense_buf = torch.zeros(S, Hd, dtype=torch.float16, device=auroc_device)
+    lab_buf = torch.zeros(S, len(label_names), dtype=torch.bool, device=auroc_device)
+    filled = 0
+    for start in range(0, len(seqs), batch_size):
+        if filled >= S:
+            break
+        batch = seqs[start : start + batch_size]
+        id_lists, metas = [], []
+        for kg, dna in batch:
+            tag = KINGDOM_TAGS[kg]
+            tids = engine.tokenize(tag)
+            id_lists.append(tids + engine.tokenize(dna))
+            metas.append((tag, len(tids), kg, dna))
+        with engine._lock:
+            hiddens = engine._forward_hidden(id_lists)
+            for h, (tag, tlen, kg, dna) in zip(hiddens, metas):
+                if h.shape[0] == 0 or filled >= S:
+                    continue
+                hd = h.to(dev)
+                codes = engine.sae.encode(hd)
+                norm = h.float().norm(dim=-1).cpu().numpy()
+                T = codes.shape[0]
+                cds_mask = cds_frame = gene_starts = None
+                if annotate_cds and kg == "prok":
+                    cds_mask, cds_frame, gene_starts = L.predict_cds(dna)
+                ctx = L.SeqContext(
+                    text=(tag + dna)[:T],
+                    tag_len=tlen,
+                    dna=dna,
+                    kingdom=kg,
+                    hidden_norm=norm[:T],
+                    cds_mask=cds_mask,
+                    cds_frame=cds_frame,
+                    gene_starts=gene_starts,
+                )
+                lab = np.stack([L.LABELERS[n](ctx)[:T] for n in label_names], axis=1)
+                take = min(T, S - filled)
+                code_buf[filled : filled + take] = codes[:take].to(torch.float16).to(auroc_device)
+                dense_buf[filled : filled + take] = hd[:take].to(torch.float16).to(auroc_device)
+                lab_buf[filled : filled + take] = torch.from_numpy(lab[:take]).to(auroc_device)
+                filled += take
+        if (start // batch_size) % 10 == 0:
+            log(f"  {start + len(batch)}/{len(seqs)} seqs | buf {filled}/{S}")
+    return ActivationBuffer(
+        codes=code_buf[:filled].cpu().numpy(),
+        dense=dense_buf[:filled].cpu().numpy(),
+        labels=lab_buf[:filled].cpu().numpy(),
+        label_names=list(label_names),
+    )

--- a/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/labelers.py
+++ b/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/labelers.py
@@ -1,0 +1,420 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Extensible per-token biological labelers for SAE feature probing.
+
+Each labeler maps a `SeqContext` (one tokenized sequence) to a per-token boolean
+mask of length `T`. The per-feature AUROC probe (`probe_features.py`) asks, for
+every label and every SAE feature, how well the feature's activation separates
+positive from negative tokens.
+
+Adding a feature is just writing a function and decorating it:
+
+    @labeler("my_concept")
+    def _my(ctx):
+        return some_bool_array_len_T
+
+`complex=True` flags labelers that are proxies or need real external annotation
+(e.g. true gene models) and should be refined later — they're the natural home
+for the "more complicated features" we want to add at the end.
+
+Conventions
+-----------
+* Tokens 0..tag_len-1 are the phylogenetic-tag prefix; sequence-derived motif /
+  positional labels are False there (use `_dna_mask`). Sequence-level labels
+  (`is_prok`) and norm-based labels (`is_sink_token`) may mark tag tokens.
+* Byte-level Evo2 tokenization is 1 char = 1 token, so token i in the DNA region
+  corresponds to base `ctx.dna[i - tag_len]`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+
+# name -> fn(ctx) -> np.ndarray[bool] of length T
+LABELERS: dict[str, callable] = {}
+# labelers that are proxies / need real annotations (documented, refine later)
+COMPLEX_LABELERS: set[str] = set()
+
+# Sink-token norm threshold (residual L2). Set by the driver from the data
+# (Evo2 7B layer-26 sinks sit ~1638 vs a ~21 median, so this cleanly isolates them).
+SINK_NORM_THRESHOLD: float = 100.0
+
+
+def labeler(name: str, complex: bool = False):
+    """Register a per-token labeler under `name`."""
+
+    def deco(fn):
+        LABELERS[name] = fn
+        if complex:
+            COMPLEX_LABELERS.add(name)
+        return fn
+
+    return deco
+
+
+@dataclass
+class SeqContext:
+    """Everything a labeler needs about one tokenized sequence."""
+
+    text: str  # tag + dna (1 char == 1 token)
+    tag_len: int  # number of leading phylo-tag tokens
+    dna: str  # the DNA region (uppercase ACGTN), len == T - tag_len
+    kingdom: str  # 'prok' | 'euk'
+    hidden_norm: np.ndarray  # [T] residual L2 norm per token
+    # Gene-structure annotation over DNA positions (filled by a gene caller; None if absent).
+    cds_mask: Optional[np.ndarray] = None  # bool[len(dna)] — within a predicted CDS (either strand)
+    cds_frame: Optional[np.ndarray] = None  # int8[len(dna)] — codon position 0/1/2 within CDS, -1 if not
+    gene_starts: Optional[np.ndarray] = None  # bool[len(dna)] — predicted translation start positions
+
+    @property
+    def T(self) -> int:  # noqa: D102
+        return self.tag_len + len(self.dna)
+
+
+def _dna_mask(ctx: SeqContext, dna_bool: np.ndarray) -> np.ndarray:
+    """Lift a per-DNA-position bool array to a per-token mask (tag tokens False)."""
+    out = np.zeros(ctx.T, dtype=bool)
+    out[ctx.tag_len : ctx.tag_len + len(dna_bool)] = dna_bool
+    return out
+
+
+def _bytes(dna: str) -> np.ndarray:
+    return np.frombuffer(dna.encode("ascii", "replace"), dtype=np.uint8)
+
+
+# --------------------------------------------------------------------- positional
+@labeler("first_100bp")
+def _first(ctx):
+    d = np.zeros(len(ctx.dna), bool)
+    d[:100] = True
+    return _dna_mask(ctx, d)
+
+
+@labeler("last_100bp")
+def _last(ctx):
+    d = np.zeros(len(ctx.dna), bool)
+    if len(d):
+        d[-100:] = True
+    return _dna_mask(ctx, d)
+
+
+@labeler("codon_pos_1")
+def _c1(ctx):
+    # frame-0 proxy (no CDS annotation): position 0 of each codon from seq start
+    return _dna_mask(ctx, np.arange(len(ctx.dna)) % 3 == 0)
+
+
+@labeler("codon_pos_3")
+def _c3(ctx):
+    return _dna_mask(ctx, np.arange(len(ctx.dna)) % 3 == 2)
+
+
+# --------------------------------------------------------------------- composition
+def _gc_window(dna: str, radius: int = 10) -> np.ndarray:
+    arr = _bytes(dna)
+    gc = ((arr == ord("G")) | (arr == ord("C"))).astype(np.float64)
+    csum = np.concatenate([[0.0], np.cumsum(gc)])
+    n = len(gc)
+    idx = np.arange(n)
+    lo = np.maximum(0, idx - radius)
+    hi = np.minimum(n, idx + radius + 1)
+    return (csum[hi] - csum[lo]) / np.maximum(1, hi - lo)
+
+
+@labeler("gc_high_window")
+def _gch(ctx):
+    return _dna_mask(ctx, _gc_window(ctx.dna) >= 0.60)
+
+
+@labeler("gc_low_window")
+def _gcl(ctx):
+    return _dna_mask(ctx, _gc_window(ctx.dna) <= 0.30)
+
+
+@labeler("homopolymer_window")
+def _homo(ctx, k: int = 5):
+    d, n = ctx.dna, len(ctx.dna)
+    out = np.zeros(n, bool)
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and d[j + 1] == d[i]:
+            j += 1
+        if j - i + 1 >= k:
+            out[i : j + 1] = True
+        i = j + 1
+    return _dna_mask(ctx, out)
+
+
+@labeler("dinuc_repeat_window")
+def _dinuc(ctx, min_reps: int = 3):
+    d, n = ctx.dna, len(ctx.dna)
+    out = np.zeros(n, bool)
+    i = 0
+    while i < n - 1:
+        if d[i] != d[i + 1]:
+            j = i
+            while j + 2 < n and d[j + 2] == d[j]:
+                j += 1
+            span = j + 2 - i
+            if span >= 2 * min_reps:
+                out[i : j + 2] = True
+            i = max(j + 1, i + 1)
+        else:
+            i += 1
+    return _dna_mask(ctx, out)
+
+
+# --------------------------------------------------------------------- motifs
+def _starts(dna: str, pattern: str) -> np.ndarray:
+    out = np.zeros(len(dna), bool)
+    for m in re.finditer(pattern, dna):
+        out[m.start()] = True
+    return out
+
+
+def _spans(dna: str, pattern: str) -> np.ndarray:
+    out = np.zeros(len(dna), bool)
+    for m in re.finditer(pattern, dna):
+        out[m.start() : m.end()] = True
+    return out
+
+
+@labeler("motif_ATG")
+def _atg(ctx):
+    return _dna_mask(ctx, _starts(ctx.dna, r"ATG"))
+
+
+@labeler("motif_stop")
+def _stop(ctx):
+    return _dna_mask(ctx, _starts(ctx.dna, r"TAA|TAG|TGA"))
+
+
+@labeler("motif_TATA")
+def _tata(ctx):
+    return _dna_mask(ctx, _spans(ctx.dna, r"TATA[AT]A"))
+
+
+@labeler("motif_RBS_SD")
+def _rbs(ctx):
+    # Shine-Dalgarno ribosome-binding site
+    return _dna_mask(ctx, _spans(ctx.dna, r"AGGAGG"))
+
+
+# --------------------------------------------------- complex / consensus (refine later)
+@labeler("kozak_atg", complex=True)
+def _kozak(ctx):
+    # Kozak: (A/G)xxATGG — mark the ATG start (match start + 3)
+    out = np.zeros(len(ctx.dna), bool)
+    for m in re.finditer(r"[AG]..ATGG", ctx.dna):
+        out[m.start() + 3] = True
+    return _dna_mask(ctx, out)
+
+
+@labeler("tss_proxy_tata", complex=True)
+def _tss(ctx):
+    # stricter canonical TATA box as a transcription-start proxy
+    return _dna_mask(ctx, _spans(ctx.dna, r"TATAAA"))
+
+
+@labeler("splice_donor", complex=True)
+def _sd(ctx):
+    # 5' donor consensus GT(A/G)AGT — mark the GT
+    return _dna_mask(ctx, _starts(ctx.dna, r"GT[AG]AG"))
+
+
+@labeler("splice_acceptor", complex=True)
+def _sa(ctx):
+    # 3' acceptor: polypyrimidine tract then AG — mark the AG
+    out = np.zeros(len(ctx.dna), bool)
+    for m in re.finditer(r"[CT]{6}[ACGT]?AG", ctx.dna):
+        out[m.end() - 2 : m.end()] = True
+    return _dna_mask(ctx, out)
+
+
+def _orf(ctx, frame: int, win: int = 60):
+    d, n = ctx.dna, len(ctx.dna)
+    stops = {"TAA", "TAG", "TGA"}
+    out = np.zeros(n, bool)
+    for p in range(frame, n - 2, 3):
+        ok = True
+        for q in range(p, min(p + win, n - 2), 3):
+            if d[q : q + 3] in stops:
+                ok = False
+                break
+        if ok:
+            out[p] = True
+    return _dna_mask(ctx, out)
+
+
+@labeler("orf_frame_0_60bp", complex=True)
+def _orf0(ctx):
+    return _orf(ctx, 0)
+
+
+@labeler("orf_frame_1_60bp", complex=True)
+def _orf1(ctx):
+    return _orf(ctx, 1)
+
+
+@labeler("orf_frame_2_60bp", complex=True)
+def _orf2(ctx):
+    return _orf(ctx, 2)
+
+
+# --------------------------------------------------------------- sequence / norm level
+@labeler("is_prok")
+def _prok(ctx):
+    return np.full(ctx.T, ctx.kingdom == "prok", dtype=bool)
+
+
+@labeler("is_euk_genic", complex=True)
+def _eukg(ctx):
+    # proxy: eukaryotic token. True "genic" needs a gene model — refine later.
+    return np.full(ctx.T, ctx.kingdom == "euk", dtype=bool)
+
+
+@labeler("is_sink_token", complex=True)
+def _sink(ctx):
+    return ctx.hidden_norm > SINK_NORM_THRESHOLD
+
+
+# --------------------------------------------- gene structure (real annotation, prok)
+# These read a CDS annotation attached to the context by a gene caller (see
+# predict_cds, prokaryotes only). They are no-ops when the annotation is absent.
+@labeler("cds_coding", complex=True)
+def _cds(ctx):
+    if ctx.cds_mask is None:
+        return np.zeros(ctx.T, bool)
+    return _dna_mask(ctx, ctx.cds_mask)
+
+
+@labeler("cds_start", complex=True)
+def _cds_start(ctx):
+    if ctx.gene_starts is None:
+        return np.zeros(ctx.T, bool)
+    return _dna_mask(ctx, ctx.gene_starts)
+
+
+@labeler("cds_frame_1", complex=True)
+def _cds_f1(ctx):
+    # codon position 1 within a REAL predicted CDS (not the frame-0-from-start proxy)
+    if ctx.cds_frame is None:
+        return np.zeros(ctx.T, bool)
+    return _dna_mask(ctx, ctx.cds_frame == 0)
+
+
+@labeler("cds_frame_3", complex=True)
+def _cds_f3(ctx):
+    if ctx.cds_frame is None:
+        return np.zeros(ctx.T, bool)
+    return _dna_mask(ctx, ctx.cds_frame == 2)
+
+
+_GENE_FINDER = None
+
+# Standard genetic code (NCBI translation table 1), codons in TCAG x TCAG x TCAG order.
+_BASES = "TCAG"
+_AA1 = "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
+CODON_TABLE = {
+    a + b + c: _AA1[i] for i, (a, b, c) in enumerate((x, y, z) for x in _BASES for y in _BASES for z in _BASES)
+}
+CODON_LIST = sorted(CODON_TABLE)  # 64 codons
+CODON_TO_IDX = {c: i for i, c in enumerate(CODON_LIST)}
+AA_LIST = sorted(set(CODON_TABLE.values()))  # 20 aa + '*' (stop)
+AA_TO_IDX = {a: i for i, a in enumerate(AA_LIST)}
+_COMP = str.maketrans("ACGTN", "TGCAN")
+
+
+def _revcomp(s):
+    return s.translate(_COMP)[::-1]
+
+
+def predict_codons(dna: str):
+    """In-frame codon + amino-acid identity at strand-correct codon anchors (prok genes).
+
+    Returns (codon_id[N], aa_id[N]) over forward DNA coordinates; the anchor is the
+    first translated base of each codon (low coord on +strand, high coord on -strand),
+    other positions are -1.  codon_id in 0..63 (CODON_LIST), aa_id in 0..20 (AA_LIST).
+    """
+    global _GENE_FINDER
+    n = len(dna)
+    codon_id = np.full(n, -1, dtype=np.int16)
+    aa_id = np.full(n, -1, dtype=np.int8)
+    if n < 60:
+        return codon_id, aa_id
+    if _GENE_FINDER is None:
+        import pyrodigal
+
+        _GENE_FINDER = pyrodigal.GeneFinder(meta=True)
+    for g in _GENE_FINDER.find_genes(dna.encode("ascii", "replace")):
+        b, e = max(0, g.begin - 1), min(n, g.end)
+        sub = dna[b:e]
+        coding = sub if g.strand == 1 else _revcomp(sub)
+        for i in range(len(coding) // 3):
+            cod = coding[3 * i : 3 * i + 3]
+            j = CODON_TO_IDX.get(cod)
+            if j is None:
+                continue
+            p = b + 3 * i if g.strand == 1 else (e - 1 - 3 * i)
+            if 0 <= p < n:
+                codon_id[p] = j
+                aa_id[p] = AA_TO_IDX[CODON_TABLE[cod]]
+    return codon_id, aa_id
+
+
+def predict_cds(dna: str):
+    """Prokaryotic gene calling via pyrodigal (meta mode) on a single DNA chunk.
+
+    Returns (cds_mask, cds_frame, gene_starts) over forward DNA coordinates:
+      cds_mask[i]    True if position i lies within any predicted CDS (either strand)
+      cds_frame[i]   codon position 0/1/2 relative to that gene's start (strand-aware), else -1
+      gene_starts[i] True at predicted translation starts
+    """
+    global _GENE_FINDER
+    n = len(dna)
+    cds_mask = np.zeros(n, dtype=bool)
+    cds_frame = np.full(n, -1, dtype=np.int8)
+    gene_starts = np.zeros(n, dtype=bool)
+    if n < 60:
+        return cds_mask, cds_frame, gene_starts
+    if _GENE_FINDER is None:
+        import pyrodigal
+
+        _GENE_FINDER = pyrodigal.GeneFinder(meta=True)
+    for g in _GENE_FINDER.find_genes(dna.encode("ascii", "replace")):
+        b, e = g.begin - 1, g.end  # 0-based half-open, forward coords
+        b, e = max(0, b), min(n, e)
+        if e <= b:
+            continue
+        cds_mask[b:e] = True
+        idx = np.arange(b, e)
+        if g.strand == 1:
+            gene_starts[b] = True
+            cds_frame[b:e] = (idx - b) % 3
+        else:  # reverse strand: start codon sits at the (forward) end
+            gene_starts[e - 1] = True
+            cds_frame[b:e] = ((e - 1) - idx) % 3
+    return cds_mask, cds_frame, gene_starts
+
+
+# Default label set for the probe (order preserved in outputs).
+DEFAULT_LABELS = list(LABELERS.keys())

--- a/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/probe.py
+++ b/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/probe.py
@@ -1,0 +1,295 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Unified Evo2 SAE probing CLI. All scoring is sae.eval.probing (model-agnostic);
+this driver only knows how to build/load Evo2 buffers and pick label sets.
+
+  probe.py extract       --out BUF [...]        build an ActivationBuffer (needs the model)
+  probe.py auroc         --acts BUF --labels .. per-feature AUROC table
+  probe.py linear        --acts BUF --labels .. SAE-vs-dense single + multi (disentanglement/distributed)
+  probe.py codon-aa      --acts CODON_BUF       codon/AA decoders + family-disjoint, SAE vs dense
+  probe.py context       --acts BUF             biological-context vs string-match firing (feat 29244/33918)
+  probe.py loss-recovered [...]                 fidelity via sae.eval.loss_recovered (needs the model)
+"""  # noqa: D205
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE))
+sys.path.insert(0, str(_HERE.parent))
+sys.path.insert(0, str(_HERE.parents[2] / "sae" / "src"))  # sparse_autoencoders/sae/src
+
+import labelers as L  # noqa: E402
+from sae.eval.probing import (  # noqa: E402
+    ActivationBuffer,
+    auroc_all,
+    auroc_vec,
+    best_single_train_test,
+    decode_eval,
+    fit_softmax,
+    split_indices,
+    standardize,
+)
+
+
+def _z(X, tr):
+    # Standardize X by the train-split mean/std (reuses sae.eval.probing.standardize).
+    mu, sd = standardize(X, tr)
+    return (X - mu) / sd
+
+
+# ───────────────────────────────────────── buffer-only subcommands (no model)
+def cmd_auroc(a):  # noqa: D103
+    buf = ActivationBuffer.load(a.acts)
+    dev = a.device
+    X = torch.from_numpy(buf.codes).to(dev).float()
+    names = [t for t in a.labels.split(",") if t in buf.name_idx]
+    Y = torch.stack([torch.from_numpy(buf.labels[:, buf.name_idx[n]]).to(dev) for n in names], 1)
+    au = auroc_all(X, Y).cpu().numpy()
+    print(f"{'label':18s} {'%pos':>6s} {'best AUROC':>10s} {'feature':>8s}")
+    for i, n in enumerate(names):
+        print(
+            f"{n:18s} {buf.labels[:, buf.name_idx[n]].mean():6.1%} {au[:, i].max():10.3f} {int(au[:, i].argmax()):8d}"
+        )
+
+
+def _eval_matrix(mat, buf, names, tr, te, dev, steps, wd):
+    X = torch.from_numpy(mat).to(dev).float()
+    Xz = _z(X, tr)
+    out = {}
+    from sae.eval.probing import fit_logreg
+
+    for n in names:
+        ytr = torch.from_numpy(buf.labels[tr.numpy(), buf.name_idx[n]]).to(dev).float()
+        yte = torch.from_numpy(buf.labels[te.numpy(), buf.name_idx[n]]).to(dev)
+        if ytr.sum() in (0, len(ytr)) or yte.sum() == 0:
+            out[n] = (float("nan"), float("nan"))
+            continue
+        w, b = fit_logreg(Xz[tr], ytr, steps=steps, wd=wd)
+        out[n] = (best_single_train_test(Xz[tr], ytr, Xz[te], yte), auroc_vec((Xz[te] @ w + b).float(), yte))
+    del X, Xz
+    torch.cuda.empty_cache()
+    return out
+
+
+def cmd_linear(a):  # noqa: D103
+    buf = ActivationBuffer.load(a.acts)
+    dev = a.device
+    names = [t for t in a.labels.split(",") if t in buf.name_idx]
+    tr, te = split_indices(buf.codes.shape[0], a.test_frac, a.seed)
+    sae = _eval_matrix(buf.codes, buf, names, tr, te, dev, a.steps, a.weight_decay)
+    den = _eval_matrix(buf.dense, buf, names, tr, te, dev, a.steps, a.weight_decay) if buf.dense is not None else None
+    h = f"{'label':18s} {'%pos':>6s} | {'SAE single':>10s} {'SAE multi':>9s}"
+    if den:
+        h += f" | {'dense single':>12s} {'dense multi':>11s} | {'Δ':>7s}"
+    print(h)
+    for n in names:
+        pos = buf.labels[:, buf.name_idx[n]].mean()
+        ss, sm = sae[n]
+        row = f"{n:18s} {pos:6.1%} | {ss:10.3f} {sm:9.3f}"
+        if den:
+            ds, dm = den[n]
+            row += f" | {ds:12.3f} {dm:11.3f} | {ss - ds:+7.3f}"
+        print(row)
+
+
+def cmd_context(a):  # noqa: D103
+    z = np.load(a.acts, allow_pickle=True)
+    codes, labels = z["codes"], z["labels"]
+    idx = {n: i for i, n in enumerate(z["label_names"])}
+    P = codes.shape[0]
+
+    def lab(n):
+        return labels[:, idx[n]].astype(bool)
+
+    def rate(feat, m):
+        return (float((codes[:, feat][m] > 0).mean()), int(m.sum())) if m.sum() else (float("nan"), 0)
+
+    ATG, STOP, START, INF = lab("motif_ATG"), lab("motif_stop"), lab("cds_start"), lab("cds_frame_1")
+    print(f"baseline: 29244={rate(29244, np.ones(P, bool))[0]:.3f} 33918={rate(33918, np.ones(P, bool))[0]:.3f}")
+    for nm, f, motif, ctx, cl in [
+        ("29244 ATG", 29244, ATG, START, "real start"),
+        ("33918 STOP", 33918, STOP, INF, "in-frame"),
+    ]:
+        ra, na = rate(f, motif & ctx)
+        rb, nb = rate(f, motif & ~ctx)
+        print(f"{nm}: {cl} {ra:.3f}(n={na}) | other {rb:.3f}(n={nb}) | ratio {ra / max(rb, 1e-9):.2f}")
+
+
+def cmd_codon_aa(a):  # noqa: D103
+    z = np.load(a.acts)
+    dev = a.device
+    codon = torch.from_numpy(z["codon"].astype(np.int64)).to(dev)
+    aa = torch.from_numpy(z["aa"].astype(np.int64)).to(dev)
+    codon_np = z["codon"].astype(np.int64)
+    ncod, naa = len(L.CODON_LIST), len(L.AA_LIST)
+    held = {"L": ["TTA", "TTG"], "S": ["AGT", "AGC"], "R": ["AGA", "AGG"]}
+    hidx = [L.CODON_TO_IDX[c] for v in held.values() for c in v]
+    print(f"{'matrix':6s} {'codon mAUROC':>12s} {'AA mAUROC':>10s} | family-disjoint recall L/S/R (chance)")
+    for nm in ("sae", "dense"):
+        if nm not in z.files:
+            continue
+        X = torch.from_numpy(z[nm]).to(dev).float()
+        Xz = (X - X.mean(0)) / (X.std(0) + 1e-6)
+        tr, te = split_indices(X.shape[0], a.test_frac, a.seed)
+        _, ca, _ = decode_eval(Xz[tr], codon[tr], Xz[te], codon[te], ncod, steps=a.steps, wd=a.weight_decay)
+        _, aaa, _ = decode_eval(Xz[tr], aa[tr], Xz[te], aa[te], naa, steps=a.steps, wd=a.weight_decay)
+        trn = torch.from_numpy(np.nonzero(~np.isin(codon_np, hidx))[0]).to(dev)
+        W, b = fit_softmax(Xz[trn], aa[trn], naa, steps=a.steps, wd=a.weight_decay)
+        rec = []
+        for A, cods in held.items():
+            m = np.isin(codon_np, [L.CODON_TO_IDX[c] for c in cods])
+            pred = (Xz[torch.from_numpy(np.nonzero(m)[0]).to(dev)] @ W + b).argmax(1).cpu().numpy()
+            rec.append(
+                f"{A}={float((pred == L.AA_TO_IDX[A]).mean()):.2f}({float((aa == L.AA_TO_IDX[A]).float().mean()):.2f})"
+            )
+        del X, Xz
+        torch.cuda.empty_cache()
+        print(f"{nm:6s} {ca:12.3f} {aaa:10.3f} | {'  '.join(rec)}")
+
+
+# ───────────────────────────────────────── model subcommands (need Evo2)
+def cmd_euk(a):
+    """Eukaryotic exon/intron/CDS domain-adjusted F1 vs shuffle null (chr21 FASTA+GFF)."""
+    from euk_windows import build_windows
+    from evo2_sae_infer.core import DEFAULT_ORGANISM_TAGS, Evo2SAE
+    from sae.eval.probing import domain_f1
+
+    eng = Evo2SAE(a.evo2_ckpt_dir, a.sae_checkpoint, a.layer, device=a.device).load()
+    windows, stats, tot, _ = build_windows(a.fasta, a.gff, a.seq_len, a.max_tokens, seed=a.seed)
+    print(
+        f"windows={len(windows)} tokens={tot} genes={stats['genes']} exons={stats['exons']} introns={stats['introns']}"
+    )
+    F, adev = eng.n_features, a.auroc_device
+    tag_ids = eng.tokenize(DEFAULT_ORGANISM_TAGS.get(a.organism, ""))
+    tlen = len(tag_ids)
+    concepts = {"exon": "exon", "intron": "intron", "cds": "gene"}
+    code_buf = torch.zeros(tot, F, dtype=torch.float16, device=adev)
+    lab = {k: torch.zeros(tot, dtype=torch.bool, device=adev) for k in ("exon", "intron", "cds")}
+    inst = {k: torch.full((tot,), -1, dtype=torch.long, device=adev) for k in ("exon", "intron", "gene")}
+    filled = 0
+    for s0 in range(0, len(windows), a.batch_size):
+        batch = windows[s0 : s0 + a.batch_size]
+        with eng._lock:
+            for h, w in zip(eng._forward_hidden([tag_ids + eng.tokenize(w["dna"]) for w in batch]), batch):
+                if h.shape[0] == 0:
+                    continue
+                codes = eng.sae.encode(h.to(a.device))
+                take = min(len(w["dna"]), codes.shape[0] - tlen, tot - filled)
+                if take <= 0:
+                    continue
+                code_buf[filled : filled + take] = codes[tlen : tlen + take].to(torch.float16).to(adev)
+                for k in lab:
+                    lab[k][filled : filled + take] = torch.from_numpy(w["labels"][k][:take]).to(adev)
+                for k in inst:
+                    inst[k][filled : filled + take] = torch.from_numpy(w["instances"][k][:take].astype(np.int64)).to(
+                        adev
+                    )
+                filled += take
+    code_buf = code_buf[:filled]
+    for d in (lab, inst):
+        for k in d:
+            d[k] = d[k][:filled]
+    fmax = code_buf.max(0).values.float()
+    g = torch.Generator(device=adev).manual_seed(a.seed)
+    print(f"encoded {filled} positions\n{'concept':8s} {'domF1':>6s} {'null':>6s} {'ratio':>6s} {'%pos':>6s}")
+    for c, ic in concepts.items():
+        f1, _ = domain_f1(code_buf, fmax, lab[c], inst[ic])
+        order = torch.randperm(filled, generator=g, device=adev)
+        f1n, _ = domain_f1(code_buf, fmax, lab[c][order], inst[ic][order])
+        bf, nl = float(f1.max()), float(f1n.max())
+        print(f"{c:8s} {bf:6.3f} {nl:6.3f} {bf / max(nl, 1e-9):6.2f} {float(lab[c].float().mean()):6.1%}")
+
+
+def cmd_extract(a):  # noqa: D103
+    from evo2_buffer import build_buffer, sample_sequences
+    from evo2_sae_infer.core import Evo2SAE
+
+    eng = Evo2SAE(a.evo2_ckpt_dir, a.sae_checkpoint, a.layer, device=a.device).load()
+    label_names = list(L.LABELERS.keys())
+    kingdoms = [k for k in a.kingdoms.split(",") if k]
+    seqs = sample_sequences(a.fasta, a.max_tokens, a.seq_len, kingdoms=kingdoms, seed=a.seed)
+    print(f"probe set: {len(seqs)} seqs (kingdoms={kingdoms})")
+    buf = build_buffer(
+        eng,
+        seqs,
+        label_names,
+        subsample=a.subsample,
+        auroc_device=a.auroc_device,
+        annotate_cds=a.annotate_cds,
+        batch_size=a.batch_size,
+        log=print,
+    )
+    buf.save(a.out)
+    print(f"saved buffer -> {a.out} ({buf.codes.shape[0]} x {buf.codes.shape[1]}, dense {buf.dense.shape[1]})")
+
+
+def main():  # noqa: D103
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--device", default="cuda:0")
+    common.add_argument("--seed", type=int, default=0)
+    common.add_argument("--steps", type=int, default=400)
+    common.add_argument("--weight-decay", type=float, default=1e-2)
+    common.add_argument("--test-frac", type=float, default=0.4)
+    for name, fn, needs_labels in [
+        ("auroc", cmd_auroc, True),
+        ("linear", cmd_linear, True),
+        ("context", cmd_context, False),
+        ("codon-aa", cmd_codon_aa, False),
+    ]:
+        p = sub.add_parser(name, parents=[common])
+        p.add_argument("--acts", required=True)
+        if needs_labels:
+            p.add_argument("--labels", required=True)
+        p.set_defaults(func=fn)
+    pe = sub.add_parser("extract", parents=[common])
+    for arg in ["--evo2-ckpt-dir", "--sae-checkpoint", "--fasta", "--out"]:
+        pe.add_argument(arg, required=True)
+    pe.add_argument("--layer", type=int, required=True)
+    pe.add_argument("--kingdoms", default="prok,euk")
+    pe.add_argument("--annotate-cds", action="store_true")
+    pe.add_argument("--max-tokens", type=int, default=200_000)
+    pe.add_argument("--subsample", type=int, default=50_000)
+    pe.add_argument("--seq-len", type=int, default=1024)
+    pe.add_argument("--batch-size", type=int, default=8)
+    pe.add_argument("--auroc-device", default="cuda:1")
+    pe.set_defaults(func=cmd_extract)
+    pk = sub.add_parser("euk-f1", parents=[common])
+    for arg in ["--evo2-ckpt-dir", "--sae-checkpoint", "--fasta", "--gff"]:
+        pk.add_argument(arg, required=True)
+    pk.add_argument("--layer", type=int, required=True)
+    pk.add_argument("--organism", default="Human")
+    pk.add_argument("--max-tokens", type=int, default=160_000)
+    pk.add_argument("--seq-len", type=int, default=1024)
+    pk.add_argument("--batch-size", type=int, default=8)
+    pk.add_argument("--auroc-device", default="cuda:1")
+    pk.set_defaults(func=cmd_euk)
+    args = ap.parse_args()
+    torch.set_grad_enabled(False)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/probe_loss_recovered.py
+++ b/bionemo-recipes/interpretability/sparse_autoencoders/recipes/evo2/scripts/probe_loss_recovered.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Loss recovered (fidelity) for the Evo2 SAE — reuses sae.eval.loss_recovered (Jared Wilber).
+
+    loss_recovered = 1 - (CE_sae - CE_clean) / (CE_zero - CE_clean)
+
+We just provide Evo2-specific callables to his generic evaluator:
+  - get_hiddens(batch): capture the layer-`L` residual via a forward hook
+  - compute_ce(batch, override): full-model next-token CE, optionally patching the
+    layer-`L` output with `override` (zero-ablation or SAE reconstruction)
+The SAE reconstruction is DENORMALIZED per token (normalize_input) so it is in the
+raw residual space the layer actually emits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as Fn
+
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE))
+sys.path.insert(0, str(_HERE.parent))
+
+from evo2_buffer import sample_sequences  # noqa: E402
+from evo2_sae_infer.core import Evo2SAE  # noqa: E402
+from sae.eval.loss_recovered import evaluate_loss_recovered  # noqa: E402  (Jared's code)
+
+
+KINGDOM_TAGS = {"prok": "|d__Bacteria|", "euk": "|d__Eukaryota|"}
+
+
+class SAEWrap(nn.Module):
+    """sae.forward(x[N,H]) -> (recon, codes) in RAW residual space (denormalized)."""
+
+    def __init__(self, sae):  # noqa: D107
+        super().__init__()
+        self.sae = sae
+
+    def forward(self, x):  # noqa: D102
+        s = self.sae
+        codes = s.encode(x)  # encode normalizes internally if normalize_input
+        recon = s.decoder(codes) + s.pre_bias
+        if getattr(s, "normalize_input", False):
+            mu = x.mean(-1, keepdim=True)
+            std = x.std(-1, keepdim=True) + 1e-8
+            recon = recon * std + mu
+        return recon, codes
+
+
+class L26Hook:  # noqa: D101
+    def __init__(self):  # noqa: D107
+        self.mode = "off"  # off | capture | replace
+        self.override = None
+        self.captured = None
+
+    def __call__(self, module, inp, output):  # noqa: D102
+        hs = output[0] if isinstance(output, tuple) else output
+        if self.mode == "replace" and self.override is not None:
+            new = self.override.to(hs.dtype)
+            return (new, *output[1:]) if isinstance(output, tuple) else new
+        if self.mode == "capture":
+            self.captured = hs.detach()
+        return output
+
+
+def main():  # noqa: D103
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--evo2-ckpt-dir", required=True)
+    ap.add_argument("--sae-checkpoint", required=True)
+    ap.add_argument("--layer", type=int, required=True)
+    ap.add_argument("--fasta", required=True)
+    ap.add_argument("--n-seqs", type=int, default=80)
+    ap.add_argument("--seq-len", type=int, default=1024)
+    ap.add_argument("--device", default="cuda:0")
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+    torch.set_grad_enabled(False)
+    dev = args.device
+
+    engine = Evo2SAE(args.evo2_ckpt_dir, args.sae_checkpoint, args.layer, device=dev).load()
+    from megatron.core.utils import unwrap_model
+
+    gen = engine._ensure_gen_model()
+    layer = unwrap_model(gen).decoder.layers[args.layer]
+    hook = L26Hook()
+    layer.register_forward_hook(hook)
+
+    pairs = sample_sequences(
+        args.fasta, args.n_seqs * args.seq_len, args.seq_len, kingdoms=["prok", "euk"], seed=args.seed
+    )[: args.n_seqs]
+    batches = []
+    for kingdom, dna in pairs:
+        ids = engine.tokenize(KINGDOM_TAGS[kingdom] + dna)
+        if len(ids) > 4:
+            batches.append(torch.tensor([ids], dtype=torch.long, device=dev))
+
+    def fwd(ids):
+        return gen(input_ids=ids, position_ids=None, attention_mask=None, labels=None, runtime_gather_output=True)
+
+    def get_hiddens(batch):
+        hook.mode = "capture"
+        fwd(batch)
+        hook.mode = "off"
+        return hook.captured  # [S, 1, H]
+
+    def compute_ce(batch, override):
+        if override is None:
+            hook.mode = "off"
+        else:
+            hook.mode = "replace"
+            hook.override = override
+        logits = fwd(batch)
+        hook.mode = "off"
+        hook.override = None
+        lg = logits[0, :-1].float()  # [S-1, V]
+        tgt = batch[0, 1:]
+        ce = Fn.cross_entropy(lg, tgt, reduction="sum")
+        return float(ce), int(tgt.numel())
+
+    with engine._lock:
+        res = evaluate_loss_recovered(SAEWrap(engine.sae), batches, get_hiddens, compute_ce, device=dev)
+    print("\n==== Evo2 7B layer-%d SAE — loss recovered ====" % args.layer)
+    print(res)
+    print(
+        f"loss_recovered = {res.loss_recovered:.3f}  "
+        f"(CE clean={res.ce_original:.3f}, SAE={res.ce_sae:.3f}, zero={res.ce_zero:.3f}, n_tok={res.n_tokens})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/bionemo-recipes/interpretability/sparse_autoencoders/sae/src/sae/eval/__init__.py
+++ b/bionemo-recipes/interpretability/sparse_autoencoders/sae/src/sae/eval/__init__.py
@@ -22,6 +22,19 @@ from .loss_recovered import (
     compute_loss_recovered,
     evaluate_loss_recovered,
 )
+from .probing import (
+    ActivationBuffer,
+    auroc_all,
+    auroc_vec,
+    best_single_train_test,
+    decode_eval,
+    domain_f1,
+    fit_logreg,
+    fit_softmax,
+    macro_auroc,
+    split_indices,
+    standardize,
+)
 from .reconstruction import (
     ReconstructionMetrics,
     compute_reconstruction_metrics,
@@ -31,16 +44,27 @@ from .sparsity import SparsityMetrics, evaluate_sparsity
 
 
 __all__ = [
+    "ActivationBuffer",
     "DeadLatentStats",
     "DeadLatentTracker",
     "EvalResults",
     "LossRecoveredResult",
     "ReconstructionMetrics",
     "SparsityMetrics",
+    "auroc_all",
+    "auroc_vec",
+    "best_single_train_test",
     "compute_loss_recovered",
     "compute_reconstruction_metrics",
+    "decode_eval",
+    "domain_f1",
     "evaluate_loss_recovered",
     "evaluate_reconstruction",
     "evaluate_sae",
     "evaluate_sparsity",
+    "fit_logreg",
+    "fit_softmax",
+    "macro_auroc",
+    "split_indices",
+    "standardize",
 ]

--- a/bionemo-recipes/interpretability/sparse_autoencoders/sae/src/sae/eval/probing.py
+++ b/bionemo-recipes/interpretability/sparse_autoencoders/sae/src/sae/eval/probing.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Model-agnostic SAE feature-probing metrics + the activation-buffer artifact.
+
+Everything here is a pure function of a probing buffer (per-token feature codes,
+an optional dense-residual twin, per-token labels, optional instance IDs). Recipe
+drivers (e.g. Evo2) only produce the buffer; all scoring lives here so it is shared
+and reusable. Companions in this package: loss_recovered (fidelity), reconstruction,
+sparsity, dead_latents.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import numpy as np
+import torch
+
+
+# ───────────────────────────────────────────────────────────── artifact
+@dataclass
+class ActivationBuffer:
+    """A probing buffer: SAE codes (+ optional dense twin), per-token labels, instance IDs."""
+
+    codes: np.ndarray  # [N, F] float16  SAE feature activations
+    labels: np.ndarray  # [N, L] bool
+    label_names: list
+    dense: Optional[np.ndarray] = None  # [N, H] float16  raw layer residual (dense twin)
+    instances: Optional[Dict[str, np.ndarray]] = None  # {concept: [N] int32, -1 outside}
+
+    def save(self, path: str) -> None:
+        """Write codes, labels, names (+ optional dense twin / instance ids) to an .npz."""
+        d = {"codes": self.codes, "labels": self.labels, "label_names": np.array(self.label_names)}
+        if self.dense is not None:
+            d["dense"] = self.dense
+        for k, v in (self.instances or {}).items():
+            d[f"inst_{k}"] = v
+        np.savez(path, **d)
+
+    @classmethod
+    def load(cls, path: str) -> "ActivationBuffer":
+        """Load an ActivationBuffer from an .npz written by save()."""
+        z = np.load(path, allow_pickle=True)
+        inst = {k[5:]: z[k] for k in z.files if k.startswith("inst_")}
+        return cls(
+            codes=z["codes"],
+            labels=z["labels"],
+            label_names=list(z["label_names"]),
+            dense=z["dense"] if "dense" in z.files else None,
+            instances=inst or None,
+        )
+
+    @property
+    def name_idx(self):
+        """Map each label name to its column index in ``labels``."""
+        return {n: i for i, n in enumerate(self.label_names)}
+
+
+def split_indices(n, test_frac=0.4, seed=0):
+    """Deterministic train/test split of ``range(n)``; returns (train_idx, test_idx)."""
+    perm = torch.randperm(n, generator=torch.Generator().manual_seed(seed))
+    nte = int(n * test_frac)
+    return perm[nte:], perm[:nte]  # train, test
+
+
+def standardize(X, tr):
+    """Return (mean, std) of ``X`` over the train rows ``tr`` (std floored by 1e-6)."""
+    mu, sd = X[tr].mean(0), X[tr].std(0) + 1e-6
+    return mu, sd
+
+
+# ───────────────────────────────────────────────────────────── AUROC
+@torch.no_grad()
+def auroc_all(X, Y, chunk=1024):
+    """X [N,F], Y [N,L] bool -> AUROC [F,L] via vectorized rank statistic."""
+    N, F = X.shape
+    L = Y.shape[1]
+    y = Y.float()
+    npos = y.sum(0)
+    nneg = N - npos
+    valid = (npos > 0) & (nneg > 0)
+    denom = (npos * nneg).clamp_min(1.0)
+    half = npos * (npos + 1) / 2.0
+    out = torch.full((F, L), 0.5, device=X.device)
+    for c0 in range(0, F, chunk):
+        c1 = min(c0 + chunk, F)
+        ranks = X[:, c0:c1].float().argsort(0).argsort(0).float() + 1.0
+        au = (y.t() @ ranks - half[:, None]) / denom[:, None]
+        out[c0:c1] = au.t()
+    out[:, ~valid] = 0.5
+    return out
+
+
+@torch.no_grad()
+def auroc_vec(scores, y):
+    """AUROC of a single score vector against boolean labels ``y`` (0.5 if degenerate)."""
+    n = scores.numel()
+    npos = int(y.sum())
+    nneg = n - npos
+    if npos == 0 or nneg == 0:
+        return 0.5
+    ranks = scores.argsort().argsort().float() + 1.0
+    return float((ranks[y].sum() - npos * (npos + 1) / 2) / (npos * nneg))
+
+
+@torch.no_grad()
+def best_single_train_test(Xtr, ytr, Xte, yte, chunk=2048):
+    """Pick the best single dim on TRAIN, report ITS AUROC on TEST (no winner's curse)."""
+
+    def per_feat(X, y):
+        n = X.shape[0]
+        npos = int(y.sum())
+        nneg = n - npos
+        if npos == 0 or nneg == 0:
+            return None
+        yf = y.float()
+        F = X.shape[1]
+        out = torch.empty(F, device=X.device)
+        for c0 in range(0, F, chunk):
+            ranks = X[:, c0 : c0 + chunk].float().argsort(0).argsort(0).float() + 1.0
+            out[c0 : c0 + chunk] = (yf @ ranks - npos * (npos + 1) / 2) / (npos * nneg)
+        return out
+
+    a_tr = per_feat(Xtr, ytr)
+    if a_tr is None:
+        return float("nan")
+    f = int(torch.maximum(a_tr, 1 - a_tr).argmax())
+    flip = bool(a_tr[f] < 0.5)
+    a_te = auroc_vec(Xte[:, f].float(), yte)
+    return float(1 - a_te if flip else a_te)
+
+
+# ───────────────────────────────────────────────────────────── linear probes
+def fit_logreg(Xtr, ytr, steps=400, lr=0.05, wd=1e-2):
+    """Fit a logistic-regression probe (Adam + BCE-with-logits); returns (w, b)."""
+    w = torch.zeros(Xtr.shape[1], device=Xtr.device, requires_grad=True)
+    b = torch.zeros(1, device=Xtr.device, requires_grad=True)
+    opt = torch.optim.Adam([w, b], lr=lr, weight_decay=wd)
+    lossf = torch.nn.BCEWithLogitsLoss()
+    with torch.enable_grad():
+        for _ in range(steps):
+            opt.zero_grad()
+            lossf(Xtr @ w + b, ytr).backward()
+            opt.step()
+    return w.detach(), b.detach()
+
+
+def fit_softmax(Xtr, ytr, nclass, steps=400, lr=0.05, wd=1e-2):
+    """Fit a multinomial-softmax probe (Adam + cross-entropy); returns (W, b)."""
+    W = torch.zeros(Xtr.shape[1], nclass, device=Xtr.device, requires_grad=True)
+    b = torch.zeros(nclass, device=Xtr.device, requires_grad=True)
+    opt = torch.optim.Adam([W, b], lr=lr, weight_decay=wd)
+    lossf = torch.nn.CrossEntropyLoss()
+    with torch.enable_grad():
+        for _ in range(steps):
+            opt.zero_grad()
+            lossf(Xtr @ W + b, ytr).backward()
+            opt.step()
+    return W.detach(), b.detach()
+
+
+@torch.no_grad()
+def macro_auroc(logits, y, nclass):
+    """Macro-averaged one-vs-rest AUROC over ``nclass``; returns (mean_auroc, n_classes_scored)."""
+    aucs = []
+    for c in range(nclass):
+        yc = y == c
+        npos = int(yc.sum())
+        if npos == 0 or npos == len(y):
+            continue
+        ranks = logits[:, c].argsort().argsort().float() + 1.0
+        aucs.append(float((ranks[yc].sum() - npos * (npos + 1) / 2) / (npos * (len(y) - npos))))
+    return (sum(aucs) / max(1, len(aucs))), len(aucs)
+
+
+def decode_eval(Xtr, ytr, Xte, yte, nclass, **kw):
+    """Fit a softmax probe on train; return (accuracy, macro_auroc, n_classes) on test."""
+    W, b = fit_softmax(Xtr, ytr, nclass, **kw)
+    logits = Xte @ W + b
+    acc = float((logits.argmax(1) == yte).float().mean())
+    mauc, ncls = macro_auroc(logits, yte, nclass)
+    return acc, mauc, ncls
+
+
+# ───────────────────────────────────────────────────────────── domain-adjusted F1
+@torch.no_grad()
+def domain_f1(codes, fmax, concept_mask, inst_ids, thresholds=(0.15, 0.3, 0.5, 0.6, 0.8), chunk=1024):
+    """InterPLM domain-adjusted F1 per feature: precision-per-position, recall-per-instance.
+
+    codes [P,F] (>=0), fmax [F], concept_mask [P] bool, inst_ids [P] int (-1 outside).
+    Returns (best_f1[F], best_threshold[F]) over the threshold sweep.
+    """
+    _, F = codes.shape
+    dev = codes.device
+    valid = inst_ids >= 0
+    uniq = torch.unique(inst_ids[valid])
+    n_inst = len(uniq)
+    if n_inst == 0:
+        return torch.zeros(F, device=dev), torch.zeros(F, device=dev)
+    remap = torch.full((int(inst_ids.max().item()) + 2,), -1, device=dev, dtype=torch.long)
+    remap[uniq.long()] = torch.arange(n_inst, device=dev)
+    inst_c = torch.where(valid, remap[inst_ids.long()], torch.full_like(inst_ids, -1, dtype=torch.long))
+    best_f1 = torch.zeros(F, device=dev)
+    best_t = torch.zeros(F, device=dev)
+    for c0 in range(0, F, chunk):
+        c1 = min(c0 + chunk, F)
+        cn = codes[:, c0:c1] / fmax[c0:c1].clamp_min(1e-6)
+        C = c1 - c0
+        cb = torch.zeros(C, device=dev)
+        ct = torch.zeros(C, device=dev)
+        for t in thresholds:
+            fire = cn > t
+            firing = fire.sum(0).float()
+            prec = torch.where(
+                firing > 0, (fire & concept_mask[:, None]).sum(0).float() / firing, torch.zeros(C, device=dev)
+            )
+            bucket = torch.zeros(n_inst, C, device=dev)
+            vm = inst_c >= 0
+            bucket.index_reduce_(0, inst_c[vm], fire[vm].float(), "amax", include_self=False)
+            recall = (bucket > 0).sum(0).float() / n_inst
+            f1 = torch.where((prec + recall) > 0, 2 * prec * recall / (prec + recall), torch.zeros(C, device=dev))
+            upd = f1 > cb
+            cb = torch.where(upd, f1, cb)
+            ct = torch.where(upd, torch.full_like(ct, t), ct)
+        best_f1[c0:c1] = cb
+        best_t[c0:c1] = ct
+    return best_f1, best_t

--- a/bionemo-recipes/interpretability/sparse_autoencoders/sae/tests/test_probing.py
+++ b/bionemo-recipes/interpretability/sparse_autoencoders/sae/tests/test_probing.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU tests for sae.eval.probing: the metrics reproduce on synthetic data (no model/GPU)."""
+
+import numpy as np
+import torch
+from sae.eval.probing import ActivationBuffer, auroc_all, split_indices, standardize
+
+
+def test_auroc_separates_predictive_from_noise():
+    """A feature equal to the label scores ~1.0 AUROC; a random feature scores near chance."""
+    torch.manual_seed(0)
+    n = 400
+    y = (torch.arange(n) % 2).float()
+    predictive = y + torch.randn(n) * 0.01  # near-perfect detector
+    noise = torch.randn(n)  # uninformative
+    x = torch.stack([predictive, noise], dim=1)  # [N, 2 features]
+    au = auroc_all(x, y.unsqueeze(1))  # [2 features, 1 label]
+    assert float(au[0, 0]) > 0.99
+    assert float(au[1, 0]) < 0.7
+
+
+def test_split_indices_disjoint_and_complete():
+    """Train/test indices partition range(n) with the requested test fraction."""
+    tr, te = split_indices(100, test_frac=0.4, seed=0)
+    tr_s, te_s = set(tr.tolist()), set(te.tolist())
+    assert tr_s.isdisjoint(te_s)
+    assert tr_s | te_s == set(range(100))
+    assert 0.35 < len(te_s) / 100 < 0.45
+
+
+def test_standardize_zero_means_train_split():
+    """standardize() returns train-split mean/std that center the train rows."""
+    torch.manual_seed(0)
+    x = torch.randn(100, 5) * 3 + 7
+    tr = torch.arange(80)
+    mu, sd = standardize(x, tr)
+    z = (x[tr] - mu) / sd
+    assert torch.allclose(z.mean(0), torch.zeros(5), atol=1e-4)
+
+
+def test_activation_buffer_roundtrip(tmp_path):
+    """ActivationBuffer save/load preserves codes, labels, names (+ name_idx mapping)."""
+    rng = np.random.default_rng(0)
+    codes = rng.random((10, 4)).astype(np.float16)
+    labels = np.tile(np.array([True, False]), (10, 1))
+    buf = ActivationBuffer(codes=codes, labels=labels, label_names=["motif_atg", "is_prok"])
+    path = str(tmp_path / "buf.npz")
+    buf.save(path)
+
+    loaded = ActivationBuffer.load(path)
+    assert np.array_equal(loaded.codes, codes)
+    assert [str(n) for n in loaded.label_names] == ["motif_atg", "is_prok"]
+    assert loaded.name_idx["is_prok"] == 1


### PR DESCRIPTION
> **Draft** — opening early for visibility; depends on nothing (sibling off the merged base). Will un-draft after the layer-26 ablation confirms the metrics + a rebase onto latest `main`.

## What

Adds the **SAE evaluation / feature-probing suite** — how we measure what an SAE's features actually encode.

- **`sae/eval/probing.py`** (shared, model-agnostic): scoring over an `ActivationBuffer` (per-token feature codes + optional dense-residual twin + per-token labels):
  - per-feature **AUROC** vs a label battery
  - **winner's-curse-corrected best-single** feature (train-select / test-eval)
  - **linear / softmax probes** (SAE vs dense twin → disentanglement / distributed concepts)
  - **InterPLM domain-adjusted F1** (per-instance recall for sparse regional features)
  - exported via `sae.eval`, beside the existing `loss_recovered` / `reconstruction` / `sparsity`.
- **Evo2 probe CLI** (`recipes/evo2/scripts/`): `probe.py` (`auroc`/`linear`/`codon-aa`/`context`/`extract`/`loss-recovered`), `evo2_buffer.py` (builds buffers), `labelers.py` (DNA labelers), `euk_windows.py` (exon/intron/CDS windows from FASTA+GFF), `probe_loss_recovered.py`.

## Design
- **Scoring is a pure function of saved buffers** → runs on CPU, no GPU/model. Only `extract`/`loss-recovered` touch a model (via a **lazy** `Evo2SAE` import), so the package + all scoring import and run **without the inference engine** — this PR is independent of the infer PR.
- **`probe_loss_recovered`** is a thin adapter onto Jared's `sae.eval.loss_recovered` (reuse, not a copy).
- **CPU test** in `sae/tests/test_probing.py` (AUROC / split / standardize / buffer round-trip), matching where the package's tests live.

## Known follow-up
`domain_f1` overlaps the ESM2 / CodonFM F1 implementations — unifying into shared `sae.eval` touches those recipes, so it's deferred (same pattern as the dashboard-dedup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
