### PR TITLE
Added a recipe for evaluating Evo2 via GFMBench-API

### DIFF
--- a/bionemo-recipes/recipes/evo2_megatron/examples/.gitignore
+++ b/bionemo-recipes/recipes/evo2_megatron/examples/.gitignore
@@ -16,3 +16,9 @@ preprocessed_data/
 pretraining_demo/
 brca1_fasta_files/
 brca1/
+benchmark_data/
+GFMBench-api/
+
+# files created during these notebook runs.
+evo2_gfmbench_results.csv
+evo2_gfmbench_results.json

--- a/bionemo-recipes/recipes/evo2_megatron/examples/evo2_gfmbench_recipe.ipynb
+++ b/bionemo-recipes/recipes/evo2_megatron/examples/evo2_gfmbench_recipe.ipynb
@@ -1,1619 +1,1649 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Evaluating Evo2 with GFMBench-API (BioNeMo Recipe)\n",
-    "\n",
-    "This notebook evaluates the **Evo2** genomic foundation model using the **BioNeMo framework** (`bionemo-evo2` + NeMo/Megatron) on the **[GFMBench-API](https://github.com/NVIDIA/GFMBench-api)** benchmark suite.\n",
-    "\n",
-    "**GFMBench-API** is a framework for evaluating genomic foundation models. It exposes a single, model-agnostic API that decouples model development from benchmark tasks and metrics:  \n",
-    "you implement inference methods once, and the same interface drives zero-shot scoring, supervised evaluation, and reporting across all tasks. See the [bioRxiv preprint](https://www.biorxiv.org/content/10.64898/2026.02.19.706811v1) for the full benchmark design and task definitions.\n",
-    "\n",
-    "This recipe evaluates Evo2 on both task categories in GFMBench-API: **zero-shot** tasks and **linear probing** for supervised tasks, following the Evo2 paper protocol. For supervised tasks, because GFMBench-API decouples model development from task-specific training, you interact with **task modules** to load training data, extract frozen Evo2 embeddings, train lightweight classifiers, and evaluate via the same task API.\n",
-    "\n",
-    "> **Note:** In practice, each developer can choose any supervised training strategy (full fine-tuning, LoRA, adapter heads, etc.) by interacting with GFMBench-API **task modules** the same way: load training data through the task API, train your model, then evaluate with `eval_test_set()`.\n",
-    "\n",
-    "## Prerequisites\n",
-    "\n",
-    "- **BioNeMo Evo2** package installed (`bionemo-evo2`)\n",
-    "\n",
-    "## Evaluation Strategy\n",
-    "\n",
-    "GFMBench-API contains **20 tasks** in two categories:\n",
-    "\n",
-    "### Zero-Shot Tasks (no training required)\n",
-    "These use Evo2's autoregressive log-likelihood and embeddings directly:\n",
-    "- **Log-Likelihood Ratio (LLR)**: `log P(variant_seq) - log P(reference_seq)` scores variant pathogenicity\n",
-    "- **Embedding Cosine Similarity / L2 Distance**: Compare representative embeddings of variant vs reference sequences\n",
-    "- **SNV-specific metrics**: Position-specific embedding and probability comparisons\n",
-    "\n",
-    "| Task | Description | Type |\n",
-    "|------|-------------|------|\n",
-    "| VepevalClinvar | ClinVar SNV pathogenicity | SNV |\n",
-    "| IndelClinvar | ClinVar indel pathogenicity | Indel |\n",
-    "| BendVEPExpression | SNV expression effects | SNV |\n",
-    "| BendVEPDisease | SNV disease effects | SNV |\n",
-    "| SonglabClinvar | ClinVar SNV (likelihood) | SNV |\n",
-    "| BRCA1 | BRCA1 functional impact | SNV |\n",
-    "| TraitGymComplex | Complex trait variants | SNV |\n",
-    "| TraitGymMendelian | Mendelian disease variants | SNV |\n",
-    "| LrbPathogenicOmim | OMIM pathogenic variants | SNV |\n",
-    "| LoleveCausalEqtl | Causal eQTL indels | Indel |\n",
-    "\n",
-    "### Supervised Tasks (linear probing)\n",
-    "For these tasks we:\n",
-    "1. Extract Evo2 embeddings (frozen backbone) for each training sample\n",
-    "2. Train a lightweight `LogisticRegression` classifier on the embeddings\n",
-    "3. Wrap the trained head + Evo2 into a model that returns label probabilities\n",
-    "4. Evaluate via GFMBench-API\n",
-    "\n",
-    "| Task | Type | Description |\n",
-    "|------|------|-------------|\n",
-    "| GuePromoterAll | Single-seq | Promoter prediction (2-class, 300bp) |\n",
-    "| GueSpliceSite | Single-seq | Splice site prediction (3-class, 400bp) |\n",
-    "| GueTranscriptionFactor | Single-seq | TF binding prediction (2-class) |\n",
-    "| VariantBenchmarksCoding | Variant-pair | Coding variant pathogenicity |\n",
-    "| VariantBenchmarksNonCoding | Variant-pair | Non-coding variant pathogenicity |\n",
-    "| VariantBenchmarksExpression | Variant-pair | Expression-affecting variants |\n",
-    "| VariantBenchmarksCommonVsRare | Variant-pair | Common vs rare variants |\n",
-    "| VariantBenchmarksMEQTL | Variant-pair | Methylation eQTL variants |\n",
-    "| VariantBenchmarksSQTL | Variant-pair | Splicing eQTL variants |\n",
-    "| LRBCausalEqtl (supervised) | Variant-pair | Causal eQTL (with tissue metadata) |"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 1. Setup GFMBench-API\n",
-    "\n",
-    "Linux commands (run from your working directory):\n",
-    "\n",
-    "```bash\n",
-    "git clone https://github.com/NVIDIA/GFMBench-api\n",
-    "export GFMBENCH_PATH=./GFMBench-api\n",
-    "cd \"$GFMBENCH_PATH\"\n",
-    "pip install -r basic_requirements.txt\n",
-    "export PYTHONPATH=\"$GFMBENCH_PATH\"\n",
-    "```\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "The following Python code will do the same:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T15:53:52.423213Z",
-     "iopub.status.busy": "2026-06-14T15:53:52.422999Z",
-     "iopub.status.idle": "2026-06-14T15:53:54.609985Z",
-     "shell.execute_reply": "2026-06-14T15:53:54.608868Z"
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Evaluating Evo2 with GFMBench-API (BioNeMo Recipe)\n",
+        "\n",
+        "This notebook evaluates the **Evo2** genomic foundation model using the **BioNeMo framework** (`bionemo-evo2` + NeMo/Megatron) on the **[GFMBench-API](https://github.com/NVIDIA/GFMBench-api)** benchmark suite.\n",
+        "\n",
+        "**GFMBench-API** is a framework for evaluating genomic foundation models. It exposes a single, model-agnostic API that decouples model development from benchmark tasks and metrics:  \n",
+        "you implement inference methods once, and the same interface drives zero-shot scoring, supervised evaluation, and reporting across all tasks. See the [bioRxiv preprint](https://www.biorxiv.org/content/10.64898/2026.02.19.706811v1) for the full benchmark design and task definitions.\n",
+        "\n",
+        "This recipe evaluates Evo2 on both task categories in GFMBench-API: **zero-shot** tasks and **linear probing** for supervised tasks, following the Evo2 paper protocol. For supervised tasks, because GFMBench-API decouples model development from task-specific training, you interact with **task modules** to load training data, extract frozen Evo2 embeddings, train lightweight classifiers, and evaluate via the same task API.\n",
+        "\n",
+        "> **Note:** In practice, each developer can choose any supervised training strategy (full fine-tuning, LoRA, adapter heads, etc.) by interacting with GFMBench-API **task modules** the same way: load training data through the task API, train your model, then evaluate with `eval_test_set()`.\n",
+        "\n",
+        "## Prerequisites\n",
+        "\n",
+        "- **BioNeMo Evo2** package installed (`bionemo-evo2`)\n",
+        "\n",
+        "## Evaluation Strategy\n",
+        "\n",
+        "GFMBench-API contains **20 tasks** in two categories:\n",
+        "\n",
+        "### Zero-Shot Tasks (no training required)\n",
+        "These use Evo2's autoregressive log-likelihood and embeddings directly:\n",
+        "- **Log-Likelihood Ratio (LLR)**: `log P(variant_seq) - log P(reference_seq)` scores variant pathogenicity\n",
+        "- **Embedding Cosine Similarity / L2 Distance**: Compare representative embeddings of variant vs reference sequences\n",
+        "- **SNV-specific metrics**: Position-specific embedding and probability comparisons\n",
+        "\n",
+        "| Task | Description | Type |\n",
+        "|------|-------------|------|\n",
+        "| VepevalClinvar | ClinVar SNV pathogenicity | SNV |\n",
+        "| IndelClinvar | ClinVar indel pathogenicity | Indel |\n",
+        "| BendVEPExpression | SNV expression effects | SNV |\n",
+        "| BendVEPDisease | SNV disease effects | SNV |\n",
+        "| SonglabClinvar | ClinVar SNV (likelihood) | SNV |\n",
+        "| BRCA1 | BRCA1 functional impact | SNV |\n",
+        "| TraitGymComplex | Complex trait variants | SNV |\n",
+        "| TraitGymMendelian | Mendelian disease variants | SNV |\n",
+        "| LrbPathogenicOmim | OMIM pathogenic variants | SNV |\n",
+        "| LoleveCausalEqtl | Causal eQTL indels | Indel |\n",
+        "\n",
+        "### Supervised Tasks (linear probing)\n",
+        "For these tasks we:\n",
+        "1. Extract Evo2 embeddings (frozen backbone) for each training sample\n",
+        "2. Train a lightweight `LogisticRegression` classifier on the embeddings\n",
+        "3. Wrap the trained head + Evo2 into a model that returns label probabilities\n",
+        "4. Evaluate via GFMBench-API\n",
+        "\n",
+        "| Task | Type | Description |\n",
+        "|------|------|-------------|\n",
+        "| GuePromoterAll | Single-seq | Promoter prediction (2-class, 300bp) |\n",
+        "| GueSpliceSite | Single-seq | Splice site prediction (3-class, 400bp) |\n",
+        "| GueTranscriptionFactor | Single-seq | TF binding prediction (2-class) |\n",
+        "| VariantBenchmarksCoding | Variant-pair | Coding variant pathogenicity |\n",
+        "| VariantBenchmarksNonCoding | Variant-pair | Non-coding variant pathogenicity |\n",
+        "| VariantBenchmarksExpression | Variant-pair | Expression-affecting variants |\n",
+        "| VariantBenchmarksCommonVsRare | Variant-pair | Common vs rare variants |\n",
+        "| VariantBenchmarksMEQTL | Variant-pair | Methylation eQTL variants |\n",
+        "| VariantBenchmarksSQTL | Variant-pair | Splicing eQTL variants |\n",
+        "| LRBCausalEqtl (supervised) | Variant-pair | Causal eQTL (with tissue metadata) |"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 1. Setup GFMBench-API\n",
+        "\n",
+        "Linux commands (run from your working directory):\n",
+        "\n",
+        "```bash\n",
+        "git clone https://github.com/NVIDIA/GFMBench-api\n",
+        "export GFMBENCH_PATH=./GFMBench-api\n",
+        "cd \"$GFMBENCH_PATH\"\n",
+        "pip install -r basic_requirements.txt\n",
+        "export PYTHONPATH=\"$GFMBENCH_PATH\"\n",
+        "```\n",
+        "\n",
+        "\n",
+        "\n",
+        "\n",
+        "\n",
+        "\n",
+        "The following Python code will do the same:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-14T15:53:52.423213Z",
+          "iopub.status.busy": "2026-06-14T15:53:52.422999Z",
+          "iopub.status.idle": "2026-06-14T15:53:54.609985Z",
+          "shell.execute_reply": "2026-06-14T15:53:54.608868Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Cloning into 'GFMBench-api'...\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Installing GFMBench-API deps from /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt\n",
+            "Requirement already satisfied: numpy==1.26.4 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 2)) (1.26.4)\n",
+            "Requirement already satisfied: pandas>=1.3.3 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 3)) (2.2.3)\n",
+            "Requirement already satisfied: torch<3,>=2.0.0 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (2.8.0a0+5228986c39.nv25.6)\n",
+            "Requirement already satisfied: tqdm==4.67.3 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 5)) (4.67.3)\n",
+            "Requirement already satisfied: datasets>=2.0.0 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (4.3.0)\n",
+            "Requirement already satisfied: huggingface_hub==0.36.2 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (0.36.2)\n",
+            "Requirement already satisfied: pyfaidx==0.9.0.4 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 10)) (0.9.0.4)\n",
+            "Requirement already satisfied: pyarrow>=6.0.0 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 11)) (22.0.0)\n",
+            "Requirement already satisfied: openpyxl==3.1.5 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 12)) (3.1.5)\n",
+            "Requirement already satisfied: biopython==1.87 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 15)) (1.87)\n",
+            "Requirement already satisfied: scikit-learn==1.7.2 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 16)) (1.7.2)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (3.18.0)\n",
+            "Requirement already satisfied: fsspec>=2023.5.0 in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (2024.12.0)\n",
+            "Requirement already satisfied: hf-xet<2.0.0,>=1.1.3 in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (1.2.0)\n",
+            "Requirement already satisfied: packaging>=20.9 in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (24.2)\n",
+            "Requirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (6.0.2)\n",
+            "Requirement already satisfied: requests in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (2.32.3)\n",
+            "Requirement already satisfied: typing-extensions>=3.7.4.3 in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (4.14.0)\n",
+            "Requirement already satisfied: et-xmlfile in /usr/local/lib/python3.12/dist-packages (from openpyxl==3.1.5->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 12)) (2.0.0)\n",
+            "Requirement already satisfied: scipy>=1.8.0 in /usr/local/lib/python3.12/dist-packages (from scikit-learn==1.7.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 16)) (1.15.3)\n",
+            "Requirement already satisfied: joblib>=1.2.0 in /usr/local/lib/python3.12/dist-packages (from scikit-learn==1.7.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 16)) (1.5.1)\n",
+            "Requirement already satisfied: threadpoolctl>=3.1.0 in /usr/local/lib/python3.12/dist-packages (from scikit-learn==1.7.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 16)) (3.6.0)\n",
+            "Requirement already satisfied: sympy>=1.13.3 in /usr/local/lib/python3.12/dist-packages (from torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (1.14.0)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.12/dist-packages (from torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (3.5)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.12/dist-packages (from torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (3.1.6)\n",
+            "Requirement already satisfied: setuptools in /usr/local/lib/python3.12/dist-packages (from torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (78.1.1)\n",
+            "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.12/dist-packages (from pandas>=1.3.3->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 3)) (2.9.0)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.12/dist-packages (from pandas>=1.3.3->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 3)) (2023.4)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.12/dist-packages (from pandas>=1.3.3->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 3)) (2025.2)\n",
+            "Requirement already satisfied: dill<0.4.1,>=0.3.0 in /usr/local/lib/python3.12/dist-packages (from datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (0.4.0)\n",
+            "Requirement already satisfied: httpx<1.0.0 in /usr/local/lib/python3.12/dist-packages (from datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (0.28.1)\n",
+            "Requirement already satisfied: xxhash in /usr/local/lib/python3.12/dist-packages (from datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (3.6.0)\n",
+            "Requirement already satisfied: multiprocess<0.70.17 in /usr/local/lib/python3.12/dist-packages (from datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (0.70.16)\n",
+            "Requirement already satisfied: aiohttp!=4.0.0a0,!=4.0.0a1 in /usr/local/lib/python3.12/dist-packages (from fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (3.12.7)\n",
+            "Requirement already satisfied: anyio in /usr/local/lib/python3.12/dist-packages (from httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (4.9.0)\n",
+            "Requirement already satisfied: certifi in /usr/local/lib/python3.12/dist-packages (from httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (2025.4.26)\n",
+            "Requirement already satisfied: httpcore==1.* in /usr/local/lib/python3.12/dist-packages (from httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (1.0.9)\n",
+            "Requirement already satisfied: idna in /usr/local/lib/python3.12/dist-packages (from httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (3.10)\n",
+            "Requirement already satisfied: h11>=0.16 in /usr/local/lib/python3.12/dist-packages (from httpcore==1.*->httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (0.16.0)\n",
+            "Requirement already satisfied: aiohappyeyeballs>=2.5.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (2.6.1)\n",
+            "Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (1.3.2)\n",
+            "Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (25.3.0)\n",
+            "Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (1.6.0)\n",
+            "Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (6.4.4)\n",
+            "Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (0.3.1)\n",
+            "Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (1.20.0)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.12/dist-packages (from python-dateutil>=2.8.2->pandas>=1.3.3->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 3)) (1.16.0)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.12/dist-packages (from requests->huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (3.4.2)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.12/dist-packages (from requests->huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (1.26.20)\n",
+            "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.12/dist-packages (from sympy>=1.13.3->torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (1.3.0)\n",
+            "Requirement already satisfied: sniffio>=1.1 in /usr/local/lib/python3.12/dist-packages (from anyio->httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (1.3.1)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.12/dist-packages (from jinja2->torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (3.0.2)\n",
+            "GFMBENCH_PATH=/data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api\n",
+            "cwd=/data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
+            "\u001b[0m"
+          ]
+        }
+      ],
+      "source": [
+        "import os\n",
+        "import sys\n",
+        "from pathlib import Path\n",
+        "\n",
+        "\n",
+        "# Clone target is relative to the notebook working directory; resolve once for stable absolute paths.\n",
+        "GFMBENCH_PATH_RELATIVE = Path(\"GFMBench-api\")\n",
+        "GFMBENCH_PATH = GFMBENCH_PATH_RELATIVE.resolve()\n",
+        "\n",
+        "# Clone only if GFMBench-api is not already present (safe to re-run the cell)\n",
+        "if not GFMBENCH_PATH.exists():\n",
+        "    os.system(\"git clone https://github.com/NVIDIA/GFMBench-api\")\n",
+        "else:\n",
+        "    print(f\"Using existing clone: {GFMBENCH_PATH}\")\n",
+        "\n",
+        "REQUIREMENTS = GFMBENCH_PATH / \"basic_requirements.txt\"\n",
+        "if not REQUIREMENTS.exists():\n",
+        "    raise FileNotFoundError(f\"{REQUIREMENTS} not found — run `git pull` in {GFMBENCH_PATH}\")\n",
+        "print(f\"Installing GFMBench-API deps from {REQUIREMENTS}\")\n",
+        "os.system(f\"{sys.executable} -m pip install -r {REQUIREMENTS}\")\n",
+        "\n",
+        "os.environ[\"GFMBENCH_PATH\"] = str(GFMBENCH_PATH)\n",
+        "os.environ[\"PYTHONPATH\"] = str(GFMBENCH_PATH)\n",
+        "sys.path.insert(0, str(GFMBENCH_PATH))\n",
+        "\n",
+        "print(f\"GFMBENCH_PATH={GFMBENCH_PATH}\")\n",
+        "print(f\"cwd={Path.cwd()}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> **Note:** You can also use GFMBench-API's example script, [`usage_examples/run_benchmark.py`](https://github.com/NVIDIA/GFMBench-api/blob/main/usage_examples/run_benchmark.py) on Linux (from `$GFMBENCH_PATH`):\n",
+        ">\n",
+        "> ```bash\n",
+        "> python ./usage_examples/run_benchmark.py \\\n",
+        ">   --model Evo2 \\\n",
+        ">   --linear_prob \\\n",
+        ">   --csv_path ./evo2_gfmbench_results.csv \\\n",
+        ">   --report_algo_name evo2_run \\\n",
+        ">   --root_data_dir_path ./benchmark_data\n",
+        "> ```\n",
+        ">"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 2. Evo2 Evaluation Pipeline\n",
+        "\n",
+        "This notebook walks through the **Evo2-paper linear probing protocol** step by step: interact with GFMBench-API task modules to load supervised train/test data, extract frozen Evo2 embeddings, train `LogisticRegression` heads, and evaluate via `task.eval_test_set()`.\n",
+        "\n",
+        "Use this approach when you need full control over embedding extraction, probe training, or per-task customization."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 2.1 Setup & Imports"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-14T15:53:54.612785Z",
+          "iopub.status.busy": "2026-06-14T15:53:54.612580Z",
+          "iopub.status.idle": "2026-06-14T15:53:56.287440Z",
+          "shell.execute_reply": "2026-06-14T15:53:56.286344Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.12/dist-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+            "  from .autonotebook import tqdm as notebook_tqdm\n"
+          ]
+        }
+      ],
+      "source": [
+        "import json\n",
+        "import logging\n",
+        "import os\n",
+        "import time\n",
+        "import traceback\n",
+        "import warnings\n",
+        "from typing import List, Optional, Tuple\n",
+        "\n",
+        "import numpy as np\n",
+        "import torch\n",
+        "from tqdm.auto import tqdm\n",
+        "\n",
+        "\n",
+        "warnings.filterwarnings(\"ignore\", category=FutureWarning)\n",
+        "logging.basicConfig(level=logging.INFO, format=\"%(asctime)s [%(levelname)s] %(message)s\")\n",
+        "logger = logging.getLogger(__name__)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 2.2 Configuration\n",
+        "\n",
+        "Adjust these settings for your environment. Paths below are relative to the current working directory."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-14T15:53:56.290109Z",
+          "iopub.status.busy": "2026-06-14T15:53:56.289856Z",
+          "iopub.status.idle": "2026-06-14T15:53:56.295896Z",
+          "shell.execute_reply": "2026-06-14T15:53:56.294735Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Checkpoint tag: evo2/1b-8k-bf16:1.0\n",
+            "Model max seq: 8192 | Batch size: 8\n",
+            "Data root: benchmark_data\n",
+            "Results CSV: evo2_gfmbench_results.csv\n"
+          ]
+        }
+      ],
+      "source": [
+        "# ---------------------------------------------------------------------------\n",
+        "# Model configuration\n",
+        "# ---------------------------------------------------------------------------\n",
+        "# BioNeMo checkpoint tag — automatically downloaded + cached from NGC.\n",
+        "# Available tags:\n",
+        "#   evo2/1b-8k-bf16:1.0   — 1B params, 8K context, bf16\n",
+        "#   evo2/1b-8k:1.0         — 1B params, 8K context, fp8\n",
+        "#   evo2/7b-8k:1.0         — 7B params, 8K context\n",
+        "#   evo2/7b-1m:1.0         — 7B params, 1M context\n",
+        "# Can also be a local path to an extracted NeMo2 checkpoint directory.\n",
+        "\n",
+        "# ---------------------------------------------------------------------------\n",
+        "# Data & output paths\n",
+        "# ---------------------------------------------------------------------------\n",
+        "\n",
+        "DATA_ROOT = \"benchmark_data\"  # Downloaded benchmark datasets (relative to cwd)\n",
+        "RESULTS_CSV = \"evo2_gfmbench_results.csv\"  # Results output path (relative to cwd)\n",
+        "CKPT_TAG = \"evo2/1b-8k-bf16:1.0\"\n",
+        "\n",
+        "# ---------------------------------------------------------------------------\n",
+        "# Evaluation settings\n",
+        "# ---------------------------------------------------------------------------\n",
+        "\n",
+        "MAX_SEQ_LENGTH = 8192  # Max tokens per sequence\n",
+        "BATCH_SIZE = 8\n",
+        "MAX_NUM_SAMPLES = None  # limit the num of samples to lower number (e.g. 100) for fast runs\n",
+        "\n",
+        "# ---------------------------------------------------------------------------\n",
+        "# Linear probing settings (for supervised tasks)\n",
+        "# ---------------------------------------------------------------------------\n",
+        "\n",
+        "LINEAR_PROBE_MAX_ITER = 5000\n",
+        "LINEAR_PROBE_C = 1.0\n",
+        "\n",
+        "os.makedirs(DATA_ROOT, exist_ok=True)\n",
+        "print(f\"Checkpoint tag: {CKPT_TAG}\")\n",
+        "print(f\"Model max seq: {MAX_SEQ_LENGTH} | Batch size: {BATCH_SIZE}\")\n",
+        "print(f\"Data root: {DATA_ROOT}\")\n",
+        "print(f\"Results CSV: {RESULTS_CSV}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 2.3 Load Evo2 Model via BioNeMo\n",
+        "\n",
+        "We use the **BioNeMo framework** (`bionemo-evo2`) to load Evo2. The notebook-compatible approach:\n",
+        "1. Initializes **Megatron parallel state manually** (single-GPU, no NeMo Trainer)\n",
+        "2. Creates the model from NeMo's `HYENA_MODEL_OPTIONS` / `MAMBA_MODEL_OPTIONS` configs\n",
+        "3. Loads checkpoint weights via **Megatron `dist_checkpointing`** (torch_dist format)\n",
+        "4. Registers a forward hook on `output_layer` to capture **embeddings** (hidden states before the lm_head)\n",
+        "\n",
+        "Supported architectures and sizes:\n",
+        "\n",
+        "| Config | Arch | Hidden | Layers | Seq Len |\n",
+        "|--------|------|--------|--------|---------|\n",
+        "| 1b | Hyena | 1920 | 25 | 8,192 |\n",
+        "| 7b | Hyena | 4096 | 32 | 8,192 |\n",
+        "| 7b_arc_longcontext | Hyena | 4096 | 32 | 1,048,576 |\n",
+        "| 40b | Hyena | 8192 | 50 | 8,192 |\n",
+        "| 1b_nv / 7b_nv / 40b_nv | Hyena | varies | varies | varies |\n",
+        "| hybrid_mamba_8b | Mamba | - | - | - |"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-14T15:53:56.298350Z",
+          "iopub.status.busy": "2026-06-14T15:53:56.298144Z",
+          "iopub.status.idle": "2026-06-14T15:54:05.653910Z",
+          "shell.execute_reply": "2026-06-14T15:54:05.652755Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2026-06-14 22:14:59,305 [INFO] The multistorageclient package is available.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Evo2BioNeMoModel class defined.\n"
+          ]
+        }
+      ],
+      "source": [
+        "from usage_examples.sanity_models.evo2_model import Evo2BioNeMoModel\n",
+        "\n",
+        "\n",
+        "print(\"Evo2BioNeMoModel class defined.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Instantiate the model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-14T15:54:05.656637Z",
+          "iopub.status.busy": "2026-06-14T15:54:05.656301Z",
+          "iopub.status.idle": "2026-06-14T15:54:19.997649Z",
+          "shell.execute_reply": "2026-06-14T15:54:19.996534Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0\n",
+            "[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0\n",
+            "[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2026-06-14 22:15:07,431 [INFO] Downloading/caching checkpoint: evo2/1b-8k-bf16:1.0\n",
+            "Using cached path='/root/.cache/bionemo/ea4a3f5c9c26d5edc10bdc85165c090ad0ff23ac2670d4f61244f5f0d9d5e817-nemo2_evo2_1b_8k_bf16.tar.gz.untar' from checked=PosixPath('/root/.cache/bionemo/ea4a3f5c9c26d5edc10bdc85165c090ad0ff23ac2670d4f61244f5f0d9d5e817-nemo2_evo2_1b_8k_bf16.tar.gz.checked')\n",
+            "2026-06-14 22:15:07,446 [INFO] Checkpoint root: /root/.cache/bionemo/ea4a3f5c9c26d5edc10bdc85165c090ad0ff23ac2670d4f61244f5f0d9d5e817-nemo2_evo2_1b_8k_bf16.tar.gz.untar\n",
+            "2026-06-14 22:15:08,593 [INFO] Note: detected 256 virtual cores but NumExpr set to maximum of 64, check \"NUMEXPR_MAX_THREADS\" environment variable.\n",
+            "2026-06-14 22:15:08,594 [INFO] Note: NumExpr detected 256 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 16.\n",
+            "2026-06-14 22:15:08,595 [INFO] NumExpr defaulting to 16 threads.\n",
+            "Import of quick_gelu from megatron.core.fusions.fused_bias_geglu failed with: Traceback (most recent call last):\n",
+            "  File \"/usr/local/lib/python3.12/dist-packages/nemo/utils/import_utils.py\", line 319, in safe_import_from\n",
+            "    return getattr(imported_module, symbol), True\n",
+            "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "AttributeError: module 'megatron.core.fusions.fused_bias_geglu' has no attribute 'quick_gelu'\n",
+            "\n",
+            "2026-06-14 22:15:10,263 [INFO] Import of quick_gelu from megatron.core.fusions.fused_bias_geglu failed with: Traceback (most recent call last):\n",
+            "  File \"/usr/local/lib/python3.12/dist-packages/nemo/utils/import_utils.py\", line 319, in safe_import_from\n",
+            "    return getattr(imported_module, symbol), True\n",
+            "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+            "AttributeError: module 'megatron.core.fusions.fused_bias_geglu' has no attribute 'quick_gelu'\n",
+            "\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[NeMo I 2026-06-14 22:15:10 nemo_logging:393] Padded vocab_size: 512, original vocab_size: 512, dummy tokens: 0.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2026-06-14 22:15:11,201 [INFO] Using hybrid override pattern\n",
+            "2026-06-14 22:15:11,202 [INFO] Hybrid allocation (S is hyena_short_conv, D is hyena_medium_conv, H is hyena, * is attention, \n",
+            "2026-06-14 22:15:11,202 [INFO] SDH*SDHSDH*SDHSDH*SDHSDH*\n",
+            "2026-06-14 22:15:11,203 [INFO] 7 heyna_short_conv layers in 25 total layers.\n",
+            "2026-06-14 22:15:11,204 [INFO] 7 heyna_medium_conv layers in 25 total layers.\n",
+            "2026-06-14 22:15:11,205 [INFO] 7 heyna layers in 25 total layers.\n",
+            "2026-06-14 22:15:11,206 [INFO] 4 attention layers in 25 total layers.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[NeMo I 2026-06-14 22:15:11 nemo_logging:393] Using byte-level tokenization\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2026-06-14 22:15:11,440 [INFO] Model created: 1,108,204,800 parameters, hidden=1920\n",
+            "2026-06-14 22:15:14,001 [INFO] Checkpoint loaded successfully\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "Loaded in 6.8s\n",
+            "  Hidden dim:  1920\n",
+            "  Max length:  8192\n",
+            "\n",
+            "Sanity check - infer_sequence_to_sequence:\n",
+            "  token_probs shape:     (2, 16)\n",
+            "  seq_embeddings shape:  (2, 16, 1920)\n",
+            "  representative shape:  (2, 1920)\n",
+            "  token_probs range:     [0.0000, 0.9951]\n",
+            "  representative norm:   [22.061846 17.920654]\n",
+            "\n",
+            "infer_variant_ref_sequences_to_labels_probs:\n",
+            "  output shape: (1, 2)\n",
+            "  probs:        [[0.00686961 0.9931304 ]]\n",
+            "  probs sum:    1.000000\n"
+          ]
+        }
+      ],
+      "source": [
+        "t0 = time.time()\n",
+        "evo2_model = Evo2BioNeMoModel(\n",
+        "    ckpt_tag=CKPT_TAG,\n",
+        "    max_length=MAX_SEQ_LENGTH,\n",
+        ")\n",
+        "elapsed = time.time() - t0\n",
+        "print(f\"\\nLoaded in {elapsed:.1f}s\")\n",
+        "print(f\"  Hidden dim:  {evo2_model.hidden_dim}\")\n",
+        "print(f\"  Max length:  {evo2_model.max_length}\")\n",
+        "\n",
+        "# Quick sanity check\n",
+        "test_seqs = [\"ACGTACGTACGTACGT\", \"NNNNACGTACGTNNNN\"]\n",
+        "probs, embeddings, representative = evo2_model.infer_sequence_to_sequence(test_seqs)\n",
+        "\n",
+        "print(\"\\nSanity check - infer_sequence_to_sequence:\")\n",
+        "print(f\"  token_probs shape:     {probs.shape}\")\n",
+        "print(f\"  seq_embeddings shape:  {embeddings.shape if embeddings is not None else 'None'}\")\n",
+        "print(f\"  representative shape:  {representative.shape if representative is not None else 'None'}\")\n",
+        "print(f\"  token_probs range:     [{probs.min():.4f}, {probs.max():.4f}]\")\n",
+        "if representative is not None:\n",
+        "    print(f\"  representative norm:   {np.linalg.norm(representative, axis=1)}\")\n",
+        "\n",
+        "# Verify variant scoring\n",
+        "var_probs = evo2_model.infer_variant_ref_sequences_to_labels_probs(\n",
+        "    variant_sequences=[\"ACGTACGTACGTACGT\"],\n",
+        "    ref_sequences=[\"ACGTACGAACGTACGT\"],\n",
+        ")\n",
+        "print(\"\\ninfer_variant_ref_sequences_to_labels_probs:\")\n",
+        "print(f\"  output shape: {var_probs.shape}\")\n",
+        "print(f\"  probs:        {var_probs}\")\n",
+        "print(f\"  probs sum:    {var_probs.sum():.6f}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-14T15:54:20.000605Z",
+          "iopub.status.busy": "2026-06-14T15:54:20.000002Z",
+          "iopub.status.idle": "2026-06-14T15:54:20.032389Z",
+          "shell.execute_reply": "2026-06-14T15:54:20.031626Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Benchmark report initialized: evo2_gfmbench_results.csv\n",
+            "Model name for reporting: evo2_1b-8k-bf16_1.0\n",
+            "TASK_CONFIG: {'max_sequence_length': 8192, 'batch_size': 8, 'max_num_samples': None, 'disable_safe_model_call': True}\n"
+          ]
+        }
+      ],
+      "source": [
+        "from gfmbench_api.benchmark_report.benchmark_report import BenchmarkReport\n",
+        "\n",
+        "\n",
+        "# Common task config (passed to every GFMBench-API task constructor)\n",
+        "TASK_CONFIG = {\n",
+        "    # Extraction window: min(task_default, this value). Keep well below MAX_SEQ_LENGTH\n",
+        "    # to avoid quadratic attention OOM at large batch sizes.\n",
+        "    \"max_sequence_length\": MAX_SEQ_LENGTH,\n",
+        "    \"batch_size\": BATCH_SIZE,\n",
+        "    \"max_num_samples\": MAX_NUM_SAMPLES,\n",
+        "    # Fail fast while validating this recipe. If this is False, GFMBench-API\n",
+        "    # converts model-interface exceptions into None outputs and metrics become N/A.\n",
+        "    \"disable_safe_model_call\": True,\n",
+        "}\n",
+        "\n",
+        "MODEL_NAME = CKPT_TAG.replace(\"/\", \"_\").replace(\":\", \"_\")\n",
+        "\n",
+        "# Initialize the benchmark report (loads existing CSV if present)\n",
+        "report = BenchmarkReport(csv_path=RESULTS_CSV)\n",
+        "print(f\"Benchmark report initialized: {RESULTS_CSV}\")\n",
+        "print(f\"Model name for reporting: {MODEL_NAME}\")\n",
+        "print(f\"TASK_CONFIG: {TASK_CONFIG}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Define Benchmark Tasks\n",
+        "\n",
+        "Choose which GFMBench-API tasks to evaluate in the cell below. **Uncomment the tasks you want to run** in `zero_shot_tasks` and/or `supervised_tasks`.\n",
+        "\n",
+        "Each enabled task is instantiated when you run that cell, which may download and cache datasets under `DATA_ROOT` on the first run. Later runs reuse the cache.\n",
+        "\n",
+        "**Note:** First-time downloads (reference genomes, HuggingFace datasets, parquet files, etc.) can take several minutes to tens of minutes per task, depending on network speed and how many tasks are enabled."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-14T15:54:20.034675Z",
+          "iopub.status.busy": "2026-06-14T15:54:20.034511Z",
+          "iopub.status.idle": "2026-06-14T15:56:55.564347Z",
+          "shell.execute_reply": "2026-06-14T15:56:55.563477Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "BRCA1 dataset or reference genome not found. Downloading...\n",
+            "Downloading and processing BRCA1 dataset...\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2026-06-14 22:15:21,588 [INFO] Downloading from: https://github.com/ArcInstitute/evo2/raw/refs/heads/main/notebooks/brca1/GRCh37.p13_chr17.fna.gz\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "   chrom       pos ref alt     score  label\n",
+            "0     17  41276135   T   G -0.372611      1\n",
+            "1     17  41276135   T   C -0.045313      1\n",
+            "2     17  41276135   T   A -0.108254      1\n",
+            "3     17  41276134   T   G -0.277963      1\n",
+            "4     17  41276134   T   C -0.388414      1\n",
+            "Saved BRCA1 DMS dataset with 3893 variants to parquet.\n",
+            "Downloading reference genome...\n",
+            "  Progress: 100.0% (23.2 MB)\n",
+            "Unzipping and normalizing FASTA header...\n",
+            "Reference genome ready: benchmark_data/brca1/GRCh37.p13_chr17.fna\n",
+            "Successfully downloaded BRCA1 dataset and reference to benchmark_data/brca1\n",
+            "Loading reference genome: benchmark_data/brca1/GRCh37.p13_chr17.fna\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2026-06-14 22:15:24,742 [INFO] Reference genome not found. Downloading hg38.fa...\n",
+            "2026-06-14 22:15:24,743 [INFO] Downloading reference genome hg38.fa (~3GB)...\n",
+            "2026-06-14 22:15:24,743 [INFO] Source: https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.fa.gz\n",
+            "2026-06-14 22:15:24,744 [INFO] This may take several minutes...\n",
+            "2026-06-14 22:15:24,745 [INFO] Downloading from: https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.fa.gz\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Extracting sequences (window size: 8192bp)...\n",
+            "Successfully extracted 3893 sequence pairs\n",
+            "  Progress: 100.0% (983.7 MB)"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2026-06-14 22:16:37,649 [INFO] Extracting hg38.fa.gz...\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2026-06-14 22:16:55,504 [INFO] Reference genome saved to: benchmark_data/reference_genome/hg38.fa\n",
+            "2026-06-14 22:16:55,505 [INFO] Loading reference genome: benchmark_data/reference_genome/hg38.fa\n",
+            "2026-06-14 22:17:18,046 [INFO] Downloading bend_variant_effects_disease from BEND repository...\n",
+            "2026-06-14 22:17:18,048 [INFO] Downloading from: https://sid.erda.dk/share_redirect/aNQa0Oz2lY/data/variant_effects/variant_effects_disease.bed\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "  Progress: 100.0% (20.4 MB)"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2026-06-14 22:17:19,675 [INFO] Data saved to: benchmark_data/bend_variant_effects_disease\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2026-06-14 22:17:19,909 [INFO] Extracting sequences (window size: 512bp)...\n",
+            "2026-06-14 22:17:36,816 [INFO] Successfully extracted 295495 sequence pairs\n",
+            "2026-06-14 22:17:37,884 [INFO] Downloading gue_splice_site from HuggingFace...\n",
+            "2026-06-14 22:17:37,887 [INFO] Dataset not found locally, downloading\n",
+            "Saving the dataset (1/1 shards): 100%|██████████| 36496/36496 [00:00<00:00, 1763317.08 examples/s]\n",
+            "Saving the dataset (1/1 shards): 100%|██████████| 4562/4562 [00:00<00:00, 887866.68 examples/s] \n",
+            "Saving the dataset (1/1 shards): 100%|██████████| 4562/4562 [00:00<00:00, 899850.21 examples/s] \n",
+            "2026-06-14 22:17:41,539 [INFO] Data saved to: benchmark_data/gue_splice_site\n",
+            "2026-06-14 22:17:41,770 [INFO] GUE: wrote benchmark_data/gue_splice_site/train.csv from HuggingFace split 'train'\n",
+            "2026-06-14 22:17:41,797 [INFO] GUE: wrote benchmark_data/gue_splice_site/dev.csv from HuggingFace split 'dev'\n",
+            "2026-06-14 22:17:41,825 [INFO] GUE: wrote benchmark_data/gue_splice_site/test.csv from HuggingFace split 'test'\n",
+            "2026-06-14 22:17:42,458 [INFO] Downloading var_bench_coding_pathogenicity from HuggingFace...\n",
+            "2026-06-14 22:17:42,459 [INFO] Dataset not found locally, downloading\n",
+            "Saving the dataset (1/1 shards): 100%|██████████| 82872/82872 [00:00<00:00, 290897.37 examples/s]\n",
+            "2026-06-14 22:17:45,945 [INFO] Data saved to: benchmark_data/var_bench_coding_pathogenicity\n",
+            "Filter: 100%|██████████| 82872/82872 [00:00<00:00, 127208.08 examples/s]\n",
+            "Filter: 100%|██████████| 82872/82872 [00:00<00:00, 132380.18 examples/s]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Zero-shot tasks enabled: 2\n",
+            "  - brca1\n",
+            "  - bend_variant_effects_disease\n",
+            "Supervised tasks enabled: 2\n",
+            "  - gue_splice_site\n",
+            "  - var_bench_coding_pathogenicity\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Uncomment the import for each task you enable below.\n",
+        "# isort: off\n",
+        "\n",
+        "# --- Zero-shot tasks imports ---\n",
+        "# from gfmbench_api.tasks.concrete.clinvar_indel_task import IndelClinvarTask\n",
+        "# from gfmbench_api.tasks.concrete.loleve_causal_eqtl_task import LoleveCausalEqtlTask\n",
+        "from gfmbench_api.tasks.concrete.brca1_task import BRCA1Task\n",
+        "from gfmbench_api.tasks.concrete.bend_vep_disease_task import BendVEPDisease\n",
+        "# from gfmbench_api.tasks.concrete.bend_vep_expression_task import BendVEPExpression\n",
+        "# from gfmbench_api.tasks.concrete.songlab_clinvar_task import SonglabClinvarTask\n",
+        "# from gfmbench_api.tasks.concrete.traitgym_complex_task import TraitGymComplexTask\n",
+        "# from gfmbench_api.tasks.concrete.traitgym_mendelian_task import TraitGymMendelianTask\n",
+        "# from gfmbench_api.tasks.concrete.lrb_pathogenic_omim_task import LrbVariantEffectPathogenicOmimTask\n",
+        "\n",
+        "# --- Supervised tasks imports ---\n",
+        "# from gfmbench_api.tasks.concrete.gue_tf_all_task import GueTranscriptionFactorTask\n",
+        "# from gfmbench_api.tasks.concrete.gue_promoter_all_task import GuePromoterAllTask\n",
+        "from gfmbench_api.tasks.concrete.gue_splice_site_task import GueSpliceSiteTask\n",
+        "from gfmbench_api.tasks.concrete.variant_benchmarks_coding_task import VariantBenchmarksCodingTask\n",
+        "# from gfmbench_api.tasks.concrete.variant_benchmarks_non_coding_task import VariantBenchmarksNonCodingTask\n",
+        "# from gfmbench_api.tasks.concrete.variant_benchmarks_expression_task import VariantBenchmarksExpressionTask\n",
+        "# from gfmbench_api.tasks.concrete.variant_benchmarks_common_vs_rare_task import VariantBenchmarksCommonVsRareTask\n",
+        "# from gfmbench_api.tasks.concrete.variant_benchmarks_meqtl_task import VariantBenchmarksMEQTLTask\n",
+        "# from gfmbench_api.tasks.concrete.variant_benchmarks_sqtl_task import VariantBenchmarksSQTLTask\n",
+        "# from gfmbench_api.tasks.concrete.lrb_causal_eqtl_task import LRBCausalEqtlTask\n",
+        "\n",
+        "# isort: on\n",
+        "# ---------------------------------------------------------------------------\n",
+        "# Zero-shot tasks (no training — model runs inference directly)\n",
+        "# ---------------------------------------------------------------------------\n",
+        "# Uncomment the tasks you want to run.\n",
+        "\n",
+        "zero_shot_tasks = [\n",
+        "    # IndelClinvarTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                    # ClinVar indels\n",
+        "    # LoleveCausalEqtlTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                # Causal eQTL indels\n",
+        "    BRCA1Task(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),  # BRCA1 functional impact (SNV)\n",
+        "    BendVEPDisease(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),  # SNV disease effects\n",
+        "    # BendVEPExpression(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                   # SNV expression effects\n",
+        "    # SonglabClinvarTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                  # ClinVar SNV (likelihood)\n",
+        "    # TraitGymComplexTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                 # Complex trait variants\n",
+        "    # TraitGymMendelianTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),               # Mendelian disease variants\n",
+        "    # LrbVariantEffectPathogenicOmimTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),  # OMIM pathogenic variants\n",
+        "]\n",
+        "\n",
+        "# ---------------------------------------------------------------------------\n",
+        "# Supervised tasks (linear probing — extract embeddings, train a classifier head)\n",
+        "# ---------------------------------------------------------------------------\n",
+        "# Uncomment the tasks you want to run.\n",
+        "\n",
+        "supervised_tasks = [\n",
+        "    # GueTranscriptionFactorTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),          # TF binding (single-seq, binary)\n",
+        "    # GuePromoterAllTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                  # Promoter prediction (single-seq, binary)\n",
+        "    GueSpliceSiteTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),  # Splice site (single-seq, 3-class)\n",
+        "    VariantBenchmarksCodingTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),  # Coding variant pathogenicity\n",
+        "    # VariantBenchmarksNonCodingTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),      # Non-coding variant pathogenicity\n",
+        "    # VariantBenchmarksExpressionTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),     # Expression-affecting variants\n",
+        "    # VariantBenchmarksCommonVsRareTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),   # Common vs rare variants\n",
+        "    # VariantBenchmarksMEQTLTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),          # Methylation eQTL variants\n",
+        "    # VariantBenchmarksSQTLTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),           # Splicing eQTL variants\n",
+        "    # LRBCausalEqtlTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                   # Causal eQTL (with tissue metadata)\n",
+        "]\n",
+        "\n",
+        "print(f\"Zero-shot tasks enabled: {len(zero_shot_tasks)}\")\n",
+        "for task in zero_shot_tasks:\n",
+        "    print(f\"  - {task.get_task_name()}\")\n",
+        "print(f\"Supervised tasks enabled: {len(supervised_tasks)}\")\n",
+        "for task in supervised_tasks:\n",
+        "    print(f\"  - {task.get_task_name()}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "### 2.5 Zero-Shot Evaluation\n",
+        "\n",
+        "For zero-shot tasks, we pass the `Evo2BioNeMoModel` directly to GFMBench-API. The benchmark calls:\n",
+        "- `infer_sequence_to_sequence(sequences)` -> `(token_probs, seq_embeddings, representative)`\n",
+        "- Computes LLR, cosine similarity, and L2 distance metrics automatically\n",
+        "- For SNV tasks, also calls `sequence_pos_to_prob_pos`\n",
+        "\n",
+        "No training is needed -- the model's pre-trained representations are evaluated as-is."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-14T15:56:55.567399Z",
+          "iopub.status.busy": "2026-06-14T15:56:55.567180Z",
+          "iopub.status.idle": "2026-06-14T17:43:38.247242Z",
+          "shell.execute_reply": "2026-06-14T17:43:38.246388Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "  Task: brca1\n",
+            "  SNV only: True\n",
+            "  Test samples: 3893\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Evaluating (Zero-Shot):   0%|          | 0/487 [00:00<?, ?it/s]2026-06-14 22:17:54,870 [WARNING] Model did not provide required inputs for 'snv_variant_effect_prediction_masked_llr_auroc' metric. This metric will return None.\n",
+            "2026-06-14 22:17:54,871 [WARNING] Model did not provide required inputs for 'snv_variant_effect_prediction_masked_llr_auprc' metric. This metric will return None.\n",
+            "Evaluating (Zero-Shot): 100%|██████████| 487/487 [18:24<00:00,  2.27s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "  Results (1109.0s):\n",
+            "    sum_probs_llr_auroc: 0.7423\n",
+            "    sum_probs_llr_auprc: 0.5332\n",
+            "    sequence_embeddings_cosinesim_auroc: 0.7495\n",
+            "    sequence_embeddings_cosinesim_auprc: 0.5426\n",
+            "    sequence_embeddings_l2_auroc: 0.7781\n",
+            "    sequence_embeddings_l2_auprc: 0.5773\n",
+            "    snv_variant_effect_cosinesim_auroc: 0.5328\n",
+            "    snv_variant_effect_cosinesim_auprc: 0.2221\n",
+            "    snv_variant_effect_prediction_masked_llr_auroc: N/A\n",
+            "    snv_variant_effect_prediction_masked_llr_auprc: N/A\n",
+            "  Task: bend_variant_effects_disease\n",
+            "  SNV only: True\n",
+            "  Test samples: 295495\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Evaluating (Zero-Shot):   0%|          | 0/36937 [00:00<?, ?it/s]2026-06-14 22:36:21,823 [WARNING] Model did not provide required inputs for 'snv_variant_effect_prediction_masked_llr_auroc' metric. This metric will return None.\n",
+            "2026-06-14 22:36:21,823 [WARNING] Model did not provide required inputs for 'snv_variant_effect_prediction_masked_llr_auprc' metric. This metric will return None.\n",
+            "Evaluating (Zero-Shot): 100%|██████████| 36937/36937 [1:26:49<00:00,  7.09it/s]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "  Results (5213.1s):\n",
+            "    sum_probs_llr_auroc: 0.9195\n",
+            "    sum_probs_llr_auprc: 0.7422\n",
+            "    sequence_embeddings_cosinesim_auroc: 0.8723\n",
+            "    sequence_embeddings_cosinesim_auprc: 0.4737\n",
+            "    sequence_embeddings_l2_auroc: 0.9115\n",
+            "    sequence_embeddings_l2_auprc: 0.5955\n",
+            "    snv_variant_effect_cosinesim_auroc: 0.5755\n",
+            "    snv_variant_effect_cosinesim_auprc: 0.0822\n",
+            "    snv_variant_effect_prediction_masked_llr_auroc: N/A\n",
+            "    snv_variant_effect_prediction_masked_llr_auprc: N/A\n",
+            "\n",
+            "Zero-shot evaluation complete. 2/2 tasks succeeded.\n"
+          ]
+        }
+      ],
+      "source": [
+        "zero_shot_results = {}\n",
+        "\n",
+        "for task in zero_shot_tasks:\n",
+        "    try:\n",
+        "        t0 = time.time()\n",
+        "        attrs = task.get_task_attributes()\n",
+        "        print(f\"  Task: {task.get_task_name()}\")\n",
+        "        print(f\"  SNV only: {attrs.get('is_snv_only_variants', 'N/A')}\")\n",
+        "        print(f\"  Test samples: {len(task.test_dataset)}\")\n",
+        "\n",
+        "        # Evaluate directly -- Evo2BioNeMoModel implements the full GFMBench-API interface\n",
+        "        results = task.eval_test_set(evo2_model)\n",
+        "\n",
+        "        elapsed = time.time() - t0\n",
+        "        print(f\"\\n  Results ({elapsed:.1f}s):\")\n",
+        "        for metric, score in results.items():\n",
+        "            val_str = f\"{score:.4f}\" if score is not None else \"N/A\"\n",
+        "            print(f\"    {metric}: {val_str}\")\n",
+        "\n",
+        "        # Store and save incrementally\n",
+        "        zero_shot_results[task.get_task_name()] = results\n",
+        "        report.add_scores(task.get_task_name(), MODEL_NAME, results)\n",
+        "        report.save_csv()\n",
+        "\n",
+        "    except Exception as e:  # noqa: PERF203\n",
+        "        print(f\"  FAILED: {e}\")\n",
+        "        traceback.print_exc()\n",
+        "    finally:\n",
+        "        torch.cuda.empty_cache()\n",
+        "\n",
+        "print(f\"\\nZero-shot evaluation complete. {len(zero_shot_results)}/{len(zero_shot_tasks)} tasks succeeded.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "### 3.6 Supervised Evaluation via Linear Probing\n",
+        "\n",
+        "For supervised tasks, Evo2 has no built-in classification head. We perform **linear probing**:\n",
+        "\n",
+        "1. **Extract embeddings** (frozen Evo2 backbone) for every training sample\n",
+        "   - Single-seq tasks: mean-pooled embedding per sequence\n",
+        "   - Variant-pair tasks: concatenation of `[variant_repr, ref_repr, variant_repr - ref_repr]`\n",
+        "2. **Train a `LogisticRegression`** on the extracted embeddings\n",
+        "3. **Wrap** the trained head + Evo2 into a model adapter that GFMBench-API can call\n",
+        "4. **Evaluate** using the standard GFMBench-API `eval_test_set()` API\n",
+        "\n",
+        "This approach avoids any gradient-based fine-tuning of the large backbone."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-14T17:43:38.250005Z",
+          "iopub.status.busy": "2026-06-14T17:43:38.249805Z",
+          "iopub.status.idle": "2026-06-14T17:43:38.295045Z",
+          "shell.execute_reply": "2026-06-14T17:43:38.294286Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Embedding extraction and linear probing utilities defined.\n"
+          ]
+        }
+      ],
+      "source": [
+        "from sklearn.linear_model import LogisticRegression\n",
+        "from torch.utils.data import DataLoader\n",
+        "\n",
+        "\n",
+        "def extract_embeddings_single_seq(\n",
+        "    model,\n",
+        "    dataset,\n",
+        "    batch_size: int,\n",
+        ") -> Tuple[np.ndarray, np.ndarray]:\n",
+        "    \"\"\"Extract mean-pooled embeddings for single-sequence dataset.\n",
+        "\n",
+        "    Dataset items: (sequence, label, conditional_input)\n",
+        "    Returns: (embeddings [N, hidden_dim], labels [N])\n",
+        "    \"\"\"\n",
+        "    loader = DataLoader(dataset, batch_size=batch_size, shuffle=False)\n",
+        "    all_embeds, all_labels = [], []\n",
+        "\n",
+        "    for batch in tqdm(loader, desc=\"Extracting embeddings (single-seq)\"):\n",
+        "        sequences, labels, _ = batch\n",
+        "        # infer_sequence_to_sequence returns (probs, seq_embeddings, representative)\n",
+        "        _, _, representative = model.infer_sequence_to_sequence(list(sequences))\n",
+        "        all_embeds.append(representative)\n",
+        "        all_labels.append(np.array(labels))\n",
+        "\n",
+        "    return np.concatenate(all_embeds, axis=0), np.concatenate(all_labels, axis=0)\n",
+        "\n",
+        "\n",
+        "def extract_embeddings_variant_pair(\n",
+        "    model,\n",
+        "    dataset,\n",
+        "    batch_size: int,\n",
+        ") -> Tuple[np.ndarray, np.ndarray]:\n",
+        "    \"\"\"Extract embeddings for variant-pair dataset.\n",
+        "\n",
+        "    Dataset items: (variant_seq, ref_seq, label, conditional_input)\n",
+        "    Returns: (embeddings [N, 3*hidden_dim], labels [N])\n",
+        "        Embedding = [variant_repr | ref_repr | variant_repr - ref_repr]\n",
+        "    \"\"\"\n",
+        "    loader = DataLoader(dataset, batch_size=batch_size, shuffle=False)\n",
+        "    all_embeds, all_labels = [], []\n",
+        "\n",
+        "    for batch in tqdm(loader, desc=\"Extracting embeddings (variant-pair)\"):\n",
+        "        var_seqs, ref_seqs, labels, _ = batch\n",
+        "        _, _, var_repr = model.infer_sequence_to_sequence(list(var_seqs))\n",
+        "        _, _, ref_repr = model.infer_sequence_to_sequence(list(ref_seqs))\n",
+        "        # Concatenate: [var, ref, var-ref] to give the linear head richer signal\n",
+        "        combined = np.concatenate([var_repr, ref_repr, var_repr - ref_repr], axis=1)\n",
+        "        all_embeds.append(combined)\n",
+        "        all_labels.append(np.array(labels))\n",
+        "\n",
+        "    return np.concatenate(all_embeds, axis=0), np.concatenate(all_labels, axis=0)\n",
+        "\n",
+        "\n",
+        "def train_linear_probe(\n",
+        "    x_train: np.ndarray,\n",
+        "    y_train: np.ndarray,\n",
+        "    num_labels: int,\n",
+        "    max_iter: int = 5000,\n",
+        "    c: float = 1.0,\n",
+        ") -> LogisticRegression:\n",
+        "    \"\"\"Train a LogisticRegression on extracted embeddings.\"\"\"\n",
+        "    multi_class = \"multinomial\" if num_labels > 2 else \"auto\"\n",
+        "    clf = LogisticRegression(\n",
+        "        max_iter=max_iter,\n",
+        "        C=c,\n",
+        "        solver=\"lbfgs\",\n",
+        "        multi_class=multi_class,\n",
+        "        n_jobs=-1,\n",
+        "    )\n",
+        "    clf.fit(x_train, y_train)\n",
+        "    train_acc = clf.score(x_train, y_train)\n",
+        "    print(f\"  Linear probe train accuracy: {train_acc:.4f}\")\n",
+        "    return clf\n",
+        "\n",
+        "\n",
+        "print(\"Embedding extraction and linear probing utilities defined.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Model Adapter for Linear Probing\n",
+        "\n",
+        "The GFMBench-API supervised evaluation calls `infer_sequence_to_labels_probs` (single-seq tasks) or `infer_variant_ref_sequences_to_labels_probs` (variant-pair tasks) and expects `[batch, num_labels]` probability arrays.\n",
+        "\n",
+        "We wrap Evo2 + the trained `LogisticRegression` to satisfy this interface."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-14T17:43:38.298001Z",
+          "iopub.status.busy": "2026-06-14T17:43:38.297820Z",
+          "iopub.status.idle": "2026-06-14T17:43:38.305264Z",
+          "shell.execute_reply": "2026-06-14T17:43:38.304283Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Evo2LinearProbeModel adapter defined.\n"
+          ]
+        }
+      ],
+      "source": [
+        "class Evo2LinearProbeModel:\n",
+        "    \"\"\"Wraps Evo2 backbone + a trained LogisticRegression to satisfy the GFM-Bench model API.\n",
+        "\n",
+        "    For single-seq tasks:   calls infer_sequence_to_labels_probs(sequences)\n",
+        "    For variant-pair tasks:  calls infer_variant_ref_sequences_to_labels_probs(var_seqs, ref_seqs)\n",
+        "\n",
+        "    Also delegates infer_sequence_to_sequence / sequence_pos_to_prob_pos /\n",
+        "    infer_masked_sequence_to_token_probs to the underlying Evo2 model so that\n",
+        "    any zero-shot metrics that the benchmark may also compute still work.\n",
+        "    \"\"\"\n",
+        "\n",
+        "    def __init__(self, backbone, clf: LogisticRegression, is_variant_pair: bool):\n",
+        "        \"\"\"Initialize adapter with Evo2 backbone and trained linear probe.\"\"\"\n",
+        "        self.backbone = backbone\n",
+        "        self.clf = clf\n",
+        "        self.is_variant_pair = is_variant_pair\n",
+        "\n",
+        "    # --- Single-sequence classification ---\n",
+        "    def infer_sequence_to_labels_probs(\n",
+        "        self,\n",
+        "        sequences: List[str],\n",
+        "        conditional_input=None,\n",
+        "    ) -> Optional[np.ndarray]:\n",
+        "        \"\"\"Return class probabilities for single-sequence inputs.\"\"\"\n",
+        "        _, _, representative = self.backbone.infer_sequence_to_sequence(sequences)\n",
+        "        probs = self.clf.predict_proba(representative)\n",
+        "        return probs.astype(np.float32)\n",
+        "\n",
+        "    # --- Variant-pair classification ---\n",
+        "    def infer_variant_ref_sequences_to_labels_probs(\n",
+        "        self,\n",
+        "        variant_sequences: List[str],\n",
+        "        ref_sequences: List[str],\n",
+        "        conditional_input=None,\n",
+        "    ) -> Optional[np.ndarray]:\n",
+        "        \"\"\"Return class probabilities for variant/reference sequence pairs.\"\"\"\n",
+        "        _, _, var_repr = self.backbone.infer_sequence_to_sequence(variant_sequences)\n",
+        "        _, _, ref_repr = self.backbone.infer_sequence_to_sequence(ref_sequences)\n",
+        "        combined = np.concatenate([var_repr, ref_repr, var_repr - ref_repr], axis=1)\n",
+        "        probs = self.clf.predict_proba(combined)\n",
+        "        return probs.astype(np.float32)\n",
+        "\n",
+        "    # --- Delegate zero-shot methods to backbone ---\n",
+        "    def infer_sequence_to_sequence(self, sequences, conditional_input=None):\n",
+        "        \"\"\"Delegate sequence inference to the Evo2 backbone.\"\"\"\n",
+        "        return self.backbone.infer_sequence_to_sequence(sequences, conditional_input)\n",
+        "\n",
+        "    def sequence_pos_to_prob_pos(self, sequences, pos):\n",
+        "        \"\"\"Delegate position-specific probability lookup to the Evo2 backbone.\"\"\"\n",
+        "        return self.backbone.sequence_pos_to_prob_pos(sequences, pos)\n",
+        "\n",
+        "    def infer_masked_sequence_to_token_probs(\n",
+        "        self, sequences, variant_pos, variant_letters, reference_letters, conditional_input=None\n",
+        "    ):\n",
+        "        \"\"\"Delegate masked-token probability inference to the Evo2 backbone.\"\"\"\n",
+        "        return self.backbone.infer_masked_sequence_to_token_probs(\n",
+        "            sequences, variant_pos, variant_letters, reference_letters, conditional_input\n",
+        "        )\n",
+        "\n",
+        "\n",
+        "print(\"Evo2LinearProbeModel adapter defined.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Run Supervised Benchmarks\n",
+        "\n",
+        "For each supervised task:\n",
+        "1. Initialize the task (downloads data if needed)\n",
+        "2. Extract embeddings from the training set\n",
+        "3. Train a linear probe (LogisticRegression)\n",
+        "4. Wrap into `Evo2LinearProbeModel`\n",
+        "5. Run `task.eval_test_set(model)` which uses the trained head for predictions"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-14T17:43:38.307770Z",
+          "iopub.status.busy": "2026-06-14T17:43:38.307599Z",
+          "iopub.status.idle": "2026-06-14T18:26:00.004348Z",
+          "shell.execute_reply": "2026-06-14T18:26:00.003356Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "  Task: gue_splice_site\n",
+            "  Type: single-seq\n",
+            "  Num labels: 3\n",
+            "  Train samples: 36496\n",
+            "  Test samples: 4562\n",
+            "\n",
+            "  Step 1: Extracting training embeddings...\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Extracting embeddings (single-seq): 100%|██████████| 4562/4562 [02:48<00:00, 27.13it/s]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "  Embeddings shape: (36496, 1920), Labels shape: (36496,)\n",
+            "\n",
+            "  Step 2: Training linear probe...\n",
+            "  Linear probe train accuracy: 0.5877\n",
+            "\n",
+            "  Step 3: Evaluating on test set...\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Evaluating: 100%|██████████| 571/571 [00:29<00:00, 19.14it/s]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "  Results (301.6s):\n",
+            "    classification_accuracy: 0.5848\n",
+            "    classification_mcc: 0.1851\n",
+            "    classification_auroc: 0.7120\n",
+            "    classification_auprc: 0.5081\n",
+            "  Task: var_bench_coding_pathogenicity\n",
+            "  Type: variant-pair\n",
+            "  Num labels: 2\n",
+            "  Train samples: 74143\n",
+            "  Test samples: 8729\n",
+            "\n",
+            "  Step 1: Extracting training embeddings...\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Extracting embeddings (variant-pair): 100%|██████████| 9268/9268 [29:57<00:00,  5.16it/s]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "  Embeddings shape: (74143, 5760), Labels shape: (74143,)\n",
+            "\n",
+            "  Step 2: Training linear probe...\n",
+            "  Linear probe train accuracy: 0.7424\n",
+            "\n",
+            "  Step 3: Evaluating on test set...\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Evaluating: 100%|██████████| 1092/1092 [03:32<00:00,  5.13it/s]"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "  Results (2300.7s):\n",
+            "    classification_accuracy: 0.7043\n",
+            "    classification_mcc: 0.4027\n",
+            "    classification_auroc: 0.7627\n",
+            "    classification_auprc: 0.7379\n",
+            "\n",
+            "Supervised evaluation complete. 2/2 tasks succeeded.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "supervised_results = {}\n",
+        "\n",
+        "for task in supervised_tasks:\n",
+        "    try:\n",
+        "        t0 = time.time()\n",
+        "        attrs = task.get_task_attributes()\n",
+        "        is_variant = attrs[\"is_variant_effect_prediction\"]\n",
+        "        num_labels = attrs[\"num_labels\"]\n",
+        "\n",
+        "        train_dataset = task.get_finetune_dataset()\n",
+        "        if train_dataset is None:\n",
+        "            print(\"  SKIPPED: no training data available\")\n",
+        "            continue\n",
+        "\n",
+        "        print(f\"  Task: {task.get_task_name()}\")\n",
+        "        print(f\"  Type: {'variant-pair' if is_variant else 'single-seq'}\")\n",
+        "        print(f\"  Num labels: {num_labels}\")\n",
+        "        print(f\"  Train samples: {len(train_dataset)}\")\n",
+        "        print(f\"  Test samples: {len(task.test_dataset)}\")\n",
+        "\n",
+        "        # Step 1: Extract embeddings from training set\n",
+        "        print(\"\\n  Step 1: Extracting training embeddings...\")\n",
+        "        if is_variant:\n",
+        "            x_train, y_train = extract_embeddings_variant_pair(evo2_model, train_dataset, BATCH_SIZE)\n",
+        "        else:\n",
+        "            x_train, y_train = extract_embeddings_single_seq(evo2_model, train_dataset, BATCH_SIZE)\n",
+        "        print(f\"  Embeddings shape: {x_train.shape}, Labels shape: {y_train.shape}\")\n",
+        "\n",
+        "        # Step 2: Train linear probe\n",
+        "        print(\"\\n  Step 2: Training linear probe...\")\n",
+        "        clf = train_linear_probe(x_train, y_train, num_labels, LINEAR_PROBE_MAX_ITER, LINEAR_PROBE_C)\n",
+        "\n",
+        "        # Step 3: Wrap into GFMBench-API compatible model\n",
+        "        probe_model = Evo2LinearProbeModel(\n",
+        "            backbone=evo2_model,\n",
+        "            clf=clf,\n",
+        "            is_variant_pair=is_variant,\n",
+        "        )\n",
+        "\n",
+        "        # Step 4: Evaluate via GFMBench-API\n",
+        "        print(\"\\n  Step 3: Evaluating on test set...\")\n",
+        "        results = task.eval_test_set(probe_model)\n",
+        "\n",
+        "        elapsed = time.time() - t0\n",
+        "        print(f\"\\n  Results ({elapsed:.1f}s):\")\n",
+        "        for metric, score in results.items():\n",
+        "            val_str = f\"{score:.4f}\" if score is not None else \"N/A\"\n",
+        "            print(f\"    {metric}: {val_str}\")\n",
+        "\n",
+        "        # Store and save incrementally\n",
+        "        supervised_results[task.get_task_name()] = results\n",
+        "        report.add_scores(task.get_task_name(), MODEL_NAME, results)\n",
+        "        report.save_csv()\n",
+        "\n",
+        "        # Free training embeddings\n",
+        "        del x_train, y_train, clf, probe_model\n",
+        "\n",
+        "    except Exception as e:\n",
+        "        print(f\"  FAILED: {e}\")\n",
+        "        traceback.print_exc()\n",
+        "    finally:\n",
+        "        torch.cuda.empty_cache()\n",
+        "\n",
+        "print(f\"\\nSupervised evaluation complete. {len(supervised_results)}/{len(supervised_tasks)} tasks succeeded.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "### 3.7 Results Summary"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-14T18:26:00.007059Z",
+          "iopub.status.busy": "2026-06-14T18:26:00.006859Z",
+          "iopub.status.idle": "2026-06-14T18:26:00.025993Z",
+          "shell.execute_reply": "2026-06-14T18:26:00.024882Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "GFMBench-API Results for evo2_1b-8k-bf16_1.0\n",
+            "\n",
+            "Zero-shot tasks\n",
+            "======================================================================\n",
+            "Tasks: 2 | Metrics: 8\n",
+            "                              sum_probs_llr_auroc  sum_probs_llr_auprc  sequence_embeddings_cosinesim_auroc  sequence_embeddings_cosinesim_auprc  sequence_embeddings_l2_auroc  sequence_embeddings_l2_auprc  snv_variant_effect_cosinesim_auroc  snv_variant_effect_cosinesim_auprc\n",
+            "task                                                                                                                                                                                                                                                                                \n",
+            "brca1                                      0.7423               0.5332                               0.7495                               0.5426                        0.7781                        0.5773                              0.5328                              0.2221\n",
+            "bend_variant_effects_disease               0.9195               0.7422                               0.8723                               0.4737                        0.9115                        0.5955                              0.5755                              0.0822\n",
+            "\n",
+            "Supervised tasks (linear probing)\n",
+            "======================================================================\n",
+            "Tasks: 2 | Metrics: 4\n",
+            "                                classification_accuracy  classification_mcc  classification_auroc  classification_auprc\n",
+            "task                                                                                                                   \n",
+            "gue_splice_site                                  0.5848              0.1851                0.7120                0.5081\n",
+            "var_bench_coding_pathogenicity                   0.7043              0.4027                0.7627                0.7379\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "import pandas as pd\n",
+        "\n",
+        "\n",
+        "# Zero-shot and supervised tasks report different metric families; keep tables separate.\n",
+        "ZERO_SHOT_METRIC_PREFIXES = (\"sum_probs_\", \"sequence_embeddings_\", \"snv_variant_effect_\")\n",
+        "SUPERVISED_METRIC_PREFIXES = (\"classification_\",)\n",
+        "\n",
+        "\n",
+        "def _filter_metric_columns(columns, prefixes):\n",
+        "    return [c for c in columns if any(c.startswith(p) for p in prefixes)]\n",
+        "\n",
+        "\n",
+        "def _results_dict_to_table(results_dict, title, metric_prefixes=None):\n",
+        "    \"\"\"Build a wide results table from eval dicts; drop empty metric columns.\"\"\"\n",
+        "    print(f\"{title}\")\n",
+        "    print(f\"{'=' * 70}\")\n",
+        "    if not results_dict:\n",
+        "        print(\"  (no results)\\n\")\n",
+        "        return None\n",
+        "\n",
+        "    rows = [{\"task\": task, **metrics} for task, metrics in results_dict.items()]\n",
+        "    table = pd.DataFrame(rows).set_index(\"task\")\n",
+        "    table = table.apply(pd.to_numeric, errors=\"coerce\")\n",
+        "    if metric_prefixes:\n",
+        "        cols = _filter_metric_columns(table.columns, metric_prefixes)\n",
+        "        table = table[cols]\n",
+        "    table = table.dropna(axis=1, how=\"all\")\n",
+        "\n",
+        "    print(f\"Tasks: {len(table)} | Metrics: {len(table.columns)}\")\n",
+        "    print(table.round(4).to_string())\n",
+        "    print()\n",
+        "    return table\n",
+        "\n",
+        "\n",
+        "pd.set_option(\"display.max_columns\", None)\n",
+        "pd.set_option(\"display.width\", 200)\n",
+        "pd.set_option(\"display.float_format\", \"{:.4f}\".format)\n",
+        "\n",
+        "print(f\"GFMBench-API Results for {MODEL_NAME}\\n\")\n",
+        "\n",
+        "zero_shot_summary = _results_dict_to_table(\n",
+        "    zero_shot_results,\n",
+        "    \"Zero-shot tasks\",\n",
+        "    metric_prefixes=ZERO_SHOT_METRIC_PREFIXES,\n",
+        ")\n",
+        "supervised_summary = _results_dict_to_table(\n",
+        "    supervised_results,\n",
+        "    \"Supervised tasks (linear probing)\",\n",
+        "    metric_prefixes=SUPERVISED_METRIC_PREFIXES,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Key AUROC metrics at a glance (aggregated by task type)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-14T18:26:00.028698Z",
+          "iopub.status.busy": "2026-06-14T18:26:00.028486Z",
+          "iopub.status.idle": "2026-06-14T18:26:00.040397Z",
+          "shell.execute_reply": "2026-06-14T18:26:00.039387Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Aggregated AUROC for Evo2 (evo2/1b-8k-bf16:1.0)\n",
+            "\n",
+            "Zero-shot (mean AUROC)\n",
+            "======================================================================\n",
+            "                                     mean_auroc  n_tasks\n",
+            "metric                                                  \n",
+            "sum_probs_llr_auroc                      0.8309        2\n",
+            "sequence_embeddings_cosinesim_auroc      0.8109        2\n",
+            "sequence_embeddings_l2_auroc             0.8448        2\n",
+            "snv_variant_effect_cosinesim_auroc       0.5541        2\n",
+            "\n",
+            "Supervised (mean AUROC)\n",
+            "======================================================================\n",
+            "                      mean_auroc  n_tasks\n",
+            "metric                                   \n",
+            "classification_auroc      0.7374        2\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "def _print_auroc_aggregates(table, title):\n",
+        "    \"\"\"Print mean AUROC per metric (per-task values are in the cell above).\"\"\"\n",
+        "    print(f\"{title}\")\n",
+        "    print(f\"{'=' * 70}\")\n",
+        "    if table is None or table.empty:\n",
+        "        print(\"  (no results)\\n\")\n",
+        "        return\n",
+        "\n",
+        "    auroc_cols = [c for c in table.columns if \"auroc\" in c.lower()]\n",
+        "    if not auroc_cols:\n",
+        "        print(\"  (no AUROC metrics)\\n\")\n",
+        "        return\n",
+        "\n",
+        "    auroc_df = table[auroc_cols].dropna(axis=1, how=\"all\")\n",
+        "    rows = []\n",
+        "    for col in auroc_df.columns:\n",
+        "        valid = auroc_df[col].dropna()\n",
+        "        if len(valid) > 0:\n",
+        "            rows.append(\n",
+        "                {\n",
+        "                    \"metric\": col,\n",
+        "                    \"mean_auroc\": valid.mean(),\n",
+        "                    \"n_tasks\": len(valid),\n",
+        "                }\n",
+        "            )\n",
+        "    if not rows:\n",
+        "        print(\"  (no valid AUROC scores)\\n\")\n",
+        "        return\n",
+        "\n",
+        "    agg = pd.DataFrame(rows).set_index(\"metric\")\n",
+        "    print(agg.round(4).to_string())\n",
+        "    print()\n",
+        "\n",
+        "\n",
+        "print(f\"Aggregated AUROC for Evo2 ({CKPT_TAG})\\n\")\n",
+        "_print_auroc_aggregates(zero_shot_summary, \"Zero-shot (mean AUROC)\")\n",
+        "_print_auroc_aggregates(supervised_summary, \"Supervised (mean AUROC)\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "### 3.8 Export"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-14T18:26:00.043048Z",
+          "iopub.status.busy": "2026-06-14T18:26:00.042836Z",
+          "iopub.status.idle": "2026-06-14T18:26:00.049643Z",
+          "shell.execute_reply": "2026-06-14T18:26:00.048669Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Results saved to: evo2_gfmbench_results.csv\n",
+            "JSON summary saved to: evo2_gfmbench_results.json\n",
+            "\n",
+            "Done! Evaluated 4 tasks total (2 zero-shot, 2 supervised).\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Final save\n",
+        "report.save_csv()\n",
+        "print(f\"Results saved to: {RESULTS_CSV}\")\n",
+        "\n",
+        "\n",
+        "json_path = RESULTS_CSV.replace(\".csv\", \".json\")\n",
+        "json_summary = {\n",
+        "    \"model\": MODEL_NAME,\n",
+        "    \"ckpt_tag\": CKPT_TAG,\n",
+        "    \"max_seq_length\": MAX_SEQ_LENGTH,\n",
+        "    \"task_config\": TASK_CONFIG,\n",
+        "    \"zero_shot_results\": zero_shot_results,\n",
+        "    \"supervised_results\": supervised_results,\n",
+        "}\n",
+        "with open(json_path, \"w\") as f:\n",
+        "    json.dump(json_summary, f, indent=2, default=str)\n",
+        "\n",
+        "print(f\"JSON summary saved to: {json_path}\")\n",
+        "n_tasks = len(zero_shot_results) + len(supervised_results)\n",
+        "print(\n",
+        "    f\"\\nDone! Evaluated {n_tasks} tasks total \"\n",
+        "    f\"({len(zero_shot_results)} zero-shot, {len(supervised_results)} supervised).\"\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": []
     }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Cloning into 'GFMBench-api'...\n"
-     ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
     },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Installing GFMBench-API deps from /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt\n",
-      "Requirement already satisfied: numpy==1.26.4 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 2)) (1.26.4)\n",
-      "Requirement already satisfied: pandas>=1.3.3 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 3)) (2.2.3)\n",
-      "Requirement already satisfied: torch<3,>=2.0.0 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (2.8.0a0+5228986c39.nv25.6)\n",
-      "Requirement already satisfied: tqdm==4.67.3 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 5)) (4.67.3)\n",
-      "Requirement already satisfied: datasets>=2.0.0 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (4.3.0)\n",
-      "Requirement already satisfied: huggingface_hub==0.36.2 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (0.36.2)\n",
-      "Requirement already satisfied: pyfaidx==0.9.0.4 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 10)) (0.9.0.4)\n",
-      "Requirement already satisfied: pyarrow>=6.0.0 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 11)) (22.0.0)\n",
-      "Requirement already satisfied: openpyxl==3.1.5 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 12)) (3.1.5)\n",
-      "Requirement already satisfied: biopython==1.87 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 15)) (1.87)\n",
-      "Requirement already satisfied: scikit-learn==1.7.2 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 16)) (1.7.2)\n",
-      "Requirement already satisfied: filelock in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (3.18.0)\n",
-      "Requirement already satisfied: fsspec>=2023.5.0 in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (2024.12.0)\n",
-      "Requirement already satisfied: hf-xet<2.0.0,>=1.1.3 in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (1.2.0)\n",
-      "Requirement already satisfied: packaging>=20.9 in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (24.2)\n",
-      "Requirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (6.0.2)\n",
-      "Requirement already satisfied: requests in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (2.32.3)\n",
-      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (4.14.0)\n",
-      "Requirement already satisfied: et-xmlfile in /usr/local/lib/python3.12/dist-packages (from openpyxl==3.1.5->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 12)) (2.0.0)\n",
-      "Requirement already satisfied: scipy>=1.8.0 in /usr/local/lib/python3.12/dist-packages (from scikit-learn==1.7.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 16)) (1.15.3)\n",
-      "Requirement already satisfied: joblib>=1.2.0 in /usr/local/lib/python3.12/dist-packages (from scikit-learn==1.7.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 16)) (1.5.1)\n",
-      "Requirement already satisfied: threadpoolctl>=3.1.0 in /usr/local/lib/python3.12/dist-packages (from scikit-learn==1.7.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 16)) (3.6.0)\n",
-      "Requirement already satisfied: sympy>=1.13.3 in /usr/local/lib/python3.12/dist-packages (from torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (1.14.0)\n",
-      "Requirement already satisfied: networkx in /usr/local/lib/python3.12/dist-packages (from torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (3.5)\n",
-      "Requirement already satisfied: jinja2 in /usr/local/lib/python3.12/dist-packages (from torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (3.1.6)\n",
-      "Requirement already satisfied: setuptools in /usr/local/lib/python3.12/dist-packages (from torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (78.1.1)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.12/dist-packages (from pandas>=1.3.3->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 3)) (2.9.0)\n",
-      "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.12/dist-packages (from pandas>=1.3.3->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 3)) (2023.4)\n",
-      "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.12/dist-packages (from pandas>=1.3.3->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 3)) (2025.2)\n",
-      "Requirement already satisfied: dill<0.4.1,>=0.3.0 in /usr/local/lib/python3.12/dist-packages (from datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (0.4.0)\n",
-      "Requirement already satisfied: httpx<1.0.0 in /usr/local/lib/python3.12/dist-packages (from datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (0.28.1)\n",
-      "Requirement already satisfied: xxhash in /usr/local/lib/python3.12/dist-packages (from datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (3.6.0)\n",
-      "Requirement already satisfied: multiprocess<0.70.17 in /usr/local/lib/python3.12/dist-packages (from datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (0.70.16)\n",
-      "Requirement already satisfied: aiohttp!=4.0.0a0,!=4.0.0a1 in /usr/local/lib/python3.12/dist-packages (from fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (3.12.7)\n",
-      "Requirement already satisfied: anyio in /usr/local/lib/python3.12/dist-packages (from httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (4.9.0)\n",
-      "Requirement already satisfied: certifi in /usr/local/lib/python3.12/dist-packages (from httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (2025.4.26)\n",
-      "Requirement already satisfied: httpcore==1.* in /usr/local/lib/python3.12/dist-packages (from httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (1.0.9)\n",
-      "Requirement already satisfied: idna in /usr/local/lib/python3.12/dist-packages (from httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (3.10)\n",
-      "Requirement already satisfied: h11>=0.16 in /usr/local/lib/python3.12/dist-packages (from httpcore==1.*->httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (0.16.0)\n",
-      "Requirement already satisfied: aiohappyeyeballs>=2.5.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (2.6.1)\n",
-      "Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (1.3.2)\n",
-      "Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (25.3.0)\n",
-      "Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (1.6.0)\n",
-      "Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (6.4.4)\n",
-      "Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (0.3.1)\n",
-      "Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (1.20.0)\n",
-      "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.12/dist-packages (from python-dateutil>=2.8.2->pandas>=1.3.3->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 3)) (1.16.0)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.12/dist-packages (from requests->huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (3.4.2)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.12/dist-packages (from requests->huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (1.26.20)\n",
-      "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.12/dist-packages (from sympy>=1.13.3->torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (1.3.0)\n",
-      "Requirement already satisfied: sniffio>=1.1 in /usr/local/lib/python3.12/dist-packages (from anyio->httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (1.3.1)\n",
-      "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.12/dist-packages (from jinja2->torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (3.0.2)\n",
-      "GFMBENCH_PATH=/data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api\n",
-      "cwd=/data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
-      "\u001b[0m"
-     ]
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.3"
     }
-   ],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "# Clone target is relative to the notebook working directory; resolve once for stable absolute paths.\n",
-    "GFMBENCH_PATH_RELATIVE = Path(\"GFMBench-api\")\n",
-    "GFMBENCH_PATH = GFMBENCH_PATH_RELATIVE.resolve()\n",
-    "\n",
-    "# Clone only if GFMBench-api is not already present (safe to re-run the cell)\n",
-    "if not GFMBENCH_PATH.exists():\n",
-    "    os.system(\"git clone https://github.com/NVIDIA/GFMBench-api\")\n",
-    "else:\n",
-    "    print(f\"Using existing clone: {GFMBENCH_PATH}\")\n",
-    "\n",
-    "REQUIREMENTS = GFMBENCH_PATH / \"basic_requirements.txt\"\n",
-    "if not REQUIREMENTS.exists():\n",
-    "    raise FileNotFoundError(\n",
-    "        f\"{REQUIREMENTS} not found — run `git pull` in {GFMBENCH_PATH}\"\n",
-    "    )\n",
-    "print(f\"Installing GFMBench-API deps from {REQUIREMENTS}\")\n",
-    "os.system(f\"{sys.executable} -m pip install -r {REQUIREMENTS}\")\n",
-    "\n",
-    "os.environ[\"GFMBENCH_PATH\"] = str(GFMBENCH_PATH)\n",
-    "os.environ[\"PYTHONPATH\"] = str(GFMBENCH_PATH)\n",
-    "sys.path.insert(0, str(GFMBENCH_PATH))\n",
-    "\n",
-    "print(f\"GFMBENCH_PATH={GFMBENCH_PATH}\")\n",
-    "print(f\"cwd={Path.cwd()}\")"
-   ]
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "> **Note:** You can also use GFMBench-API's example script, [`usage_examples/run_benchmark.py`](https://github.com/NVIDIA/GFMBench-api/blob/main/usage_examples/run_benchmark.py) on Linux (from `$GFMBENCH_PATH`):\n",
-    ">\n",
-    "> ```bash\n",
-    "> python ./usage_examples/run_benchmark.py \\\n",
-    ">   --model Evo2 \\\n",
-    ">   --linear_prob \\\n",
-    ">   --csv_path ./evo2_gfmbench_results.csv \\\n",
-    ">   --report_algo_name evo2_run \\\n",
-    ">   --root_data_dir_path ./benchmark_data\n",
-    "> ```\n",
-    ">"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 2. Evo2 Evaluation Pipeline\n",
-    "\n",
-    "This notebook walks through the **Evo2-paper linear probing protocol** step by step: interact with GFMBench-API task modules to load supervised train/test data, extract frozen Evo2 embeddings, train `LogisticRegression` heads, and evaluate via `task.eval_test_set()`.\n",
-    "\n",
-    "Use this approach when you need full control over embedding extraction, probe training, or per-task customization."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2.1 Setup & Imports"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T15:53:54.612785Z",
-     "iopub.status.busy": "2026-06-14T15:53:54.612580Z",
-     "iopub.status.idle": "2026-06-14T15:53:56.287440Z",
-     "shell.execute_reply": "2026-06-14T15:53:56.286344Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/lib/python3.12/dist-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
-   "source": [
-    "import os\n",
-    "import time\n",
-    "import warnings\n",
-    "import logging\n",
-    "from typing import List, Optional, Tuple\n",
-    "import json\n",
-    "\n",
-    "import numpy as np\n",
-    "import torch\n",
-    "from tqdm.auto import tqdm\n",
-    "\n",
-    "warnings.filterwarnings(\"ignore\", category=FutureWarning)\n",
-    "logging.basicConfig(level=logging.INFO, format=\"%(asctime)s [%(levelname)s] %(message)s\")\n",
-    "logger = logging.getLogger(__name__)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2.2 Configuration\n",
-    "\n",
-    "Adjust these settings for your environment. Paths below are relative to the current working directory."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T15:53:56.290109Z",
-     "iopub.status.busy": "2026-06-14T15:53:56.289856Z",
-     "iopub.status.idle": "2026-06-14T15:53:56.295896Z",
-     "shell.execute_reply": "2026-06-14T15:53:56.294735Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Checkpoint tag: evo2/1b-8k-bf16:1.0\n",
-      "Model max seq: 8192 | Batch size: 8\n",
-      "Data root: benchmark_data\n",
-      "Results CSV: evo2_gfmbench_results.csv\n"
-     ]
-    }
-   ],
-   "source": [
-    "# ---------------------------------------------------------------------------\n",
-    "# Model configuration\n",
-    "# ---------------------------------------------------------------------------\n",
-    "# BioNeMo checkpoint tag — automatically downloaded + cached from NGC.\n",
-    "# Available tags:\n",
-    "#   evo2/1b-8k-bf16:1.0   — 1B params, 8K context, bf16\n",
-    "#   evo2/1b-8k:1.0         — 1B params, 8K context, fp8\n",
-    "#   evo2/7b-8k:1.0         — 7B params, 8K context\n",
-    "#   evo2/7b-1m:1.0         — 7B params, 1M context\n",
-    "# Can also be a local path to an extracted NeMo2 checkpoint directory.\n",
-    "\n",
-    "# ---------------------------------------------------------------------------\n",
-    "# Data & output paths\n",
-    "# ---------------------------------------------------------------------------\n",
-    "\n",
-    "DATA_ROOT = \"benchmark_data\"  # Downloaded benchmark datasets (relative to cwd)\n",
-    "RESULTS_CSV = \"evo2_gfmbench_results.csv\"  # Results output path (relative to cwd)\n",
-    "CKPT_TAG = \"evo2/1b-8k-bf16:1.0\"\n",
-    "\n",
-    "# ---------------------------------------------------------------------------\n",
-    "# Evaluation settings\n",
-    "# ---------------------------------------------------------------------------\n",
-    "\n",
-    "MAX_SEQ_LENGTH = 8192           # Max tokens per sequence\n",
-    "BATCH_SIZE = 8\n",
-    "MAX_NUM_SAMPLES = None          # limit the num of samples to lower number (e.g. 100) for fast runs\n",
-    "\n",
-    "# ---------------------------------------------------------------------------\n",
-    "# Linear probing settings (for supervised tasks)\n",
-    "# ---------------------------------------------------------------------------\n",
-    "\n",
-    "LINEAR_PROBE_MAX_ITER = 5000\n",
-    "LINEAR_PROBE_C = 1.0\n",
-    "\n",
-    "os.makedirs(DATA_ROOT, exist_ok=True)\n",
-    "print(f\"Checkpoint tag: {CKPT_TAG}\")\n",
-    "print(f\"Model max seq: {MAX_SEQ_LENGTH} | Batch size: {BATCH_SIZE}\")\n",
-    "print(f\"Data root: {DATA_ROOT}\")\n",
-    "print(f\"Results CSV: {RESULTS_CSV}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2.3 Load Evo2 Model via BioNeMo\n",
-    "\n",
-    "We use the **BioNeMo framework** (`bionemo-evo2`) to load Evo2. The notebook-compatible approach:\n",
-    "1. Initializes **Megatron parallel state manually** (single-GPU, no NeMo Trainer)\n",
-    "2. Creates the model from NeMo's `HYENA_MODEL_OPTIONS` / `MAMBA_MODEL_OPTIONS` configs\n",
-    "3. Loads checkpoint weights via **Megatron `dist_checkpointing`** (torch_dist format)\n",
-    "4. Registers a forward hook on `output_layer` to capture **embeddings** (hidden states before the lm_head)\n",
-    "\n",
-    "Supported architectures and sizes:\n",
-    "\n",
-    "| Config | Arch | Hidden | Layers | Seq Len |\n",
-    "|--------|------|--------|--------|---------|\n",
-    "| 1b | Hyena | 1920 | 25 | 8,192 |\n",
-    "| 7b | Hyena | 4096 | 32 | 8,192 |\n",
-    "| 7b_arc_longcontext | Hyena | 4096 | 32 | 1,048,576 |\n",
-    "| 40b | Hyena | 8192 | 50 | 8,192 |\n",
-    "| 1b_nv / 7b_nv / 40b_nv | Hyena | varies | varies | varies |\n",
-    "| hybrid_mamba_8b | Mamba | - | - | - |"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T15:53:56.298350Z",
-     "iopub.status.busy": "2026-06-14T15:53:56.298144Z",
-     "iopub.status.idle": "2026-06-14T15:54:05.653910Z",
-     "shell.execute_reply": "2026-06-14T15:54:05.652755Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-14 22:14:59,305 [INFO] The multistorageclient package is available.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Evo2BioNeMoModel class defined.\n"
-     ]
-    }
-   ],
-   "source": [
-    "from usage_examples.sanity_models.evo2_model import Evo2BioNeMoModel\n",
-    "\n",
-    "print(\"Evo2BioNeMoModel class defined.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Instantiate the model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T15:54:05.656637Z",
-     "iopub.status.busy": "2026-06-14T15:54:05.656301Z",
-     "iopub.status.idle": "2026-06-14T15:54:19.997649Z",
-     "shell.execute_reply": "2026-06-14T15:54:19.996534Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0\n",
-      "[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0\n",
-      "[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-14 22:15:07,431 [INFO] Downloading/caching checkpoint: evo2/1b-8k-bf16:1.0\n",
-      "Using cached path='/root/.cache/bionemo/ea4a3f5c9c26d5edc10bdc85165c090ad0ff23ac2670d4f61244f5f0d9d5e817-nemo2_evo2_1b_8k_bf16.tar.gz.untar' from checked=PosixPath('/root/.cache/bionemo/ea4a3f5c9c26d5edc10bdc85165c090ad0ff23ac2670d4f61244f5f0d9d5e817-nemo2_evo2_1b_8k_bf16.tar.gz.checked')\n",
-      "2026-06-14 22:15:07,446 [INFO] Checkpoint root: /root/.cache/bionemo/ea4a3f5c9c26d5edc10bdc85165c090ad0ff23ac2670d4f61244f5f0d9d5e817-nemo2_evo2_1b_8k_bf16.tar.gz.untar\n",
-      "2026-06-14 22:15:08,593 [INFO] Note: detected 256 virtual cores but NumExpr set to maximum of 64, check \"NUMEXPR_MAX_THREADS\" environment variable.\n",
-      "2026-06-14 22:15:08,594 [INFO] Note: NumExpr detected 256 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 16.\n",
-      "2026-06-14 22:15:08,595 [INFO] NumExpr defaulting to 16 threads.\n",
-      "Import of quick_gelu from megatron.core.fusions.fused_bias_geglu failed with: Traceback (most recent call last):\n",
-      "  File \"/usr/local/lib/python3.12/dist-packages/nemo/utils/import_utils.py\", line 319, in safe_import_from\n",
-      "    return getattr(imported_module, symbol), True\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "AttributeError: module 'megatron.core.fusions.fused_bias_geglu' has no attribute 'quick_gelu'\n",
-      "\n",
-      "2026-06-14 22:15:10,263 [INFO] Import of quick_gelu from megatron.core.fusions.fused_bias_geglu failed with: Traceback (most recent call last):\n",
-      "  File \"/usr/local/lib/python3.12/dist-packages/nemo/utils/import_utils.py\", line 319, in safe_import_from\n",
-      "    return getattr(imported_module, symbol), True\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "AttributeError: module 'megatron.core.fusions.fused_bias_geglu' has no attribute 'quick_gelu'\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[NeMo I 2026-06-14 22:15:10 nemo_logging:393] Padded vocab_size: 512, original vocab_size: 512, dummy tokens: 0.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-14 22:15:11,201 [INFO] Using hybrid override pattern\n",
-      "2026-06-14 22:15:11,202 [INFO] Hybrid allocation (S is hyena_short_conv, D is hyena_medium_conv, H is hyena, * is attention, \n",
-      "2026-06-14 22:15:11,202 [INFO] SDH*SDHSDH*SDHSDH*SDHSDH*\n",
-      "2026-06-14 22:15:11,203 [INFO] 7 heyna_short_conv layers in 25 total layers.\n",
-      "2026-06-14 22:15:11,204 [INFO] 7 heyna_medium_conv layers in 25 total layers.\n",
-      "2026-06-14 22:15:11,205 [INFO] 7 heyna layers in 25 total layers.\n",
-      "2026-06-14 22:15:11,206 [INFO] 4 attention layers in 25 total layers.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[NeMo I 2026-06-14 22:15:11 nemo_logging:393] Using byte-level tokenization\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-14 22:15:11,440 [INFO] Model created: 1,108,204,800 parameters, hidden=1920\n",
-      "2026-06-14 22:15:14,001 [INFO] Checkpoint loaded successfully\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Loaded in 6.8s\n",
-      "  Hidden dim:  1920\n",
-      "  Max length:  8192\n",
-      "\n",
-      "Sanity check - infer_sequence_to_sequence:\n",
-      "  token_probs shape:     (2, 16)\n",
-      "  seq_embeddings shape:  (2, 16, 1920)\n",
-      "  representative shape:  (2, 1920)\n",
-      "  token_probs range:     [0.0000, 0.9951]\n",
-      "  representative norm:   [22.061846 17.920654]\n",
-      "\n",
-      "infer_variant_ref_sequences_to_labels_probs:\n",
-      "  output shape: (1, 2)\n",
-      "  probs:        [[0.00686961 0.9931304 ]]\n",
-      "  probs sum:    1.000000\n"
-     ]
-    }
-   ],
-   "source": [
-    "t0 = time.time()\n",
-    "evo2_model = Evo2BioNeMoModel(\n",
-    "    ckpt_tag=CKPT_TAG,\n",
-    "    max_length=MAX_SEQ_LENGTH,\n",
-    ")\n",
-    "elapsed = time.time() - t0\n",
-    "print(f\"\\nLoaded in {elapsed:.1f}s\")\n",
-    "print(f\"  Hidden dim:  {evo2_model.hidden_dim}\")\n",
-    "print(f\"  Max length:  {evo2_model.max_length}\")\n",
-    "\n",
-    "# Quick sanity check\n",
-    "test_seqs = [\"ACGTACGTACGTACGT\", \"NNNNACGTACGTNNNN\"]\n",
-    "probs, embeddings, representative = evo2_model.infer_sequence_to_sequence(test_seqs)\n",
-    "\n",
-    "print(f\"\\nSanity check - infer_sequence_to_sequence:\")\n",
-    "print(f\"  token_probs shape:     {probs.shape}\")\n",
-    "print(f\"  seq_embeddings shape:  {embeddings.shape if embeddings is not None else 'None'}\")\n",
-    "print(f\"  representative shape:  {representative.shape if representative is not None else 'None'}\")\n",
-    "print(f\"  token_probs range:     [{probs.min():.4f}, {probs.max():.4f}]\")\n",
-    "if representative is not None:\n",
-    "    print(f\"  representative norm:   {np.linalg.norm(representative, axis=1)}\")\n",
-    "\n",
-    "# Verify variant scoring\n",
-    "var_probs = evo2_model.infer_variant_ref_sequences_to_labels_probs(\n",
-    "    variant_sequences=[\"ACGTACGTACGTACGT\"],\n",
-    "    ref_sequences=[\"ACGTACGAACGTACGT\"],\n",
-    ")\n",
-    "print(f\"\\ninfer_variant_ref_sequences_to_labels_probs:\")\n",
-    "print(f\"  output shape: {var_probs.shape}\")\n",
-    "print(f\"  probs:        {var_probs}\")\n",
-    "print(f\"  probs sum:    {var_probs.sum():.6f}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T15:54:20.000605Z",
-     "iopub.status.busy": "2026-06-14T15:54:20.000002Z",
-     "iopub.status.idle": "2026-06-14T15:54:20.032389Z",
-     "shell.execute_reply": "2026-06-14T15:54:20.031626Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Benchmark report initialized: evo2_gfmbench_results.csv\n",
-      "Model name for reporting: evo2_1b-8k-bf16_1.0\n",
-      "TASK_CONFIG: {'max_sequence_length': 8192, 'batch_size': 8, 'max_num_samples': None, 'disable_safe_model_call': True}\n"
-     ]
-    }
-   ],
-   "source": [
-    "from gfmbench_api.benchmark_report.benchmark_report import BenchmarkReport\n",
-    "\n",
-    "# Common task config (passed to every GFMBench-API task constructor)\n",
-    "TASK_CONFIG = {\n",
-    "    # Extraction window: min(task_default, this value). Keep well below MAX_SEQ_LENGTH\n",
-    "    # to avoid quadratic attention OOM at large batch sizes.\n",
-    "    \"max_sequence_length\": MAX_SEQ_LENGTH,\n",
-    "    \"batch_size\": BATCH_SIZE,\n",
-    "    \"max_num_samples\": MAX_NUM_SAMPLES,\n",
-    "    # Fail fast while validating this recipe. If this is False, GFMBench-API\n",
-    "    # converts model-interface exceptions into None outputs and metrics become N/A.\n",
-    "    \"disable_safe_model_call\": True,\n",
-    "}\n",
-    "\n",
-    "MODEL_NAME = CKPT_TAG.replace(\"/\", \"_\").replace(\":\", \"_\")\n",
-    "\n",
-    "# Initialize the benchmark report (loads existing CSV if present)\n",
-    "report = BenchmarkReport(csv_path=RESULTS_CSV)\n",
-    "print(f\"Benchmark report initialized: {RESULTS_CSV}\")\n",
-    "print(f\"Model name for reporting: {MODEL_NAME}\")\n",
-    "print(f\"TASK_CONFIG: {TASK_CONFIG}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Define Benchmark Tasks\n",
-    "\n",
-    "Choose which GFMBench-API tasks to evaluate in the cell below. **Uncomment the tasks you want to run** in `zero_shot_tasks` and/or `supervised_tasks`.\n",
-    "\n",
-    "Each enabled task is instantiated when you run that cell, which may download and cache datasets under `DATA_ROOT` on the first run. Later runs reuse the cache.\n",
-    "\n",
-    "**Note:** First-time downloads (reference genomes, HuggingFace datasets, parquet files, etc.) can take several minutes to tens of minutes per task, depending on network speed and how many tasks are enabled."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T15:54:20.034675Z",
-     "iopub.status.busy": "2026-06-14T15:54:20.034511Z",
-     "iopub.status.idle": "2026-06-14T15:56:55.564347Z",
-     "shell.execute_reply": "2026-06-14T15:56:55.563477Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BRCA1 dataset or reference genome not found. Downloading...\n",
-      "Downloading and processing BRCA1 dataset...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-14 22:15:21,588 [INFO] Downloading from: https://github.com/ArcInstitute/evo2/raw/refs/heads/main/notebooks/brca1/GRCh37.p13_chr17.fna.gz\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   chrom       pos ref alt     score  label\n",
-      "0     17  41276135   T   G -0.372611      1\n",
-      "1     17  41276135   T   C -0.045313      1\n",
-      "2     17  41276135   T   A -0.108254      1\n",
-      "3     17  41276134   T   G -0.277963      1\n",
-      "4     17  41276134   T   C -0.388414      1\n",
-      "Saved BRCA1 DMS dataset with 3893 variants to parquet.\n",
-      "Downloading reference genome...\n",
-      "  Progress: 100.0% (23.2 MB)\n",
-      "Unzipping and normalizing FASTA header...\n",
-      "Reference genome ready: benchmark_data/brca1/GRCh37.p13_chr17.fna\n",
-      "Successfully downloaded BRCA1 dataset and reference to benchmark_data/brca1\n",
-      "Loading reference genome: benchmark_data/brca1/GRCh37.p13_chr17.fna\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-14 22:15:24,742 [INFO] Reference genome not found. Downloading hg38.fa...\n",
-      "2026-06-14 22:15:24,743 [INFO] Downloading reference genome hg38.fa (~3GB)...\n",
-      "2026-06-14 22:15:24,743 [INFO] Source: https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.fa.gz\n",
-      "2026-06-14 22:15:24,744 [INFO] This may take several minutes...\n",
-      "2026-06-14 22:15:24,745 [INFO] Downloading from: https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.fa.gz\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Extracting sequences (window size: 8192bp)...\n",
-      "Successfully extracted 3893 sequence pairs\n",
-      "  Progress: 100.0% (983.7 MB)"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-14 22:16:37,649 [INFO] Extracting hg38.fa.gz...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-14 22:16:55,504 [INFO] Reference genome saved to: benchmark_data/reference_genome/hg38.fa\n",
-      "2026-06-14 22:16:55,505 [INFO] Loading reference genome: benchmark_data/reference_genome/hg38.fa\n",
-      "2026-06-14 22:17:18,046 [INFO] Downloading bend_variant_effects_disease from BEND repository...\n",
-      "2026-06-14 22:17:18,048 [INFO] Downloading from: https://sid.erda.dk/share_redirect/aNQa0Oz2lY/data/variant_effects/variant_effects_disease.bed\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Progress: 100.0% (20.4 MB)"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-14 22:17:19,675 [INFO] Data saved to: benchmark_data/bend_variant_effects_disease\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-14 22:17:19,909 [INFO] Extracting sequences (window size: 512bp)...\n",
-      "2026-06-14 22:17:36,816 [INFO] Successfully extracted 295495 sequence pairs\n",
-      "2026-06-14 22:17:37,884 [INFO] Downloading gue_splice_site from HuggingFace...\n",
-      "2026-06-14 22:17:37,887 [INFO] Dataset not found locally, downloading\n",
-      "Saving the dataset (1/1 shards): 100%|██████████| 36496/36496 [00:00<00:00, 1763317.08 examples/s]\n",
-      "Saving the dataset (1/1 shards): 100%|██████████| 4562/4562 [00:00<00:00, 887866.68 examples/s] \n",
-      "Saving the dataset (1/1 shards): 100%|██████████| 4562/4562 [00:00<00:00, 899850.21 examples/s] \n",
-      "2026-06-14 22:17:41,539 [INFO] Data saved to: benchmark_data/gue_splice_site\n",
-      "2026-06-14 22:17:41,770 [INFO] GUE: wrote benchmark_data/gue_splice_site/train.csv from HuggingFace split 'train'\n",
-      "2026-06-14 22:17:41,797 [INFO] GUE: wrote benchmark_data/gue_splice_site/dev.csv from HuggingFace split 'dev'\n",
-      "2026-06-14 22:17:41,825 [INFO] GUE: wrote benchmark_data/gue_splice_site/test.csv from HuggingFace split 'test'\n",
-      "2026-06-14 22:17:42,458 [INFO] Downloading var_bench_coding_pathogenicity from HuggingFace...\n",
-      "2026-06-14 22:17:42,459 [INFO] Dataset not found locally, downloading\n",
-      "Saving the dataset (1/1 shards): 100%|██████████| 82872/82872 [00:00<00:00, 290897.37 examples/s]\n",
-      "2026-06-14 22:17:45,945 [INFO] Data saved to: benchmark_data/var_bench_coding_pathogenicity\n",
-      "Filter: 100%|██████████| 82872/82872 [00:00<00:00, 127208.08 examples/s]\n",
-      "Filter: 100%|██████████| 82872/82872 [00:00<00:00, 132380.18 examples/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Zero-shot tasks enabled: 2\n",
-      "  - brca1\n",
-      "  - bend_variant_effects_disease\n",
-      "Supervised tasks enabled: 2\n",
-      "  - gue_splice_site\n",
-      "  - var_bench_coding_pathogenicity\n"
-     ]
-    }
-   ],
-   "source": [
-    "from gfmbench_api.tasks.concrete.bend_vep_disease_task import BendVEPDisease\n",
-    "from gfmbench_api.tasks.concrete.bend_vep_expression_task import BendVEPExpression\n",
-    "from gfmbench_api.tasks.concrete.brca1_task import BRCA1Task\n",
-    "from gfmbench_api.tasks.concrete.clinvar_indel_task import IndelClinvarTask\n",
-    "from gfmbench_api.tasks.concrete.gue_promoter_all_task import GuePromoterAllTask\n",
-    "from gfmbench_api.tasks.concrete.gue_splice_site_task import GueSpliceSiteTask\n",
-    "from gfmbench_api.tasks.concrete.gue_tf_all_task import GueTranscriptionFactorTask\n",
-    "from gfmbench_api.tasks.concrete.lrb_causal_eqtl_task import LRBCausalEqtlTask\n",
-    "from gfmbench_api.tasks.concrete.lrb_pathogenic_omim_task import LrbVariantEffectPathogenicOmimTask\n",
-    "from gfmbench_api.tasks.concrete.loleve_causal_eqtl_task import LoleveCausalEqtlTask\n",
-    "from gfmbench_api.tasks.concrete.songlab_clinvar_task import SonglabClinvarTask\n",
-    "from gfmbench_api.tasks.concrete.traitgym_complex_task import TraitGymComplexTask\n",
-    "from gfmbench_api.tasks.concrete.traitgym_mendelian_task import TraitGymMendelianTask\n",
-    "from gfmbench_api.tasks.concrete.variant_benchmarks_coding_task import VariantBenchmarksCodingTask\n",
-    "from gfmbench_api.tasks.concrete.variant_benchmarks_common_vs_rare_task import VariantBenchmarksCommonVsRareTask\n",
-    "from gfmbench_api.tasks.concrete.variant_benchmarks_expression_task import VariantBenchmarksExpressionTask\n",
-    "from gfmbench_api.tasks.concrete.variant_benchmarks_meqtl_task import VariantBenchmarksMEQTLTask\n",
-    "from gfmbench_api.tasks.concrete.variant_benchmarks_non_coding_task import VariantBenchmarksNonCodingTask\n",
-    "from gfmbench_api.tasks.concrete.variant_benchmarks_sqtl_task import VariantBenchmarksSQTLTask\n",
-    "\n",
-    "# ---------------------------------------------------------------------------\n",
-    "# Zero-shot tasks (no training — model runs inference directly)\n",
-    "# ---------------------------------------------------------------------------\n",
-    "# Uncomment the tasks you want to run.\n",
-    "\n",
-    "zero_shot_tasks = [\n",
-    "    # IndelClinvarTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                    # ClinVar indels\n",
-    "    # LoleveCausalEqtlTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                # Causal eQTL indels\n",
-    "    BRCA1Task(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                           # BRCA1 functional impact (SNV)\n",
-    "    BendVEPDisease(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                        # SNV disease effects\n",
-    "    # BendVEPExpression(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                   # SNV expression effects\n",
-    "    # SonglabClinvarTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                  # ClinVar SNV (likelihood)\n",
-    "    # TraitGymComplexTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                 # Complex trait variants\n",
-    "    # TraitGymMendelianTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),               # Mendelian disease variants\n",
-    "    # LrbVariantEffectPathogenicOmimTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),  # OMIM pathogenic variants\n",
-    "]\n",
-    "\n",
-    "# ---------------------------------------------------------------------------\n",
-    "# Supervised tasks (linear probing — extract embeddings, train a classifier head)\n",
-    "# ---------------------------------------------------------------------------\n",
-    "# Uncomment the tasks you want to run.\n",
-    "\n",
-    "supervised_tasks = [\n",
-    "    # GueTranscriptionFactorTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),          # TF binding (single-seq, binary)\n",
-    "    # GuePromoterAllTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                  # Promoter prediction (single-seq, binary)\n",
-    "    GueSpliceSiteTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                   # Splice site (single-seq, 3-class)\n",
-    "    VariantBenchmarksCodingTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),         # Coding variant pathogenicity\n",
-    "    # VariantBenchmarksNonCodingTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),      # Non-coding variant pathogenicity\n",
-    "    # VariantBenchmarksExpressionTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),     # Expression-affecting variants\n",
-    "    # VariantBenchmarksCommonVsRareTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),   # Common vs rare variants\n",
-    "    # VariantBenchmarksMEQTLTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),          # Methylation eQTL variants\n",
-    "    # VariantBenchmarksSQTLTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),           # Splicing eQTL variants\n",
-    "    # LRBCausalEqtlTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                   # Causal eQTL (with tissue metadata)\n",
-    "]\n",
-    "\n",
-    "print(f\"Zero-shot tasks enabled: {len(zero_shot_tasks)}\")\n",
-    "for task in zero_shot_tasks:\n",
-    "    print(f\"  - {task.get_task_name()}\")\n",
-    "print(f\"Supervised tasks enabled: {len(supervised_tasks)}\")\n",
-    "for task in supervised_tasks:\n",
-    "    print(f\"  - {task.get_task_name()}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "### 2.5 Zero-Shot Evaluation\n",
-    "\n",
-    "For zero-shot tasks, we pass the `Evo2BioNeMoModel` directly to GFMBench-API. The benchmark calls:\n",
-    "- `infer_sequence_to_sequence(sequences)` -> `(token_probs, seq_embeddings, representative)`\n",
-    "- Computes LLR, cosine similarity, and L2 distance metrics automatically\n",
-    "- For SNV tasks, also calls `sequence_pos_to_prob_pos`\n",
-    "\n",
-    "No training is needed -- the model's pre-trained representations are evaluated as-is."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T15:56:55.567399Z",
-     "iopub.status.busy": "2026-06-14T15:56:55.567180Z",
-     "iopub.status.idle": "2026-06-14T17:43:38.247242Z",
-     "shell.execute_reply": "2026-06-14T17:43:38.246388Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Task: brca1\n",
-      "  SNV only: True\n",
-      "  Test samples: 3893\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Evaluating (Zero-Shot):   0%|          | 0/487 [00:00<?, ?it/s]2026-06-14 22:17:54,870 [WARNING] Model did not provide required inputs for 'snv_variant_effect_prediction_masked_llr_auroc' metric. This metric will return None.\n",
-      "2026-06-14 22:17:54,871 [WARNING] Model did not provide required inputs for 'snv_variant_effect_prediction_masked_llr_auprc' metric. This metric will return None.\n",
-      "Evaluating (Zero-Shot): 100%|██████████| 487/487 [18:24<00:00,  2.27s/it]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "  Results (1109.0s):\n",
-      "    sum_probs_llr_auroc: 0.7423\n",
-      "    sum_probs_llr_auprc: 0.5332\n",
-      "    sequence_embeddings_cosinesim_auroc: 0.7495\n",
-      "    sequence_embeddings_cosinesim_auprc: 0.5426\n",
-      "    sequence_embeddings_l2_auroc: 0.7781\n",
-      "    sequence_embeddings_l2_auprc: 0.5773\n",
-      "    snv_variant_effect_cosinesim_auroc: 0.5328\n",
-      "    snv_variant_effect_cosinesim_auprc: 0.2221\n",
-      "    snv_variant_effect_prediction_masked_llr_auroc: N/A\n",
-      "    snv_variant_effect_prediction_masked_llr_auprc: N/A\n",
-      "  Task: bend_variant_effects_disease\n",
-      "  SNV only: True\n",
-      "  Test samples: 295495\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Evaluating (Zero-Shot):   0%|          | 0/36937 [00:00<?, ?it/s]2026-06-14 22:36:21,823 [WARNING] Model did not provide required inputs for 'snv_variant_effect_prediction_masked_llr_auroc' metric. This metric will return None.\n",
-      "2026-06-14 22:36:21,823 [WARNING] Model did not provide required inputs for 'snv_variant_effect_prediction_masked_llr_auprc' metric. This metric will return None.\n",
-      "Evaluating (Zero-Shot): 100%|██████████| 36937/36937 [1:26:49<00:00,  7.09it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "  Results (5213.1s):\n",
-      "    sum_probs_llr_auroc: 0.9195\n",
-      "    sum_probs_llr_auprc: 0.7422\n",
-      "    sequence_embeddings_cosinesim_auroc: 0.8723\n",
-      "    sequence_embeddings_cosinesim_auprc: 0.4737\n",
-      "    sequence_embeddings_l2_auroc: 0.9115\n",
-      "    sequence_embeddings_l2_auprc: 0.5955\n",
-      "    snv_variant_effect_cosinesim_auroc: 0.5755\n",
-      "    snv_variant_effect_cosinesim_auprc: 0.0822\n",
-      "    snv_variant_effect_prediction_masked_llr_auroc: N/A\n",
-      "    snv_variant_effect_prediction_masked_llr_auprc: N/A\n",
-      "\n",
-      "Zero-shot evaluation complete. 2/2 tasks succeeded.\n"
-     ]
-    }
-   ],
-   "source": [
-    "zero_shot_results = {}\n",
-    "\n",
-    "for task in zero_shot_tasks:\n",
-    "    try:\n",
-    "        t0 = time.time()\n",
-    "        attrs = task.get_task_attributes()\n",
-    "        print(f\"  Task: {task.get_task_name()}\")\n",
-    "        print(f\"  SNV only: {attrs.get('is_snv_only_variants', 'N/A')}\")\n",
-    "        print(f\"  Test samples: {len(task.test_dataset)}\")\n",
-    "\n",
-    "        # Evaluate directly -- Evo2BioNeMoModel implements the full GFMBench-API interface\n",
-    "        results = task.eval_test_set(evo2_model)\n",
-    "\n",
-    "        elapsed = time.time() - t0\n",
-    "        print(f\"\\n  Results ({elapsed:.1f}s):\")\n",
-    "        for metric, score in results.items():\n",
-    "            val_str = f\"{score:.4f}\" if score is not None else \"N/A\"\n",
-    "            print(f\"    {metric}: {val_str}\")\n",
-    "\n",
-    "        # Store and save incrementally\n",
-    "        zero_shot_results[task.get_task_name()] = results\n",
-    "        report.add_scores(task.get_task_name(), MODEL_NAME, results)\n",
-    "        report.save_csv()\n",
-    "\n",
-    "    except Exception as e:\n",
-    "        print(f\"  FAILED: {e}\")\n",
-    "        import traceback; traceback.print_exc()\n",
-    "    finally:\n",
-    "        torch.cuda.empty_cache()\n",
-    "\n",
-    "print(f\"\\nZero-shot evaluation complete. {len(zero_shot_results)}/{len(zero_shot_tasks)} tasks succeeded.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "### 3.6 Supervised Evaluation via Linear Probing\n",
-    "\n",
-    "For supervised tasks, Evo2 has no built-in classification head. We perform **linear probing**:\n",
-    "\n",
-    "1. **Extract embeddings** (frozen Evo2 backbone) for every training sample\n",
-    "   - Single-seq tasks: mean-pooled embedding per sequence\n",
-    "   - Variant-pair tasks: concatenation of `[variant_repr, ref_repr, variant_repr - ref_repr]`\n",
-    "2. **Train a `LogisticRegression`** on the extracted embeddings\n",
-    "3. **Wrap** the trained head + Evo2 into a model adapter that GFMBench-API can call\n",
-    "4. **Evaluate** using the standard GFMBench-API `eval_test_set()` API\n",
-    "\n",
-    "This approach avoids any gradient-based fine-tuning of the large backbone."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T17:43:38.250005Z",
-     "iopub.status.busy": "2026-06-14T17:43:38.249805Z",
-     "iopub.status.idle": "2026-06-14T17:43:38.295045Z",
-     "shell.execute_reply": "2026-06-14T17:43:38.294286Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Embedding extraction and linear probing utilities defined.\n"
-     ]
-    }
-   ],
-   "source": [
-    "from sklearn.linear_model import LogisticRegression\n",
-    "from torch.utils.data import DataLoader\n",
-    "\n",
-    "\n",
-    "def extract_embeddings_single_seq(\n",
-    "    model,\n",
-    "    dataset,\n",
-    "    batch_size: int,\n",
-    ") -> Tuple[np.ndarray, np.ndarray]:\n",
-    "    \"\"\"Extract mean-pooled embeddings for single-sequence dataset.\n",
-    "\n",
-    "    Dataset items: (sequence, label, conditional_input)\n",
-    "    Returns: (embeddings [N, hidden_dim], labels [N])\n",
-    "    \"\"\"\n",
-    "    loader = DataLoader(dataset, batch_size=batch_size, shuffle=False)\n",
-    "    all_embeds, all_labels = [], []\n",
-    "\n",
-    "    for batch in tqdm(loader, desc=\"Extracting embeddings (single-seq)\"):\n",
-    "        sequences, labels, _ = batch\n",
-    "        # infer_sequence_to_sequence returns (probs, seq_embeddings, representative)\n",
-    "        _, _, representative = model.infer_sequence_to_sequence(list(sequences))\n",
-    "        all_embeds.append(representative)\n",
-    "        all_labels.append(np.array(labels))\n",
-    "\n",
-    "    return np.concatenate(all_embeds, axis=0), np.concatenate(all_labels, axis=0)\n",
-    "\n",
-    "\n",
-    "def extract_embeddings_variant_pair(\n",
-    "    model,\n",
-    "    dataset,\n",
-    "    batch_size: int,\n",
-    ") -> Tuple[np.ndarray, np.ndarray]:\n",
-    "    \"\"\"Extract embeddings for variant-pair dataset.\n",
-    "\n",
-    "    Dataset items: (variant_seq, ref_seq, label, conditional_input)\n",
-    "    Returns: (embeddings [N, 3*hidden_dim], labels [N])\n",
-    "        Embedding = [variant_repr | ref_repr | variant_repr - ref_repr]\n",
-    "    \"\"\"\n",
-    "    loader = DataLoader(dataset, batch_size=batch_size, shuffle=False)\n",
-    "    all_embeds, all_labels = [], []\n",
-    "\n",
-    "    for batch in tqdm(loader, desc=\"Extracting embeddings (variant-pair)\"):\n",
-    "        var_seqs, ref_seqs, labels, _ = batch\n",
-    "        _, _, var_repr = model.infer_sequence_to_sequence(list(var_seqs))\n",
-    "        _, _, ref_repr = model.infer_sequence_to_sequence(list(ref_seqs))\n",
-    "        # Concatenate: [var, ref, var-ref] to give the linear head richer signal\n",
-    "        combined = np.concatenate([var_repr, ref_repr, var_repr - ref_repr], axis=1)\n",
-    "        all_embeds.append(combined)\n",
-    "        all_labels.append(np.array(labels))\n",
-    "\n",
-    "    return np.concatenate(all_embeds, axis=0), np.concatenate(all_labels, axis=0)\n",
-    "\n",
-    "\n",
-    "def train_linear_probe(\n",
-    "    X_train: np.ndarray,\n",
-    "    y_train: np.ndarray,\n",
-    "    num_labels: int,\n",
-    "    max_iter: int = 5000,\n",
-    "    C: float = 1.0,\n",
-    ") -> LogisticRegression:\n",
-    "    \"\"\"Train a LogisticRegression on extracted embeddings.\"\"\"\n",
-    "    multi_class = \"multinomial\" if num_labels > 2 else \"auto\"\n",
-    "    clf = LogisticRegression(\n",
-    "        max_iter=max_iter,\n",
-    "        C=C,\n",
-    "        solver=\"lbfgs\",\n",
-    "        multi_class=multi_class,\n",
-    "        n_jobs=-1,\n",
-    "    )\n",
-    "    clf.fit(X_train, y_train)\n",
-    "    train_acc = clf.score(X_train, y_train)\n",
-    "    print(f\"  Linear probe train accuracy: {train_acc:.4f}\")\n",
-    "    return clf\n",
-    "\n",
-    "\n",
-    "print(\"Embedding extraction and linear probing utilities defined.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Model Adapter for Linear Probing\n",
-    "\n",
-    "The GFMBench-API supervised evaluation calls `infer_sequence_to_labels_probs` (single-seq tasks) or `infer_variant_ref_sequences_to_labels_probs` (variant-pair tasks) and expects `[batch, num_labels]` probability arrays.\n",
-    "\n",
-    "We wrap Evo2 + the trained `LogisticRegression` to satisfy this interface."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T17:43:38.298001Z",
-     "iopub.status.busy": "2026-06-14T17:43:38.297820Z",
-     "iopub.status.idle": "2026-06-14T17:43:38.305264Z",
-     "shell.execute_reply": "2026-06-14T17:43:38.304283Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Evo2LinearProbeModel adapter defined.\n"
-     ]
-    }
-   ],
-   "source": [
-    "class Evo2LinearProbeModel:\n",
-    "    \"\"\"Wraps Evo2 backbone + a trained LogisticRegression to satisfy the GFM-Bench model API.\n",
-    "\n",
-    "    For single-seq tasks:   calls infer_sequence_to_labels_probs(sequences)\n",
-    "    For variant-pair tasks:  calls infer_variant_ref_sequences_to_labels_probs(var_seqs, ref_seqs)\n",
-    "\n",
-    "    Also delegates infer_sequence_to_sequence / sequence_pos_to_prob_pos /\n",
-    "    infer_masked_sequence_to_token_probs to the underlying Evo2 model so that\n",
-    "    any zero-shot metrics that the benchmark may also compute still work.\n",
-    "    \"\"\"\n",
-    "\n",
-    "    def __init__(self, backbone, clf: LogisticRegression, is_variant_pair: bool):\n",
-    "        self.backbone = backbone\n",
-    "        self.clf = clf\n",
-    "        self.is_variant_pair = is_variant_pair\n",
-    "\n",
-    "    # --- Single-sequence classification ---\n",
-    "    def infer_sequence_to_labels_probs(\n",
-    "        self, sequences: List[str], conditional_input=None,\n",
-    "    ) -> Optional[np.ndarray]:\n",
-    "        _, _, representative = self.backbone.infer_sequence_to_sequence(sequences)\n",
-    "        probs = self.clf.predict_proba(representative)\n",
-    "        return probs.astype(np.float32)\n",
-    "\n",
-    "    # --- Variant-pair classification ---\n",
-    "    def infer_variant_ref_sequences_to_labels_probs(\n",
-    "        self, variant_sequences: List[str], ref_sequences: List[str], conditional_input=None,\n",
-    "    ) -> Optional[np.ndarray]:\n",
-    "        _, _, var_repr = self.backbone.infer_sequence_to_sequence(variant_sequences)\n",
-    "        _, _, ref_repr = self.backbone.infer_sequence_to_sequence(ref_sequences)\n",
-    "        combined = np.concatenate([var_repr, ref_repr, var_repr - ref_repr], axis=1)\n",
-    "        probs = self.clf.predict_proba(combined)\n",
-    "        return probs.astype(np.float32)\n",
-    "\n",
-    "    # --- Delegate zero-shot methods to backbone ---\n",
-    "    def infer_sequence_to_sequence(self, sequences, conditional_input=None):\n",
-    "        return self.backbone.infer_sequence_to_sequence(sequences, conditional_input)\n",
-    "\n",
-    "    def sequence_pos_to_prob_pos(self, sequences, pos):\n",
-    "        return self.backbone.sequence_pos_to_prob_pos(sequences, pos)\n",
-    "\n",
-    "    def infer_masked_sequence_to_token_probs(self, sequences, variant_pos, variant_letters, reference_letters, conditional_input=None):\n",
-    "        return self.backbone.infer_masked_sequence_to_token_probs(sequences, variant_pos, variant_letters, reference_letters, conditional_input)\n",
-    "\n",
-    "\n",
-    "print(\"Evo2LinearProbeModel adapter defined.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Run Supervised Benchmarks\n",
-    "\n",
-    "For each supervised task:\n",
-    "1. Initialize the task (downloads data if needed)\n",
-    "2. Extract embeddings from the training set\n",
-    "3. Train a linear probe (LogisticRegression)\n",
-    "4. Wrap into `Evo2LinearProbeModel`\n",
-    "5. Run `task.eval_test_set(model)` which uses the trained head for predictions"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T17:43:38.307770Z",
-     "iopub.status.busy": "2026-06-14T17:43:38.307599Z",
-     "iopub.status.idle": "2026-06-14T18:26:00.004348Z",
-     "shell.execute_reply": "2026-06-14T18:26:00.003356Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Task: gue_splice_site\n",
-      "  Type: single-seq\n",
-      "  Num labels: 3\n",
-      "  Train samples: 36496\n",
-      "  Test samples: 4562\n",
-      "\n",
-      "  Step 1: Extracting training embeddings...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Extracting embeddings (single-seq): 100%|██████████| 4562/4562 [02:48<00:00, 27.13it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Embeddings shape: (36496, 1920), Labels shape: (36496,)\n",
-      "\n",
-      "  Step 2: Training linear probe...\n",
-      "  Linear probe train accuracy: 0.5877\n",
-      "\n",
-      "  Step 3: Evaluating on test set...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Evaluating: 100%|██████████| 571/571 [00:29<00:00, 19.14it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "  Results (301.6s):\n",
-      "    classification_accuracy: 0.5848\n",
-      "    classification_mcc: 0.1851\n",
-      "    classification_auroc: 0.7120\n",
-      "    classification_auprc: 0.5081\n",
-      "  Task: var_bench_coding_pathogenicity\n",
-      "  Type: variant-pair\n",
-      "  Num labels: 2\n",
-      "  Train samples: 74143\n",
-      "  Test samples: 8729\n",
-      "\n",
-      "  Step 1: Extracting training embeddings...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Extracting embeddings (variant-pair): 100%|██████████| 9268/9268 [29:57<00:00,  5.16it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Embeddings shape: (74143, 5760), Labels shape: (74143,)\n",
-      "\n",
-      "  Step 2: Training linear probe...\n",
-      "  Linear probe train accuracy: 0.7424\n",
-      "\n",
-      "  Step 3: Evaluating on test set...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Evaluating: 100%|██████████| 1092/1092 [03:32<00:00,  5.13it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "  Results (2300.7s):\n",
-      "    classification_accuracy: 0.7043\n",
-      "    classification_mcc: 0.4027\n",
-      "    classification_auroc: 0.7627\n",
-      "    classification_auprc: 0.7379\n",
-      "\n",
-      "Supervised evaluation complete. 2/2 tasks succeeded.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "supervised_results = {}\n",
-    "\n",
-    "for task in supervised_tasks:\n",
-    "    try:\n",
-    "        t0 = time.time()\n",
-    "        attrs = task.get_task_attributes()\n",
-    "        is_variant = attrs[\"is_variant_effect_prediction\"]\n",
-    "        num_labels = attrs[\"num_labels\"]\n",
-    "\n",
-    "        train_dataset = task.get_finetune_dataset()\n",
-    "        if train_dataset is None:\n",
-    "            print(f\"  SKIPPED: no training data available\")\n",
-    "            continue\n",
-    "\n",
-    "        print(f\"  Task: {task.get_task_name()}\")\n",
-    "        print(f\"  Type: {'variant-pair' if is_variant else 'single-seq'}\")\n",
-    "        print(f\"  Num labels: {num_labels}\")\n",
-    "        print(f\"  Train samples: {len(train_dataset)}\")\n",
-    "        print(f\"  Test samples: {len(task.test_dataset)}\")\n",
-    "\n",
-    "        # Step 1: Extract embeddings from training set\n",
-    "        print(f\"\\n  Step 1: Extracting training embeddings...\")\n",
-    "        if is_variant:\n",
-    "            X_train, y_train = extract_embeddings_variant_pair(evo2_model, train_dataset, BATCH_SIZE)\n",
-    "        else:\n",
-    "            X_train, y_train = extract_embeddings_single_seq(evo2_model, train_dataset, BATCH_SIZE)\n",
-    "        print(f\"  Embeddings shape: {X_train.shape}, Labels shape: {y_train.shape}\")\n",
-    "\n",
-    "        # Step 2: Train linear probe\n",
-    "        print(f\"\\n  Step 2: Training linear probe...\")\n",
-    "        clf = train_linear_probe(X_train, y_train, num_labels, LINEAR_PROBE_MAX_ITER, LINEAR_PROBE_C)\n",
-    "\n",
-    "        # Step 3: Wrap into GFMBench-API compatible model\n",
-    "        probe_model = Evo2LinearProbeModel(\n",
-    "            backbone=evo2_model,\n",
-    "            clf=clf,\n",
-    "            is_variant_pair=is_variant,\n",
-    "        )\n",
-    "\n",
-    "        # Step 4: Evaluate via GFMBench-API\n",
-    "        print(f\"\\n  Step 3: Evaluating on test set...\")\n",
-    "        results = task.eval_test_set(probe_model)\n",
-    "\n",
-    "        elapsed = time.time() - t0\n",
-    "        print(f\"\\n  Results ({elapsed:.1f}s):\")\n",
-    "        for metric, score in results.items():\n",
-    "            val_str = f\"{score:.4f}\" if score is not None else \"N/A\"\n",
-    "            print(f\"    {metric}: {val_str}\")\n",
-    "\n",
-    "        # Store and save incrementally\n",
-    "        supervised_results[task.get_task_name()] = results\n",
-    "        report.add_scores(task.get_task_name(), MODEL_NAME, results)\n",
-    "        report.save_csv()\n",
-    "\n",
-    "        # Free training embeddings\n",
-    "        del X_train, y_train, clf, probe_model\n",
-    "\n",
-    "    except Exception as e:\n",
-    "        print(f\"  FAILED: {e}\")\n",
-    "        import traceback; traceback.print_exc()\n",
-    "    finally:\n",
-    "        torch.cuda.empty_cache()\n",
-    "\n",
-    "print(f\"\\nSupervised evaluation complete. {len(supervised_results)}/{len(supervised_tasks)} tasks succeeded.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "### 3.7 Results Summary"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T18:26:00.007059Z",
-     "iopub.status.busy": "2026-06-14T18:26:00.006859Z",
-     "iopub.status.idle": "2026-06-14T18:26:00.025993Z",
-     "shell.execute_reply": "2026-06-14T18:26:00.024882Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "GFMBench-API Results for evo2_1b-8k-bf16_1.0\n",
-      "\n",
-      "Zero-shot tasks\n",
-      "======================================================================\n",
-      "Tasks: 2 | Metrics: 8\n",
-      "                              sum_probs_llr_auroc  sum_probs_llr_auprc  sequence_embeddings_cosinesim_auroc  sequence_embeddings_cosinesim_auprc  sequence_embeddings_l2_auroc  sequence_embeddings_l2_auprc  snv_variant_effect_cosinesim_auroc  snv_variant_effect_cosinesim_auprc\n",
-      "task                                                                                                                                                                                                                                                                                \n",
-      "brca1                                      0.7423               0.5332                               0.7495                               0.5426                        0.7781                        0.5773                              0.5328                              0.2221\n",
-      "bend_variant_effects_disease               0.9195               0.7422                               0.8723                               0.4737                        0.9115                        0.5955                              0.5755                              0.0822\n",
-      "\n",
-      "Supervised tasks (linear probing)\n",
-      "======================================================================\n",
-      "Tasks: 2 | Metrics: 4\n",
-      "                                classification_accuracy  classification_mcc  classification_auroc  classification_auprc\n",
-      "task                                                                                                                   \n",
-      "gue_splice_site                                  0.5848              0.1851                0.7120                0.5081\n",
-      "var_bench_coding_pathogenicity                   0.7043              0.4027                0.7627                0.7379\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "import pandas as pd\n",
-    "\n",
-    "# Zero-shot and supervised tasks report different metric families; keep tables separate.\n",
-    "ZERO_SHOT_METRIC_PREFIXES = (\"sum_probs_\", \"sequence_embeddings_\", \"snv_variant_effect_\")\n",
-    "SUPERVISED_METRIC_PREFIXES = (\"classification_\",)\n",
-    "\n",
-    "\n",
-    "def _filter_metric_columns(columns, prefixes):\n",
-    "    return [c for c in columns if any(c.startswith(p) for p in prefixes)]\n",
-    "\n",
-    "\n",
-    "def _results_dict_to_table(results_dict, title, metric_prefixes=None):\n",
-    "    \"\"\"Build a wide results table from eval dicts; drop empty metric columns.\"\"\"\n",
-    "    print(f\"{title}\")\n",
-    "    print(f\"{'=' * 70}\")\n",
-    "    if not results_dict:\n",
-    "        print(\"  (no results)\\n\")\n",
-    "        return None\n",
-    "\n",
-    "    rows = [{\"task\": task, **metrics} for task, metrics in results_dict.items()]\n",
-    "    table = pd.DataFrame(rows).set_index(\"task\")\n",
-    "    table = table.apply(pd.to_numeric, errors=\"coerce\")\n",
-    "    if metric_prefixes:\n",
-    "        cols = _filter_metric_columns(table.columns, metric_prefixes)\n",
-    "        table = table[cols]\n",
-    "    table = table.dropna(axis=1, how=\"all\")\n",
-    "\n",
-    "    print(f\"Tasks: {len(table)} | Metrics: {len(table.columns)}\")\n",
-    "    print(table.round(4).to_string())\n",
-    "    print()\n",
-    "    return table\n",
-    "\n",
-    "\n",
-    "pd.set_option(\"display.max_columns\", None)\n",
-    "pd.set_option(\"display.width\", 200)\n",
-    "pd.set_option(\"display.float_format\", \"{:.4f}\".format)\n",
-    "\n",
-    "print(f\"GFMBench-API Results for {MODEL_NAME}\\n\")\n",
-    "\n",
-    "zero_shot_summary = _results_dict_to_table(\n",
-    "    zero_shot_results,\n",
-    "    \"Zero-shot tasks\",\n",
-    "    metric_prefixes=ZERO_SHOT_METRIC_PREFIXES,\n",
-    ")\n",
-    "supervised_summary = _results_dict_to_table(\n",
-    "    supervised_results,\n",
-    "    \"Supervised tasks (linear probing)\",\n",
-    "    metric_prefixes=SUPERVISED_METRIC_PREFIXES,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Key AUROC metrics at a glance (aggregated by task type)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T18:26:00.028698Z",
-     "iopub.status.busy": "2026-06-14T18:26:00.028486Z",
-     "iopub.status.idle": "2026-06-14T18:26:00.040397Z",
-     "shell.execute_reply": "2026-06-14T18:26:00.039387Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Aggregated AUROC for Evo2 (evo2/1b-8k-bf16:1.0)\n",
-      "\n",
-      "Zero-shot (mean AUROC)\n",
-      "======================================================================\n",
-      "                                     mean_auroc  n_tasks\n",
-      "metric                                                  \n",
-      "sum_probs_llr_auroc                      0.8309        2\n",
-      "sequence_embeddings_cosinesim_auroc      0.8109        2\n",
-      "sequence_embeddings_l2_auroc             0.8448        2\n",
-      "snv_variant_effect_cosinesim_auroc       0.5541        2\n",
-      "\n",
-      "Supervised (mean AUROC)\n",
-      "======================================================================\n",
-      "                      mean_auroc  n_tasks\n",
-      "metric                                   \n",
-      "classification_auroc      0.7374        2\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "def _print_auroc_aggregates(table, title):\n",
-    "    \"\"\"Print mean AUROC per metric (per-task values are in the cell above).\"\"\"\n",
-    "    print(f\"{title}\")\n",
-    "    print(f\"{'=' * 70}\")\n",
-    "    if table is None or table.empty:\n",
-    "        print(\"  (no results)\\n\")\n",
-    "        return\n",
-    "\n",
-    "    auroc_cols = [c for c in table.columns if \"auroc\" in c.lower()]\n",
-    "    if not auroc_cols:\n",
-    "        print(\"  (no AUROC metrics)\\n\")\n",
-    "        return\n",
-    "\n",
-    "    auroc_df = table[auroc_cols].dropna(axis=1, how=\"all\")\n",
-    "    rows = []\n",
-    "    for col in auroc_df.columns:\n",
-    "        valid = auroc_df[col].dropna()\n",
-    "        if len(valid) > 0:\n",
-    "            rows.append({\n",
-    "                \"metric\": col,\n",
-    "                \"mean_auroc\": valid.mean(),\n",
-    "                \"n_tasks\": len(valid),\n",
-    "            })\n",
-    "    if not rows:\n",
-    "        print(\"  (no valid AUROC scores)\\n\")\n",
-    "        return\n",
-    "\n",
-    "    agg = pd.DataFrame(rows).set_index(\"metric\")\n",
-    "    print(agg.round(4).to_string())\n",
-    "    print()\n",
-    "\n",
-    "\n",
-    "print(f\"Aggregated AUROC for Evo2 ({CKPT_TAG})\\n\")\n",
-    "_print_auroc_aggregates(zero_shot_summary, \"Zero-shot (mean AUROC)\")\n",
-    "_print_auroc_aggregates(supervised_summary, \"Supervised (mean AUROC)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "### 3.8 Export"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-14T18:26:00.043048Z",
-     "iopub.status.busy": "2026-06-14T18:26:00.042836Z",
-     "iopub.status.idle": "2026-06-14T18:26:00.049643Z",
-     "shell.execute_reply": "2026-06-14T18:26:00.048669Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Results saved to: evo2_gfmbench_results.csv\n",
-      "JSON summary saved to: evo2_gfmbench_results.json\n",
-      "\n",
-      "Done! Evaluated 4 tasks total (2 zero-shot, 2 supervised).\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Final save\n",
-    "report.save_csv()\n",
-    "print(f\"Results saved to: {RESULTS_CSV}\")\n",
-    "\n",
-    "\n",
-    "json_path = RESULTS_CSV.replace(\".csv\", \".json\")\n",
-    "json_summary = {\n",
-    "    \"model\": MODEL_NAME,\n",
-    "    \"ckpt_tag\": CKPT_TAG,\n",
-    "    \"max_seq_length\": MAX_SEQ_LENGTH,\n",
-    "    \"task_config\": TASK_CONFIG,\n",
-    "    \"zero_shot_results\": zero_shot_results,\n",
-    "    \"supervised_results\": supervised_results,\n",
-    "}\n",
-    "with open(json_path, \"w\") as f:\n",
-    "    json.dump(json_summary, f, indent=2, default=str)\n",
-    "\n",
-    "print(f\"JSON summary saved to: {json_path}\")\n",
-    "n_tasks = len(zero_shot_results) + len(supervised_results)\n",
-    "print(f\"\\nDone! Evaluated {n_tasks} tasks total \"\n",
-    "      f\"({len(zero_shot_results)} zero-shot, {len(supervised_results)} supervised).\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 4
 }

--- a/bionemo-recipes/recipes/evo2_megatron/examples/evo2_gfmbench_recipe.ipynb
+++ b/bionemo-recipes/recipes/evo2_megatron/examples/evo2_gfmbench_recipe.ipynb
@@ -1,0 +1,1619 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Evaluating Evo2 with GFMBench-API (BioNeMo Recipe)\n",
+    "\n",
+    "This notebook evaluates the **Evo2** genomic foundation model using the **BioNeMo framework** (`bionemo-evo2` + NeMo/Megatron) on the **[GFMBench-API](https://github.com/NVIDIA/GFMBench-api)** benchmark suite.\n",
+    "\n",
+    "**GFMBench-API** is a framework for evaluating genomic foundation models. It exposes a single, model-agnostic API that decouples model development from benchmark tasks and metrics:  \n",
+    "you implement inference methods once, and the same interface drives zero-shot scoring, supervised evaluation, and reporting across all tasks. See the [bioRxiv preprint](https://www.biorxiv.org/content/10.64898/2026.02.19.706811v1) for the full benchmark design and task definitions.\n",
+    "\n",
+    "This recipe evaluates Evo2 on both task categories in GFMBench-API: **zero-shot** tasks and **linear probing** for supervised tasks, following the Evo2 paper protocol. For supervised tasks, because GFMBench-API decouples model development from task-specific training, you interact with **task modules** to load training data, extract frozen Evo2 embeddings, train lightweight classifiers, and evaluate via the same task API.\n",
+    "\n",
+    "> **Note:** In practice, each developer can choose any supervised training strategy (full fine-tuning, LoRA, adapter heads, etc.) by interacting with GFMBench-API **task modules** the same way: load training data through the task API, train your model, then evaluate with `eval_test_set()`.\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "- **BioNeMo Evo2** package installed (`bionemo-evo2`)\n",
+    "\n",
+    "## Evaluation Strategy\n",
+    "\n",
+    "GFMBench-API contains **20 tasks** in two categories:\n",
+    "\n",
+    "### Zero-Shot Tasks (no training required)\n",
+    "These use Evo2's autoregressive log-likelihood and embeddings directly:\n",
+    "- **Log-Likelihood Ratio (LLR)**: `log P(variant_seq) - log P(reference_seq)` scores variant pathogenicity\n",
+    "- **Embedding Cosine Similarity / L2 Distance**: Compare representative embeddings of variant vs reference sequences\n",
+    "- **SNV-specific metrics**: Position-specific embedding and probability comparisons\n",
+    "\n",
+    "| Task | Description | Type |\n",
+    "|------|-------------|------|\n",
+    "| VepevalClinvar | ClinVar SNV pathogenicity | SNV |\n",
+    "| IndelClinvar | ClinVar indel pathogenicity | Indel |\n",
+    "| BendVEPExpression | SNV expression effects | SNV |\n",
+    "| BendVEPDisease | SNV disease effects | SNV |\n",
+    "| SonglabClinvar | ClinVar SNV (likelihood) | SNV |\n",
+    "| BRCA1 | BRCA1 functional impact | SNV |\n",
+    "| TraitGymComplex | Complex trait variants | SNV |\n",
+    "| TraitGymMendelian | Mendelian disease variants | SNV |\n",
+    "| LrbPathogenicOmim | OMIM pathogenic variants | SNV |\n",
+    "| LoleveCausalEqtl | Causal eQTL indels | Indel |\n",
+    "\n",
+    "### Supervised Tasks (linear probing)\n",
+    "For these tasks we:\n",
+    "1. Extract Evo2 embeddings (frozen backbone) for each training sample\n",
+    "2. Train a lightweight `LogisticRegression` classifier on the embeddings\n",
+    "3. Wrap the trained head + Evo2 into a model that returns label probabilities\n",
+    "4. Evaluate via GFMBench-API\n",
+    "\n",
+    "| Task | Type | Description |\n",
+    "|------|------|-------------|\n",
+    "| GuePromoterAll | Single-seq | Promoter prediction (2-class, 300bp) |\n",
+    "| GueSpliceSite | Single-seq | Splice site prediction (3-class, 400bp) |\n",
+    "| GueTranscriptionFactor | Single-seq | TF binding prediction (2-class) |\n",
+    "| VariantBenchmarksCoding | Variant-pair | Coding variant pathogenicity |\n",
+    "| VariantBenchmarksNonCoding | Variant-pair | Non-coding variant pathogenicity |\n",
+    "| VariantBenchmarksExpression | Variant-pair | Expression-affecting variants |\n",
+    "| VariantBenchmarksCommonVsRare | Variant-pair | Common vs rare variants |\n",
+    "| VariantBenchmarksMEQTL | Variant-pair | Methylation eQTL variants |\n",
+    "| VariantBenchmarksSQTL | Variant-pair | Splicing eQTL variants |\n",
+    "| LRBCausalEqtl (supervised) | Variant-pair | Causal eQTL (with tissue metadata) |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 1. Setup GFMBench-API\n",
+    "\n",
+    "Linux commands (run from your working directory):\n",
+    "\n",
+    "```bash\n",
+    "git clone https://github.com/NVIDIA/GFMBench-api\n",
+    "export GFMBENCH_PATH=./GFMBench-api\n",
+    "cd \"$GFMBENCH_PATH\"\n",
+    "pip install -r basic_requirements.txt\n",
+    "export PYTHONPATH=\"$GFMBENCH_PATH\"\n",
+    "```\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "The following Python code will do the same:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T15:53:52.423213Z",
+     "iopub.status.busy": "2026-06-14T15:53:52.422999Z",
+     "iopub.status.idle": "2026-06-14T15:53:54.609985Z",
+     "shell.execute_reply": "2026-06-14T15:53:54.608868Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Cloning into 'GFMBench-api'...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Installing GFMBench-API deps from /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt\n",
+      "Requirement already satisfied: numpy==1.26.4 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 2)) (1.26.4)\n",
+      "Requirement already satisfied: pandas>=1.3.3 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 3)) (2.2.3)\n",
+      "Requirement already satisfied: torch<3,>=2.0.0 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (2.8.0a0+5228986c39.nv25.6)\n",
+      "Requirement already satisfied: tqdm==4.67.3 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 5)) (4.67.3)\n",
+      "Requirement already satisfied: datasets>=2.0.0 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (4.3.0)\n",
+      "Requirement already satisfied: huggingface_hub==0.36.2 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (0.36.2)\n",
+      "Requirement already satisfied: pyfaidx==0.9.0.4 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 10)) (0.9.0.4)\n",
+      "Requirement already satisfied: pyarrow>=6.0.0 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 11)) (22.0.0)\n",
+      "Requirement already satisfied: openpyxl==3.1.5 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 12)) (3.1.5)\n",
+      "Requirement already satisfied: biopython==1.87 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 15)) (1.87)\n",
+      "Requirement already satisfied: scikit-learn==1.7.2 in /usr/local/lib/python3.12/dist-packages (from -r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 16)) (1.7.2)\n",
+      "Requirement already satisfied: filelock in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (3.18.0)\n",
+      "Requirement already satisfied: fsspec>=2023.5.0 in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (2024.12.0)\n",
+      "Requirement already satisfied: hf-xet<2.0.0,>=1.1.3 in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (1.2.0)\n",
+      "Requirement already satisfied: packaging>=20.9 in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (24.2)\n",
+      "Requirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (6.0.2)\n",
+      "Requirement already satisfied: requests in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (2.32.3)\n",
+      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /usr/local/lib/python3.12/dist-packages (from huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (4.14.0)\n",
+      "Requirement already satisfied: et-xmlfile in /usr/local/lib/python3.12/dist-packages (from openpyxl==3.1.5->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 12)) (2.0.0)\n",
+      "Requirement already satisfied: scipy>=1.8.0 in /usr/local/lib/python3.12/dist-packages (from scikit-learn==1.7.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 16)) (1.15.3)\n",
+      "Requirement already satisfied: joblib>=1.2.0 in /usr/local/lib/python3.12/dist-packages (from scikit-learn==1.7.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 16)) (1.5.1)\n",
+      "Requirement already satisfied: threadpoolctl>=3.1.0 in /usr/local/lib/python3.12/dist-packages (from scikit-learn==1.7.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 16)) (3.6.0)\n",
+      "Requirement already satisfied: sympy>=1.13.3 in /usr/local/lib/python3.12/dist-packages (from torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (1.14.0)\n",
+      "Requirement already satisfied: networkx in /usr/local/lib/python3.12/dist-packages (from torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (3.5)\n",
+      "Requirement already satisfied: jinja2 in /usr/local/lib/python3.12/dist-packages (from torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (3.1.6)\n",
+      "Requirement already satisfied: setuptools in /usr/local/lib/python3.12/dist-packages (from torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (78.1.1)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.12/dist-packages (from pandas>=1.3.3->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 3)) (2.9.0)\n",
+      "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.12/dist-packages (from pandas>=1.3.3->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 3)) (2023.4)\n",
+      "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.12/dist-packages (from pandas>=1.3.3->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 3)) (2025.2)\n",
+      "Requirement already satisfied: dill<0.4.1,>=0.3.0 in /usr/local/lib/python3.12/dist-packages (from datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (0.4.0)\n",
+      "Requirement already satisfied: httpx<1.0.0 in /usr/local/lib/python3.12/dist-packages (from datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (0.28.1)\n",
+      "Requirement already satisfied: xxhash in /usr/local/lib/python3.12/dist-packages (from datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (3.6.0)\n",
+      "Requirement already satisfied: multiprocess<0.70.17 in /usr/local/lib/python3.12/dist-packages (from datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (0.70.16)\n",
+      "Requirement already satisfied: aiohttp!=4.0.0a0,!=4.0.0a1 in /usr/local/lib/python3.12/dist-packages (from fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (3.12.7)\n",
+      "Requirement already satisfied: anyio in /usr/local/lib/python3.12/dist-packages (from httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (4.9.0)\n",
+      "Requirement already satisfied: certifi in /usr/local/lib/python3.12/dist-packages (from httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (2025.4.26)\n",
+      "Requirement already satisfied: httpcore==1.* in /usr/local/lib/python3.12/dist-packages (from httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (1.0.9)\n",
+      "Requirement already satisfied: idna in /usr/local/lib/python3.12/dist-packages (from httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (3.10)\n",
+      "Requirement already satisfied: h11>=0.16 in /usr/local/lib/python3.12/dist-packages (from httpcore==1.*->httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (0.16.0)\n",
+      "Requirement already satisfied: aiohappyeyeballs>=2.5.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (2.6.1)\n",
+      "Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (1.3.2)\n",
+      "Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (25.3.0)\n",
+      "Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (1.6.0)\n",
+      "Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (6.4.4)\n",
+      "Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (0.3.1)\n",
+      "Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.12/dist-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2025.9.0,>=2023.1.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (1.20.0)\n",
+      "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.12/dist-packages (from python-dateutil>=2.8.2->pandas>=1.3.3->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 3)) (1.16.0)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.12/dist-packages (from requests->huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (3.4.2)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.12/dist-packages (from requests->huggingface_hub==0.36.2->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 9)) (1.26.20)\n",
+      "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.12/dist-packages (from sympy>=1.13.3->torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (1.3.0)\n",
+      "Requirement already satisfied: sniffio>=1.1 in /usr/local/lib/python3.12/dist-packages (from anyio->httpx<1.0.0->datasets>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 8)) (1.3.1)\n",
+      "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.12/dist-packages (from jinja2->torch<3,>=2.0.0->-r /data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api/basic_requirements.txt (line 4)) (3.0.2)\n",
+      "GFMBENCH_PATH=/data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples/GFMBench-api\n",
+      "cwd=/data/sense/alarey/code/bionemo-framework/bionemo-recipes/recipes/evo2_megatron/examples\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Clone target is relative to the notebook working directory; resolve once for stable absolute paths.\n",
+    "GFMBENCH_PATH_RELATIVE = Path(\"GFMBench-api\")\n",
+    "GFMBENCH_PATH = GFMBENCH_PATH_RELATIVE.resolve()\n",
+    "\n",
+    "# Clone only if GFMBench-api is not already present (safe to re-run the cell)\n",
+    "if not GFMBENCH_PATH.exists():\n",
+    "    os.system(\"git clone https://github.com/NVIDIA/GFMBench-api\")\n",
+    "else:\n",
+    "    print(f\"Using existing clone: {GFMBENCH_PATH}\")\n",
+    "\n",
+    "REQUIREMENTS = GFMBENCH_PATH / \"basic_requirements.txt\"\n",
+    "if not REQUIREMENTS.exists():\n",
+    "    raise FileNotFoundError(\n",
+    "        f\"{REQUIREMENTS} not found — run `git pull` in {GFMBENCH_PATH}\"\n",
+    "    )\n",
+    "print(f\"Installing GFMBench-API deps from {REQUIREMENTS}\")\n",
+    "os.system(f\"{sys.executable} -m pip install -r {REQUIREMENTS}\")\n",
+    "\n",
+    "os.environ[\"GFMBENCH_PATH\"] = str(GFMBENCH_PATH)\n",
+    "os.environ[\"PYTHONPATH\"] = str(GFMBENCH_PATH)\n",
+    "sys.path.insert(0, str(GFMBENCH_PATH))\n",
+    "\n",
+    "print(f\"GFMBENCH_PATH={GFMBENCH_PATH}\")\n",
+    "print(f\"cwd={Path.cwd()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Note:** You can also use GFMBench-API's example script, [`usage_examples/run_benchmark.py`](https://github.com/NVIDIA/GFMBench-api/blob/main/usage_examples/run_benchmark.py) on Linux (from `$GFMBENCH_PATH`):\n",
+    ">\n",
+    "> ```bash\n",
+    "> python ./usage_examples/run_benchmark.py \\\n",
+    ">   --model Evo2 \\\n",
+    ">   --linear_prob \\\n",
+    ">   --csv_path ./evo2_gfmbench_results.csv \\\n",
+    ">   --report_algo_name evo2_run \\\n",
+    ">   --root_data_dir_path ./benchmark_data\n",
+    "> ```\n",
+    ">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2. Evo2 Evaluation Pipeline\n",
+    "\n",
+    "This notebook walks through the **Evo2-paper linear probing protocol** step by step: interact with GFMBench-API task modules to load supervised train/test data, extract frozen Evo2 embeddings, train `LogisticRegression` heads, and evaluate via `task.eval_test_set()`.\n",
+    "\n",
+    "Use this approach when you need full control over embedding extraction, probe training, or per-task customization."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.1 Setup & Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T15:53:54.612785Z",
+     "iopub.status.busy": "2026-06-14T15:53:54.612580Z",
+     "iopub.status.idle": "2026-06-14T15:53:56.287440Z",
+     "shell.execute_reply": "2026-06-14T15:53:56.286344Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.12/dist-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import time\n",
+    "import warnings\n",
+    "import logging\n",
+    "from typing import List, Optional, Tuple\n",
+    "import json\n",
+    "\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "from tqdm.auto import tqdm\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning)\n",
+    "logging.basicConfig(level=logging.INFO, format=\"%(asctime)s [%(levelname)s] %(message)s\")\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.2 Configuration\n",
+    "\n",
+    "Adjust these settings for your environment. Paths below are relative to the current working directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T15:53:56.290109Z",
+     "iopub.status.busy": "2026-06-14T15:53:56.289856Z",
+     "iopub.status.idle": "2026-06-14T15:53:56.295896Z",
+     "shell.execute_reply": "2026-06-14T15:53:56.294735Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checkpoint tag: evo2/1b-8k-bf16:1.0\n",
+      "Model max seq: 8192 | Batch size: 8\n",
+      "Data root: benchmark_data\n",
+      "Results CSV: evo2_gfmbench_results.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ---------------------------------------------------------------------------\n",
+    "# Model configuration\n",
+    "# ---------------------------------------------------------------------------\n",
+    "# BioNeMo checkpoint tag — automatically downloaded + cached from NGC.\n",
+    "# Available tags:\n",
+    "#   evo2/1b-8k-bf16:1.0   — 1B params, 8K context, bf16\n",
+    "#   evo2/1b-8k:1.0         — 1B params, 8K context, fp8\n",
+    "#   evo2/7b-8k:1.0         — 7B params, 8K context\n",
+    "#   evo2/7b-1m:1.0         — 7B params, 1M context\n",
+    "# Can also be a local path to an extracted NeMo2 checkpoint directory.\n",
+    "\n",
+    "# ---------------------------------------------------------------------------\n",
+    "# Data & output paths\n",
+    "# ---------------------------------------------------------------------------\n",
+    "\n",
+    "DATA_ROOT = \"benchmark_data\"  # Downloaded benchmark datasets (relative to cwd)\n",
+    "RESULTS_CSV = \"evo2_gfmbench_results.csv\"  # Results output path (relative to cwd)\n",
+    "CKPT_TAG = \"evo2/1b-8k-bf16:1.0\"\n",
+    "\n",
+    "# ---------------------------------------------------------------------------\n",
+    "# Evaluation settings\n",
+    "# ---------------------------------------------------------------------------\n",
+    "\n",
+    "MAX_SEQ_LENGTH = 8192           # Max tokens per sequence\n",
+    "BATCH_SIZE = 8\n",
+    "MAX_NUM_SAMPLES = None          # limit the num of samples to lower number (e.g. 100) for fast runs\n",
+    "\n",
+    "# ---------------------------------------------------------------------------\n",
+    "# Linear probing settings (for supervised tasks)\n",
+    "# ---------------------------------------------------------------------------\n",
+    "\n",
+    "LINEAR_PROBE_MAX_ITER = 5000\n",
+    "LINEAR_PROBE_C = 1.0\n",
+    "\n",
+    "os.makedirs(DATA_ROOT, exist_ok=True)\n",
+    "print(f\"Checkpoint tag: {CKPT_TAG}\")\n",
+    "print(f\"Model max seq: {MAX_SEQ_LENGTH} | Batch size: {BATCH_SIZE}\")\n",
+    "print(f\"Data root: {DATA_ROOT}\")\n",
+    "print(f\"Results CSV: {RESULTS_CSV}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.3 Load Evo2 Model via BioNeMo\n",
+    "\n",
+    "We use the **BioNeMo framework** (`bionemo-evo2`) to load Evo2. The notebook-compatible approach:\n",
+    "1. Initializes **Megatron parallel state manually** (single-GPU, no NeMo Trainer)\n",
+    "2. Creates the model from NeMo's `HYENA_MODEL_OPTIONS` / `MAMBA_MODEL_OPTIONS` configs\n",
+    "3. Loads checkpoint weights via **Megatron `dist_checkpointing`** (torch_dist format)\n",
+    "4. Registers a forward hook on `output_layer` to capture **embeddings** (hidden states before the lm_head)\n",
+    "\n",
+    "Supported architectures and sizes:\n",
+    "\n",
+    "| Config | Arch | Hidden | Layers | Seq Len |\n",
+    "|--------|------|--------|--------|---------|\n",
+    "| 1b | Hyena | 1920 | 25 | 8,192 |\n",
+    "| 7b | Hyena | 4096 | 32 | 8,192 |\n",
+    "| 7b_arc_longcontext | Hyena | 4096 | 32 | 1,048,576 |\n",
+    "| 40b | Hyena | 8192 | 50 | 8,192 |\n",
+    "| 1b_nv / 7b_nv / 40b_nv | Hyena | varies | varies | varies |\n",
+    "| hybrid_mamba_8b | Mamba | - | - | - |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T15:53:56.298350Z",
+     "iopub.status.busy": "2026-06-14T15:53:56.298144Z",
+     "iopub.status.idle": "2026-06-14T15:54:05.653910Z",
+     "shell.execute_reply": "2026-06-14T15:54:05.652755Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 22:14:59,305 [INFO] The multistorageclient package is available.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Evo2BioNeMoModel class defined.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from usage_examples.sanity_models.evo2_model import Evo2BioNeMoModel\n",
+    "\n",
+    "print(\"Evo2BioNeMoModel class defined.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Instantiate the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T15:54:05.656637Z",
+     "iopub.status.busy": "2026-06-14T15:54:05.656301Z",
+     "iopub.status.idle": "2026-06-14T15:54:19.997649Z",
+     "shell.execute_reply": "2026-06-14T15:54:19.996534Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0\n",
+      "[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0\n",
+      "[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 22:15:07,431 [INFO] Downloading/caching checkpoint: evo2/1b-8k-bf16:1.0\n",
+      "Using cached path='/root/.cache/bionemo/ea4a3f5c9c26d5edc10bdc85165c090ad0ff23ac2670d4f61244f5f0d9d5e817-nemo2_evo2_1b_8k_bf16.tar.gz.untar' from checked=PosixPath('/root/.cache/bionemo/ea4a3f5c9c26d5edc10bdc85165c090ad0ff23ac2670d4f61244f5f0d9d5e817-nemo2_evo2_1b_8k_bf16.tar.gz.checked')\n",
+      "2026-06-14 22:15:07,446 [INFO] Checkpoint root: /root/.cache/bionemo/ea4a3f5c9c26d5edc10bdc85165c090ad0ff23ac2670d4f61244f5f0d9d5e817-nemo2_evo2_1b_8k_bf16.tar.gz.untar\n",
+      "2026-06-14 22:15:08,593 [INFO] Note: detected 256 virtual cores but NumExpr set to maximum of 64, check \"NUMEXPR_MAX_THREADS\" environment variable.\n",
+      "2026-06-14 22:15:08,594 [INFO] Note: NumExpr detected 256 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 16.\n",
+      "2026-06-14 22:15:08,595 [INFO] NumExpr defaulting to 16 threads.\n",
+      "Import of quick_gelu from megatron.core.fusions.fused_bias_geglu failed with: Traceback (most recent call last):\n",
+      "  File \"/usr/local/lib/python3.12/dist-packages/nemo/utils/import_utils.py\", line 319, in safe_import_from\n",
+      "    return getattr(imported_module, symbol), True\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "AttributeError: module 'megatron.core.fusions.fused_bias_geglu' has no attribute 'quick_gelu'\n",
+      "\n",
+      "2026-06-14 22:15:10,263 [INFO] Import of quick_gelu from megatron.core.fusions.fused_bias_geglu failed with: Traceback (most recent call last):\n",
+      "  File \"/usr/local/lib/python3.12/dist-packages/nemo/utils/import_utils.py\", line 319, in safe_import_from\n",
+      "    return getattr(imported_module, symbol), True\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "AttributeError: module 'megatron.core.fusions.fused_bias_geglu' has no attribute 'quick_gelu'\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[NeMo I 2026-06-14 22:15:10 nemo_logging:393] Padded vocab_size: 512, original vocab_size: 512, dummy tokens: 0.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 22:15:11,201 [INFO] Using hybrid override pattern\n",
+      "2026-06-14 22:15:11,202 [INFO] Hybrid allocation (S is hyena_short_conv, D is hyena_medium_conv, H is hyena, * is attention, \n",
+      "2026-06-14 22:15:11,202 [INFO] SDH*SDHSDH*SDHSDH*SDHSDH*\n",
+      "2026-06-14 22:15:11,203 [INFO] 7 heyna_short_conv layers in 25 total layers.\n",
+      "2026-06-14 22:15:11,204 [INFO] 7 heyna_medium_conv layers in 25 total layers.\n",
+      "2026-06-14 22:15:11,205 [INFO] 7 heyna layers in 25 total layers.\n",
+      "2026-06-14 22:15:11,206 [INFO] 4 attention layers in 25 total layers.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[NeMo I 2026-06-14 22:15:11 nemo_logging:393] Using byte-level tokenization\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 22:15:11,440 [INFO] Model created: 1,108,204,800 parameters, hidden=1920\n",
+      "2026-06-14 22:15:14,001 [INFO] Checkpoint loaded successfully\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Loaded in 6.8s\n",
+      "  Hidden dim:  1920\n",
+      "  Max length:  8192\n",
+      "\n",
+      "Sanity check - infer_sequence_to_sequence:\n",
+      "  token_probs shape:     (2, 16)\n",
+      "  seq_embeddings shape:  (2, 16, 1920)\n",
+      "  representative shape:  (2, 1920)\n",
+      "  token_probs range:     [0.0000, 0.9951]\n",
+      "  representative norm:   [22.061846 17.920654]\n",
+      "\n",
+      "infer_variant_ref_sequences_to_labels_probs:\n",
+      "  output shape: (1, 2)\n",
+      "  probs:        [[0.00686961 0.9931304 ]]\n",
+      "  probs sum:    1.000000\n"
+     ]
+    }
+   ],
+   "source": [
+    "t0 = time.time()\n",
+    "evo2_model = Evo2BioNeMoModel(\n",
+    "    ckpt_tag=CKPT_TAG,\n",
+    "    max_length=MAX_SEQ_LENGTH,\n",
+    ")\n",
+    "elapsed = time.time() - t0\n",
+    "print(f\"\\nLoaded in {elapsed:.1f}s\")\n",
+    "print(f\"  Hidden dim:  {evo2_model.hidden_dim}\")\n",
+    "print(f\"  Max length:  {evo2_model.max_length}\")\n",
+    "\n",
+    "# Quick sanity check\n",
+    "test_seqs = [\"ACGTACGTACGTACGT\", \"NNNNACGTACGTNNNN\"]\n",
+    "probs, embeddings, representative = evo2_model.infer_sequence_to_sequence(test_seqs)\n",
+    "\n",
+    "print(f\"\\nSanity check - infer_sequence_to_sequence:\")\n",
+    "print(f\"  token_probs shape:     {probs.shape}\")\n",
+    "print(f\"  seq_embeddings shape:  {embeddings.shape if embeddings is not None else 'None'}\")\n",
+    "print(f\"  representative shape:  {representative.shape if representative is not None else 'None'}\")\n",
+    "print(f\"  token_probs range:     [{probs.min():.4f}, {probs.max():.4f}]\")\n",
+    "if representative is not None:\n",
+    "    print(f\"  representative norm:   {np.linalg.norm(representative, axis=1)}\")\n",
+    "\n",
+    "# Verify variant scoring\n",
+    "var_probs = evo2_model.infer_variant_ref_sequences_to_labels_probs(\n",
+    "    variant_sequences=[\"ACGTACGTACGTACGT\"],\n",
+    "    ref_sequences=[\"ACGTACGAACGTACGT\"],\n",
+    ")\n",
+    "print(f\"\\ninfer_variant_ref_sequences_to_labels_probs:\")\n",
+    "print(f\"  output shape: {var_probs.shape}\")\n",
+    "print(f\"  probs:        {var_probs}\")\n",
+    "print(f\"  probs sum:    {var_probs.sum():.6f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T15:54:20.000605Z",
+     "iopub.status.busy": "2026-06-14T15:54:20.000002Z",
+     "iopub.status.idle": "2026-06-14T15:54:20.032389Z",
+     "shell.execute_reply": "2026-06-14T15:54:20.031626Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Benchmark report initialized: evo2_gfmbench_results.csv\n",
+      "Model name for reporting: evo2_1b-8k-bf16_1.0\n",
+      "TASK_CONFIG: {'max_sequence_length': 8192, 'batch_size': 8, 'max_num_samples': None, 'disable_safe_model_call': True}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from gfmbench_api.benchmark_report.benchmark_report import BenchmarkReport\n",
+    "\n",
+    "# Common task config (passed to every GFMBench-API task constructor)\n",
+    "TASK_CONFIG = {\n",
+    "    # Extraction window: min(task_default, this value). Keep well below MAX_SEQ_LENGTH\n",
+    "    # to avoid quadratic attention OOM at large batch sizes.\n",
+    "    \"max_sequence_length\": MAX_SEQ_LENGTH,\n",
+    "    \"batch_size\": BATCH_SIZE,\n",
+    "    \"max_num_samples\": MAX_NUM_SAMPLES,\n",
+    "    # Fail fast while validating this recipe. If this is False, GFMBench-API\n",
+    "    # converts model-interface exceptions into None outputs and metrics become N/A.\n",
+    "    \"disable_safe_model_call\": True,\n",
+    "}\n",
+    "\n",
+    "MODEL_NAME = CKPT_TAG.replace(\"/\", \"_\").replace(\":\", \"_\")\n",
+    "\n",
+    "# Initialize the benchmark report (loads existing CSV if present)\n",
+    "report = BenchmarkReport(csv_path=RESULTS_CSV)\n",
+    "print(f\"Benchmark report initialized: {RESULTS_CSV}\")\n",
+    "print(f\"Model name for reporting: {MODEL_NAME}\")\n",
+    "print(f\"TASK_CONFIG: {TASK_CONFIG}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define Benchmark Tasks\n",
+    "\n",
+    "Choose which GFMBench-API tasks to evaluate in the cell below. **Uncomment the tasks you want to run** in `zero_shot_tasks` and/or `supervised_tasks`.\n",
+    "\n",
+    "Each enabled task is instantiated when you run that cell, which may download and cache datasets under `DATA_ROOT` on the first run. Later runs reuse the cache.\n",
+    "\n",
+    "**Note:** First-time downloads (reference genomes, HuggingFace datasets, parquet files, etc.) can take several minutes to tens of minutes per task, depending on network speed and how many tasks are enabled."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T15:54:20.034675Z",
+     "iopub.status.busy": "2026-06-14T15:54:20.034511Z",
+     "iopub.status.idle": "2026-06-14T15:56:55.564347Z",
+     "shell.execute_reply": "2026-06-14T15:56:55.563477Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BRCA1 dataset or reference genome not found. Downloading...\n",
+      "Downloading and processing BRCA1 dataset...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 22:15:21,588 [INFO] Downloading from: https://github.com/ArcInstitute/evo2/raw/refs/heads/main/notebooks/brca1/GRCh37.p13_chr17.fna.gz\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   chrom       pos ref alt     score  label\n",
+      "0     17  41276135   T   G -0.372611      1\n",
+      "1     17  41276135   T   C -0.045313      1\n",
+      "2     17  41276135   T   A -0.108254      1\n",
+      "3     17  41276134   T   G -0.277963      1\n",
+      "4     17  41276134   T   C -0.388414      1\n",
+      "Saved BRCA1 DMS dataset with 3893 variants to parquet.\n",
+      "Downloading reference genome...\n",
+      "  Progress: 100.0% (23.2 MB)\n",
+      "Unzipping and normalizing FASTA header...\n",
+      "Reference genome ready: benchmark_data/brca1/GRCh37.p13_chr17.fna\n",
+      "Successfully downloaded BRCA1 dataset and reference to benchmark_data/brca1\n",
+      "Loading reference genome: benchmark_data/brca1/GRCh37.p13_chr17.fna\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 22:15:24,742 [INFO] Reference genome not found. Downloading hg38.fa...\n",
+      "2026-06-14 22:15:24,743 [INFO] Downloading reference genome hg38.fa (~3GB)...\n",
+      "2026-06-14 22:15:24,743 [INFO] Source: https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.fa.gz\n",
+      "2026-06-14 22:15:24,744 [INFO] This may take several minutes...\n",
+      "2026-06-14 22:15:24,745 [INFO] Downloading from: https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.fa.gz\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting sequences (window size: 8192bp)...\n",
+      "Successfully extracted 3893 sequence pairs\n",
+      "  Progress: 100.0% (983.7 MB)"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 22:16:37,649 [INFO] Extracting hg38.fa.gz...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 22:16:55,504 [INFO] Reference genome saved to: benchmark_data/reference_genome/hg38.fa\n",
+      "2026-06-14 22:16:55,505 [INFO] Loading reference genome: benchmark_data/reference_genome/hg38.fa\n",
+      "2026-06-14 22:17:18,046 [INFO] Downloading bend_variant_effects_disease from BEND repository...\n",
+      "2026-06-14 22:17:18,048 [INFO] Downloading from: https://sid.erda.dk/share_redirect/aNQa0Oz2lY/data/variant_effects/variant_effects_disease.bed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Progress: 100.0% (20.4 MB)"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 22:17:19,675 [INFO] Data saved to: benchmark_data/bend_variant_effects_disease\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-14 22:17:19,909 [INFO] Extracting sequences (window size: 512bp)...\n",
+      "2026-06-14 22:17:36,816 [INFO] Successfully extracted 295495 sequence pairs\n",
+      "2026-06-14 22:17:37,884 [INFO] Downloading gue_splice_site from HuggingFace...\n",
+      "2026-06-14 22:17:37,887 [INFO] Dataset not found locally, downloading\n",
+      "Saving the dataset (1/1 shards): 100%|██████████| 36496/36496 [00:00<00:00, 1763317.08 examples/s]\n",
+      "Saving the dataset (1/1 shards): 100%|██████████| 4562/4562 [00:00<00:00, 887866.68 examples/s] \n",
+      "Saving the dataset (1/1 shards): 100%|██████████| 4562/4562 [00:00<00:00, 899850.21 examples/s] \n",
+      "2026-06-14 22:17:41,539 [INFO] Data saved to: benchmark_data/gue_splice_site\n",
+      "2026-06-14 22:17:41,770 [INFO] GUE: wrote benchmark_data/gue_splice_site/train.csv from HuggingFace split 'train'\n",
+      "2026-06-14 22:17:41,797 [INFO] GUE: wrote benchmark_data/gue_splice_site/dev.csv from HuggingFace split 'dev'\n",
+      "2026-06-14 22:17:41,825 [INFO] GUE: wrote benchmark_data/gue_splice_site/test.csv from HuggingFace split 'test'\n",
+      "2026-06-14 22:17:42,458 [INFO] Downloading var_bench_coding_pathogenicity from HuggingFace...\n",
+      "2026-06-14 22:17:42,459 [INFO] Dataset not found locally, downloading\n",
+      "Saving the dataset (1/1 shards): 100%|██████████| 82872/82872 [00:00<00:00, 290897.37 examples/s]\n",
+      "2026-06-14 22:17:45,945 [INFO] Data saved to: benchmark_data/var_bench_coding_pathogenicity\n",
+      "Filter: 100%|██████████| 82872/82872 [00:00<00:00, 127208.08 examples/s]\n",
+      "Filter: 100%|██████████| 82872/82872 [00:00<00:00, 132380.18 examples/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Zero-shot tasks enabled: 2\n",
+      "  - brca1\n",
+      "  - bend_variant_effects_disease\n",
+      "Supervised tasks enabled: 2\n",
+      "  - gue_splice_site\n",
+      "  - var_bench_coding_pathogenicity\n"
+     ]
+    }
+   ],
+   "source": [
+    "from gfmbench_api.tasks.concrete.bend_vep_disease_task import BendVEPDisease\n",
+    "from gfmbench_api.tasks.concrete.bend_vep_expression_task import BendVEPExpression\n",
+    "from gfmbench_api.tasks.concrete.brca1_task import BRCA1Task\n",
+    "from gfmbench_api.tasks.concrete.clinvar_indel_task import IndelClinvarTask\n",
+    "from gfmbench_api.tasks.concrete.gue_promoter_all_task import GuePromoterAllTask\n",
+    "from gfmbench_api.tasks.concrete.gue_splice_site_task import GueSpliceSiteTask\n",
+    "from gfmbench_api.tasks.concrete.gue_tf_all_task import GueTranscriptionFactorTask\n",
+    "from gfmbench_api.tasks.concrete.lrb_causal_eqtl_task import LRBCausalEqtlTask\n",
+    "from gfmbench_api.tasks.concrete.lrb_pathogenic_omim_task import LrbVariantEffectPathogenicOmimTask\n",
+    "from gfmbench_api.tasks.concrete.loleve_causal_eqtl_task import LoleveCausalEqtlTask\n",
+    "from gfmbench_api.tasks.concrete.songlab_clinvar_task import SonglabClinvarTask\n",
+    "from gfmbench_api.tasks.concrete.traitgym_complex_task import TraitGymComplexTask\n",
+    "from gfmbench_api.tasks.concrete.traitgym_mendelian_task import TraitGymMendelianTask\n",
+    "from gfmbench_api.tasks.concrete.variant_benchmarks_coding_task import VariantBenchmarksCodingTask\n",
+    "from gfmbench_api.tasks.concrete.variant_benchmarks_common_vs_rare_task import VariantBenchmarksCommonVsRareTask\n",
+    "from gfmbench_api.tasks.concrete.variant_benchmarks_expression_task import VariantBenchmarksExpressionTask\n",
+    "from gfmbench_api.tasks.concrete.variant_benchmarks_meqtl_task import VariantBenchmarksMEQTLTask\n",
+    "from gfmbench_api.tasks.concrete.variant_benchmarks_non_coding_task import VariantBenchmarksNonCodingTask\n",
+    "from gfmbench_api.tasks.concrete.variant_benchmarks_sqtl_task import VariantBenchmarksSQTLTask\n",
+    "\n",
+    "# ---------------------------------------------------------------------------\n",
+    "# Zero-shot tasks (no training — model runs inference directly)\n",
+    "# ---------------------------------------------------------------------------\n",
+    "# Uncomment the tasks you want to run.\n",
+    "\n",
+    "zero_shot_tasks = [\n",
+    "    # IndelClinvarTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                    # ClinVar indels\n",
+    "    # LoleveCausalEqtlTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                # Causal eQTL indels\n",
+    "    BRCA1Task(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                           # BRCA1 functional impact (SNV)\n",
+    "    BendVEPDisease(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                        # SNV disease effects\n",
+    "    # BendVEPExpression(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                   # SNV expression effects\n",
+    "    # SonglabClinvarTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                  # ClinVar SNV (likelihood)\n",
+    "    # TraitGymComplexTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                 # Complex trait variants\n",
+    "    # TraitGymMendelianTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),               # Mendelian disease variants\n",
+    "    # LrbVariantEffectPathogenicOmimTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),  # OMIM pathogenic variants\n",
+    "]\n",
+    "\n",
+    "# ---------------------------------------------------------------------------\n",
+    "# Supervised tasks (linear probing — extract embeddings, train a classifier head)\n",
+    "# ---------------------------------------------------------------------------\n",
+    "# Uncomment the tasks you want to run.\n",
+    "\n",
+    "supervised_tasks = [\n",
+    "    # GueTranscriptionFactorTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),          # TF binding (single-seq, binary)\n",
+    "    # GuePromoterAllTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                  # Promoter prediction (single-seq, binary)\n",
+    "    GueSpliceSiteTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                   # Splice site (single-seq, 3-class)\n",
+    "    VariantBenchmarksCodingTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),         # Coding variant pathogenicity\n",
+    "    # VariantBenchmarksNonCodingTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),      # Non-coding variant pathogenicity\n",
+    "    # VariantBenchmarksExpressionTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),     # Expression-affecting variants\n",
+    "    # VariantBenchmarksCommonVsRareTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),   # Common vs rare variants\n",
+    "    # VariantBenchmarksMEQTLTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),          # Methylation eQTL variants\n",
+    "    # VariantBenchmarksSQTLTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),           # Splicing eQTL variants\n",
+    "    # LRBCausalEqtlTask(root_data_dir_path=DATA_ROOT, task_config=TASK_CONFIG),                   # Causal eQTL (with tissue metadata)\n",
+    "]\n",
+    "\n",
+    "print(f\"Zero-shot tasks enabled: {len(zero_shot_tasks)}\")\n",
+    "for task in zero_shot_tasks:\n",
+    "    print(f\"  - {task.get_task_name()}\")\n",
+    "print(f\"Supervised tasks enabled: {len(supervised_tasks)}\")\n",
+    "for task in supervised_tasks:\n",
+    "    print(f\"  - {task.get_task_name()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "### 2.5 Zero-Shot Evaluation\n",
+    "\n",
+    "For zero-shot tasks, we pass the `Evo2BioNeMoModel` directly to GFMBench-API. The benchmark calls:\n",
+    "- `infer_sequence_to_sequence(sequences)` -> `(token_probs, seq_embeddings, representative)`\n",
+    "- Computes LLR, cosine similarity, and L2 distance metrics automatically\n",
+    "- For SNV tasks, also calls `sequence_pos_to_prob_pos`\n",
+    "\n",
+    "No training is needed -- the model's pre-trained representations are evaluated as-is."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T15:56:55.567399Z",
+     "iopub.status.busy": "2026-06-14T15:56:55.567180Z",
+     "iopub.status.idle": "2026-06-14T17:43:38.247242Z",
+     "shell.execute_reply": "2026-06-14T17:43:38.246388Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Task: brca1\n",
+      "  SNV only: True\n",
+      "  Test samples: 3893\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating (Zero-Shot):   0%|          | 0/487 [00:00<?, ?it/s]2026-06-14 22:17:54,870 [WARNING] Model did not provide required inputs for 'snv_variant_effect_prediction_masked_llr_auroc' metric. This metric will return None.\n",
+      "2026-06-14 22:17:54,871 [WARNING] Model did not provide required inputs for 'snv_variant_effect_prediction_masked_llr_auprc' metric. This metric will return None.\n",
+      "Evaluating (Zero-Shot): 100%|██████████| 487/487 [18:24<00:00,  2.27s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Results (1109.0s):\n",
+      "    sum_probs_llr_auroc: 0.7423\n",
+      "    sum_probs_llr_auprc: 0.5332\n",
+      "    sequence_embeddings_cosinesim_auroc: 0.7495\n",
+      "    sequence_embeddings_cosinesim_auprc: 0.5426\n",
+      "    sequence_embeddings_l2_auroc: 0.7781\n",
+      "    sequence_embeddings_l2_auprc: 0.5773\n",
+      "    snv_variant_effect_cosinesim_auroc: 0.5328\n",
+      "    snv_variant_effect_cosinesim_auprc: 0.2221\n",
+      "    snv_variant_effect_prediction_masked_llr_auroc: N/A\n",
+      "    snv_variant_effect_prediction_masked_llr_auprc: N/A\n",
+      "  Task: bend_variant_effects_disease\n",
+      "  SNV only: True\n",
+      "  Test samples: 295495\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating (Zero-Shot):   0%|          | 0/36937 [00:00<?, ?it/s]2026-06-14 22:36:21,823 [WARNING] Model did not provide required inputs for 'snv_variant_effect_prediction_masked_llr_auroc' metric. This metric will return None.\n",
+      "2026-06-14 22:36:21,823 [WARNING] Model did not provide required inputs for 'snv_variant_effect_prediction_masked_llr_auprc' metric. This metric will return None.\n",
+      "Evaluating (Zero-Shot): 100%|██████████| 36937/36937 [1:26:49<00:00,  7.09it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Results (5213.1s):\n",
+      "    sum_probs_llr_auroc: 0.9195\n",
+      "    sum_probs_llr_auprc: 0.7422\n",
+      "    sequence_embeddings_cosinesim_auroc: 0.8723\n",
+      "    sequence_embeddings_cosinesim_auprc: 0.4737\n",
+      "    sequence_embeddings_l2_auroc: 0.9115\n",
+      "    sequence_embeddings_l2_auprc: 0.5955\n",
+      "    snv_variant_effect_cosinesim_auroc: 0.5755\n",
+      "    snv_variant_effect_cosinesim_auprc: 0.0822\n",
+      "    snv_variant_effect_prediction_masked_llr_auroc: N/A\n",
+      "    snv_variant_effect_prediction_masked_llr_auprc: N/A\n",
+      "\n",
+      "Zero-shot evaluation complete. 2/2 tasks succeeded.\n"
+     ]
+    }
+   ],
+   "source": [
+    "zero_shot_results = {}\n",
+    "\n",
+    "for task in zero_shot_tasks:\n",
+    "    try:\n",
+    "        t0 = time.time()\n",
+    "        attrs = task.get_task_attributes()\n",
+    "        print(f\"  Task: {task.get_task_name()}\")\n",
+    "        print(f\"  SNV only: {attrs.get('is_snv_only_variants', 'N/A')}\")\n",
+    "        print(f\"  Test samples: {len(task.test_dataset)}\")\n",
+    "\n",
+    "        # Evaluate directly -- Evo2BioNeMoModel implements the full GFMBench-API interface\n",
+    "        results = task.eval_test_set(evo2_model)\n",
+    "\n",
+    "        elapsed = time.time() - t0\n",
+    "        print(f\"\\n  Results ({elapsed:.1f}s):\")\n",
+    "        for metric, score in results.items():\n",
+    "            val_str = f\"{score:.4f}\" if score is not None else \"N/A\"\n",
+    "            print(f\"    {metric}: {val_str}\")\n",
+    "\n",
+    "        # Store and save incrementally\n",
+    "        zero_shot_results[task.get_task_name()] = results\n",
+    "        report.add_scores(task.get_task_name(), MODEL_NAME, results)\n",
+    "        report.save_csv()\n",
+    "\n",
+    "    except Exception as e:\n",
+    "        print(f\"  FAILED: {e}\")\n",
+    "        import traceback; traceback.print_exc()\n",
+    "    finally:\n",
+    "        torch.cuda.empty_cache()\n",
+    "\n",
+    "print(f\"\\nZero-shot evaluation complete. {len(zero_shot_results)}/{len(zero_shot_tasks)} tasks succeeded.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "### 3.6 Supervised Evaluation via Linear Probing\n",
+    "\n",
+    "For supervised tasks, Evo2 has no built-in classification head. We perform **linear probing**:\n",
+    "\n",
+    "1. **Extract embeddings** (frozen Evo2 backbone) for every training sample\n",
+    "   - Single-seq tasks: mean-pooled embedding per sequence\n",
+    "   - Variant-pair tasks: concatenation of `[variant_repr, ref_repr, variant_repr - ref_repr]`\n",
+    "2. **Train a `LogisticRegression`** on the extracted embeddings\n",
+    "3. **Wrap** the trained head + Evo2 into a model adapter that GFMBench-API can call\n",
+    "4. **Evaluate** using the standard GFMBench-API `eval_test_set()` API\n",
+    "\n",
+    "This approach avoids any gradient-based fine-tuning of the large backbone."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T17:43:38.250005Z",
+     "iopub.status.busy": "2026-06-14T17:43:38.249805Z",
+     "iopub.status.idle": "2026-06-14T17:43:38.295045Z",
+     "shell.execute_reply": "2026-06-14T17:43:38.294286Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Embedding extraction and linear probing utilities defined.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from torch.utils.data import DataLoader\n",
+    "\n",
+    "\n",
+    "def extract_embeddings_single_seq(\n",
+    "    model,\n",
+    "    dataset,\n",
+    "    batch_size: int,\n",
+    ") -> Tuple[np.ndarray, np.ndarray]:\n",
+    "    \"\"\"Extract mean-pooled embeddings for single-sequence dataset.\n",
+    "\n",
+    "    Dataset items: (sequence, label, conditional_input)\n",
+    "    Returns: (embeddings [N, hidden_dim], labels [N])\n",
+    "    \"\"\"\n",
+    "    loader = DataLoader(dataset, batch_size=batch_size, shuffle=False)\n",
+    "    all_embeds, all_labels = [], []\n",
+    "\n",
+    "    for batch in tqdm(loader, desc=\"Extracting embeddings (single-seq)\"):\n",
+    "        sequences, labels, _ = batch\n",
+    "        # infer_sequence_to_sequence returns (probs, seq_embeddings, representative)\n",
+    "        _, _, representative = model.infer_sequence_to_sequence(list(sequences))\n",
+    "        all_embeds.append(representative)\n",
+    "        all_labels.append(np.array(labels))\n",
+    "\n",
+    "    return np.concatenate(all_embeds, axis=0), np.concatenate(all_labels, axis=0)\n",
+    "\n",
+    "\n",
+    "def extract_embeddings_variant_pair(\n",
+    "    model,\n",
+    "    dataset,\n",
+    "    batch_size: int,\n",
+    ") -> Tuple[np.ndarray, np.ndarray]:\n",
+    "    \"\"\"Extract embeddings for variant-pair dataset.\n",
+    "\n",
+    "    Dataset items: (variant_seq, ref_seq, label, conditional_input)\n",
+    "    Returns: (embeddings [N, 3*hidden_dim], labels [N])\n",
+    "        Embedding = [variant_repr | ref_repr | variant_repr - ref_repr]\n",
+    "    \"\"\"\n",
+    "    loader = DataLoader(dataset, batch_size=batch_size, shuffle=False)\n",
+    "    all_embeds, all_labels = [], []\n",
+    "\n",
+    "    for batch in tqdm(loader, desc=\"Extracting embeddings (variant-pair)\"):\n",
+    "        var_seqs, ref_seqs, labels, _ = batch\n",
+    "        _, _, var_repr = model.infer_sequence_to_sequence(list(var_seqs))\n",
+    "        _, _, ref_repr = model.infer_sequence_to_sequence(list(ref_seqs))\n",
+    "        # Concatenate: [var, ref, var-ref] to give the linear head richer signal\n",
+    "        combined = np.concatenate([var_repr, ref_repr, var_repr - ref_repr], axis=1)\n",
+    "        all_embeds.append(combined)\n",
+    "        all_labels.append(np.array(labels))\n",
+    "\n",
+    "    return np.concatenate(all_embeds, axis=0), np.concatenate(all_labels, axis=0)\n",
+    "\n",
+    "\n",
+    "def train_linear_probe(\n",
+    "    X_train: np.ndarray,\n",
+    "    y_train: np.ndarray,\n",
+    "    num_labels: int,\n",
+    "    max_iter: int = 5000,\n",
+    "    C: float = 1.0,\n",
+    ") -> LogisticRegression:\n",
+    "    \"\"\"Train a LogisticRegression on extracted embeddings.\"\"\"\n",
+    "    multi_class = \"multinomial\" if num_labels > 2 else \"auto\"\n",
+    "    clf = LogisticRegression(\n",
+    "        max_iter=max_iter,\n",
+    "        C=C,\n",
+    "        solver=\"lbfgs\",\n",
+    "        multi_class=multi_class,\n",
+    "        n_jobs=-1,\n",
+    "    )\n",
+    "    clf.fit(X_train, y_train)\n",
+    "    train_acc = clf.score(X_train, y_train)\n",
+    "    print(f\"  Linear probe train accuracy: {train_acc:.4f}\")\n",
+    "    return clf\n",
+    "\n",
+    "\n",
+    "print(\"Embedding extraction and linear probing utilities defined.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Model Adapter for Linear Probing\n",
+    "\n",
+    "The GFMBench-API supervised evaluation calls `infer_sequence_to_labels_probs` (single-seq tasks) or `infer_variant_ref_sequences_to_labels_probs` (variant-pair tasks) and expects `[batch, num_labels]` probability arrays.\n",
+    "\n",
+    "We wrap Evo2 + the trained `LogisticRegression` to satisfy this interface."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T17:43:38.298001Z",
+     "iopub.status.busy": "2026-06-14T17:43:38.297820Z",
+     "iopub.status.idle": "2026-06-14T17:43:38.305264Z",
+     "shell.execute_reply": "2026-06-14T17:43:38.304283Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Evo2LinearProbeModel adapter defined.\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Evo2LinearProbeModel:\n",
+    "    \"\"\"Wraps Evo2 backbone + a trained LogisticRegression to satisfy the GFM-Bench model API.\n",
+    "\n",
+    "    For single-seq tasks:   calls infer_sequence_to_labels_probs(sequences)\n",
+    "    For variant-pair tasks:  calls infer_variant_ref_sequences_to_labels_probs(var_seqs, ref_seqs)\n",
+    "\n",
+    "    Also delegates infer_sequence_to_sequence / sequence_pos_to_prob_pos /\n",
+    "    infer_masked_sequence_to_token_probs to the underlying Evo2 model so that\n",
+    "    any zero-shot metrics that the benchmark may also compute still work.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def __init__(self, backbone, clf: LogisticRegression, is_variant_pair: bool):\n",
+    "        self.backbone = backbone\n",
+    "        self.clf = clf\n",
+    "        self.is_variant_pair = is_variant_pair\n",
+    "\n",
+    "    # --- Single-sequence classification ---\n",
+    "    def infer_sequence_to_labels_probs(\n",
+    "        self, sequences: List[str], conditional_input=None,\n",
+    "    ) -> Optional[np.ndarray]:\n",
+    "        _, _, representative = self.backbone.infer_sequence_to_sequence(sequences)\n",
+    "        probs = self.clf.predict_proba(representative)\n",
+    "        return probs.astype(np.float32)\n",
+    "\n",
+    "    # --- Variant-pair classification ---\n",
+    "    def infer_variant_ref_sequences_to_labels_probs(\n",
+    "        self, variant_sequences: List[str], ref_sequences: List[str], conditional_input=None,\n",
+    "    ) -> Optional[np.ndarray]:\n",
+    "        _, _, var_repr = self.backbone.infer_sequence_to_sequence(variant_sequences)\n",
+    "        _, _, ref_repr = self.backbone.infer_sequence_to_sequence(ref_sequences)\n",
+    "        combined = np.concatenate([var_repr, ref_repr, var_repr - ref_repr], axis=1)\n",
+    "        probs = self.clf.predict_proba(combined)\n",
+    "        return probs.astype(np.float32)\n",
+    "\n",
+    "    # --- Delegate zero-shot methods to backbone ---\n",
+    "    def infer_sequence_to_sequence(self, sequences, conditional_input=None):\n",
+    "        return self.backbone.infer_sequence_to_sequence(sequences, conditional_input)\n",
+    "\n",
+    "    def sequence_pos_to_prob_pos(self, sequences, pos):\n",
+    "        return self.backbone.sequence_pos_to_prob_pos(sequences, pos)\n",
+    "\n",
+    "    def infer_masked_sequence_to_token_probs(self, sequences, variant_pos, variant_letters, reference_letters, conditional_input=None):\n",
+    "        return self.backbone.infer_masked_sequence_to_token_probs(sequences, variant_pos, variant_letters, reference_letters, conditional_input)\n",
+    "\n",
+    "\n",
+    "print(\"Evo2LinearProbeModel adapter defined.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run Supervised Benchmarks\n",
+    "\n",
+    "For each supervised task:\n",
+    "1. Initialize the task (downloads data if needed)\n",
+    "2. Extract embeddings from the training set\n",
+    "3. Train a linear probe (LogisticRegression)\n",
+    "4. Wrap into `Evo2LinearProbeModel`\n",
+    "5. Run `task.eval_test_set(model)` which uses the trained head for predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T17:43:38.307770Z",
+     "iopub.status.busy": "2026-06-14T17:43:38.307599Z",
+     "iopub.status.idle": "2026-06-14T18:26:00.004348Z",
+     "shell.execute_reply": "2026-06-14T18:26:00.003356Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Task: gue_splice_site\n",
+      "  Type: single-seq\n",
+      "  Num labels: 3\n",
+      "  Train samples: 36496\n",
+      "  Test samples: 4562\n",
+      "\n",
+      "  Step 1: Extracting training embeddings...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Extracting embeddings (single-seq): 100%|██████████| 4562/4562 [02:48<00:00, 27.13it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Embeddings shape: (36496, 1920), Labels shape: (36496,)\n",
+      "\n",
+      "  Step 2: Training linear probe...\n",
+      "  Linear probe train accuracy: 0.5877\n",
+      "\n",
+      "  Step 3: Evaluating on test set...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 571/571 [00:29<00:00, 19.14it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Results (301.6s):\n",
+      "    classification_accuracy: 0.5848\n",
+      "    classification_mcc: 0.1851\n",
+      "    classification_auroc: 0.7120\n",
+      "    classification_auprc: 0.5081\n",
+      "  Task: var_bench_coding_pathogenicity\n",
+      "  Type: variant-pair\n",
+      "  Num labels: 2\n",
+      "  Train samples: 74143\n",
+      "  Test samples: 8729\n",
+      "\n",
+      "  Step 1: Extracting training embeddings...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Extracting embeddings (variant-pair): 100%|██████████| 9268/9268 [29:57<00:00,  5.16it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Embeddings shape: (74143, 5760), Labels shape: (74143,)\n",
+      "\n",
+      "  Step 2: Training linear probe...\n",
+      "  Linear probe train accuracy: 0.7424\n",
+      "\n",
+      "  Step 3: Evaluating on test set...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating: 100%|██████████| 1092/1092 [03:32<00:00,  5.13it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Results (2300.7s):\n",
+      "    classification_accuracy: 0.7043\n",
+      "    classification_mcc: 0.4027\n",
+      "    classification_auroc: 0.7627\n",
+      "    classification_auprc: 0.7379\n",
+      "\n",
+      "Supervised evaluation complete. 2/2 tasks succeeded.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "supervised_results = {}\n",
+    "\n",
+    "for task in supervised_tasks:\n",
+    "    try:\n",
+    "        t0 = time.time()\n",
+    "        attrs = task.get_task_attributes()\n",
+    "        is_variant = attrs[\"is_variant_effect_prediction\"]\n",
+    "        num_labels = attrs[\"num_labels\"]\n",
+    "\n",
+    "        train_dataset = task.get_finetune_dataset()\n",
+    "        if train_dataset is None:\n",
+    "            print(f\"  SKIPPED: no training data available\")\n",
+    "            continue\n",
+    "\n",
+    "        print(f\"  Task: {task.get_task_name()}\")\n",
+    "        print(f\"  Type: {'variant-pair' if is_variant else 'single-seq'}\")\n",
+    "        print(f\"  Num labels: {num_labels}\")\n",
+    "        print(f\"  Train samples: {len(train_dataset)}\")\n",
+    "        print(f\"  Test samples: {len(task.test_dataset)}\")\n",
+    "\n",
+    "        # Step 1: Extract embeddings from training set\n",
+    "        print(f\"\\n  Step 1: Extracting training embeddings...\")\n",
+    "        if is_variant:\n",
+    "            X_train, y_train = extract_embeddings_variant_pair(evo2_model, train_dataset, BATCH_SIZE)\n",
+    "        else:\n",
+    "            X_train, y_train = extract_embeddings_single_seq(evo2_model, train_dataset, BATCH_SIZE)\n",
+    "        print(f\"  Embeddings shape: {X_train.shape}, Labels shape: {y_train.shape}\")\n",
+    "\n",
+    "        # Step 2: Train linear probe\n",
+    "        print(f\"\\n  Step 2: Training linear probe...\")\n",
+    "        clf = train_linear_probe(X_train, y_train, num_labels, LINEAR_PROBE_MAX_ITER, LINEAR_PROBE_C)\n",
+    "\n",
+    "        # Step 3: Wrap into GFMBench-API compatible model\n",
+    "        probe_model = Evo2LinearProbeModel(\n",
+    "            backbone=evo2_model,\n",
+    "            clf=clf,\n",
+    "            is_variant_pair=is_variant,\n",
+    "        )\n",
+    "\n",
+    "        # Step 4: Evaluate via GFMBench-API\n",
+    "        print(f\"\\n  Step 3: Evaluating on test set...\")\n",
+    "        results = task.eval_test_set(probe_model)\n",
+    "\n",
+    "        elapsed = time.time() - t0\n",
+    "        print(f\"\\n  Results ({elapsed:.1f}s):\")\n",
+    "        for metric, score in results.items():\n",
+    "            val_str = f\"{score:.4f}\" if score is not None else \"N/A\"\n",
+    "            print(f\"    {metric}: {val_str}\")\n",
+    "\n",
+    "        # Store and save incrementally\n",
+    "        supervised_results[task.get_task_name()] = results\n",
+    "        report.add_scores(task.get_task_name(), MODEL_NAME, results)\n",
+    "        report.save_csv()\n",
+    "\n",
+    "        # Free training embeddings\n",
+    "        del X_train, y_train, clf, probe_model\n",
+    "\n",
+    "    except Exception as e:\n",
+    "        print(f\"  FAILED: {e}\")\n",
+    "        import traceback; traceback.print_exc()\n",
+    "    finally:\n",
+    "        torch.cuda.empty_cache()\n",
+    "\n",
+    "print(f\"\\nSupervised evaluation complete. {len(supervised_results)}/{len(supervised_tasks)} tasks succeeded.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "### 3.7 Results Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T18:26:00.007059Z",
+     "iopub.status.busy": "2026-06-14T18:26:00.006859Z",
+     "iopub.status.idle": "2026-06-14T18:26:00.025993Z",
+     "shell.execute_reply": "2026-06-14T18:26:00.024882Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GFMBench-API Results for evo2_1b-8k-bf16_1.0\n",
+      "\n",
+      "Zero-shot tasks\n",
+      "======================================================================\n",
+      "Tasks: 2 | Metrics: 8\n",
+      "                              sum_probs_llr_auroc  sum_probs_llr_auprc  sequence_embeddings_cosinesim_auroc  sequence_embeddings_cosinesim_auprc  sequence_embeddings_l2_auroc  sequence_embeddings_l2_auprc  snv_variant_effect_cosinesim_auroc  snv_variant_effect_cosinesim_auprc\n",
+      "task                                                                                                                                                                                                                                                                                \n",
+      "brca1                                      0.7423               0.5332                               0.7495                               0.5426                        0.7781                        0.5773                              0.5328                              0.2221\n",
+      "bend_variant_effects_disease               0.9195               0.7422                               0.8723                               0.4737                        0.9115                        0.5955                              0.5755                              0.0822\n",
+      "\n",
+      "Supervised tasks (linear probing)\n",
+      "======================================================================\n",
+      "Tasks: 2 | Metrics: 4\n",
+      "                                classification_accuracy  classification_mcc  classification_auroc  classification_auprc\n",
+      "task                                                                                                                   \n",
+      "gue_splice_site                                  0.5848              0.1851                0.7120                0.5081\n",
+      "var_bench_coding_pathogenicity                   0.7043              0.4027                0.7627                0.7379\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "# Zero-shot and supervised tasks report different metric families; keep tables separate.\n",
+    "ZERO_SHOT_METRIC_PREFIXES = (\"sum_probs_\", \"sequence_embeddings_\", \"snv_variant_effect_\")\n",
+    "SUPERVISED_METRIC_PREFIXES = (\"classification_\",)\n",
+    "\n",
+    "\n",
+    "def _filter_metric_columns(columns, prefixes):\n",
+    "    return [c for c in columns if any(c.startswith(p) for p in prefixes)]\n",
+    "\n",
+    "\n",
+    "def _results_dict_to_table(results_dict, title, metric_prefixes=None):\n",
+    "    \"\"\"Build a wide results table from eval dicts; drop empty metric columns.\"\"\"\n",
+    "    print(f\"{title}\")\n",
+    "    print(f\"{'=' * 70}\")\n",
+    "    if not results_dict:\n",
+    "        print(\"  (no results)\\n\")\n",
+    "        return None\n",
+    "\n",
+    "    rows = [{\"task\": task, **metrics} for task, metrics in results_dict.items()]\n",
+    "    table = pd.DataFrame(rows).set_index(\"task\")\n",
+    "    table = table.apply(pd.to_numeric, errors=\"coerce\")\n",
+    "    if metric_prefixes:\n",
+    "        cols = _filter_metric_columns(table.columns, metric_prefixes)\n",
+    "        table = table[cols]\n",
+    "    table = table.dropna(axis=1, how=\"all\")\n",
+    "\n",
+    "    print(f\"Tasks: {len(table)} | Metrics: {len(table.columns)}\")\n",
+    "    print(table.round(4).to_string())\n",
+    "    print()\n",
+    "    return table\n",
+    "\n",
+    "\n",
+    "pd.set_option(\"display.max_columns\", None)\n",
+    "pd.set_option(\"display.width\", 200)\n",
+    "pd.set_option(\"display.float_format\", \"{:.4f}\".format)\n",
+    "\n",
+    "print(f\"GFMBench-API Results for {MODEL_NAME}\\n\")\n",
+    "\n",
+    "zero_shot_summary = _results_dict_to_table(\n",
+    "    zero_shot_results,\n",
+    "    \"Zero-shot tasks\",\n",
+    "    metric_prefixes=ZERO_SHOT_METRIC_PREFIXES,\n",
+    ")\n",
+    "supervised_summary = _results_dict_to_table(\n",
+    "    supervised_results,\n",
+    "    \"Supervised tasks (linear probing)\",\n",
+    "    metric_prefixes=SUPERVISED_METRIC_PREFIXES,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Key AUROC metrics at a glance (aggregated by task type)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T18:26:00.028698Z",
+     "iopub.status.busy": "2026-06-14T18:26:00.028486Z",
+     "iopub.status.idle": "2026-06-14T18:26:00.040397Z",
+     "shell.execute_reply": "2026-06-14T18:26:00.039387Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Aggregated AUROC for Evo2 (evo2/1b-8k-bf16:1.0)\n",
+      "\n",
+      "Zero-shot (mean AUROC)\n",
+      "======================================================================\n",
+      "                                     mean_auroc  n_tasks\n",
+      "metric                                                  \n",
+      "sum_probs_llr_auroc                      0.8309        2\n",
+      "sequence_embeddings_cosinesim_auroc      0.8109        2\n",
+      "sequence_embeddings_l2_auroc             0.8448        2\n",
+      "snv_variant_effect_cosinesim_auroc       0.5541        2\n",
+      "\n",
+      "Supervised (mean AUROC)\n",
+      "======================================================================\n",
+      "                      mean_auroc  n_tasks\n",
+      "metric                                   \n",
+      "classification_auroc      0.7374        2\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "def _print_auroc_aggregates(table, title):\n",
+    "    \"\"\"Print mean AUROC per metric (per-task values are in the cell above).\"\"\"\n",
+    "    print(f\"{title}\")\n",
+    "    print(f\"{'=' * 70}\")\n",
+    "    if table is None or table.empty:\n",
+    "        print(\"  (no results)\\n\")\n",
+    "        return\n",
+    "\n",
+    "    auroc_cols = [c for c in table.columns if \"auroc\" in c.lower()]\n",
+    "    if not auroc_cols:\n",
+    "        print(\"  (no AUROC metrics)\\n\")\n",
+    "        return\n",
+    "\n",
+    "    auroc_df = table[auroc_cols].dropna(axis=1, how=\"all\")\n",
+    "    rows = []\n",
+    "    for col in auroc_df.columns:\n",
+    "        valid = auroc_df[col].dropna()\n",
+    "        if len(valid) > 0:\n",
+    "            rows.append({\n",
+    "                \"metric\": col,\n",
+    "                \"mean_auroc\": valid.mean(),\n",
+    "                \"n_tasks\": len(valid),\n",
+    "            })\n",
+    "    if not rows:\n",
+    "        print(\"  (no valid AUROC scores)\\n\")\n",
+    "        return\n",
+    "\n",
+    "    agg = pd.DataFrame(rows).set_index(\"metric\")\n",
+    "    print(agg.round(4).to_string())\n",
+    "    print()\n",
+    "\n",
+    "\n",
+    "print(f\"Aggregated AUROC for Evo2 ({CKPT_TAG})\\n\")\n",
+    "_print_auroc_aggregates(zero_shot_summary, \"Zero-shot (mean AUROC)\")\n",
+    "_print_auroc_aggregates(supervised_summary, \"Supervised (mean AUROC)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "### 3.8 Export"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-14T18:26:00.043048Z",
+     "iopub.status.busy": "2026-06-14T18:26:00.042836Z",
+     "iopub.status.idle": "2026-06-14T18:26:00.049643Z",
+     "shell.execute_reply": "2026-06-14T18:26:00.048669Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Results saved to: evo2_gfmbench_results.csv\n",
+      "JSON summary saved to: evo2_gfmbench_results.json\n",
+      "\n",
+      "Done! Evaluated 4 tasks total (2 zero-shot, 2 supervised).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Final save\n",
+    "report.save_csv()\n",
+    "print(f\"Results saved to: {RESULTS_CSV}\")\n",
+    "\n",
+    "\n",
+    "json_path = RESULTS_CSV.replace(\".csv\", \".json\")\n",
+    "json_summary = {\n",
+    "    \"model\": MODEL_NAME,\n",
+    "    \"ckpt_tag\": CKPT_TAG,\n",
+    "    \"max_seq_length\": MAX_SEQ_LENGTH,\n",
+    "    \"task_config\": TASK_CONFIG,\n",
+    "    \"zero_shot_results\": zero_shot_results,\n",
+    "    \"supervised_results\": supervised_results,\n",
+    "}\n",
+    "with open(json_path, \"w\") as f:\n",
+    "    json.dump(json_summary, f, indent=2, default=str)\n",
+    "\n",
+    "print(f\"JSON summary saved to: {json_path}\")\n",
+    "n_tasks = len(zero_shot_results) + len(supervised_results)\n",
+    "print(f\"\\nDone! Evaluated {n_tasks} tasks total \"\n",
+    "      f\"({len(zero_shot_results)} zero-shot, {len(supervised_results)} supervised).\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
### Description

Adds evo2_gfmbench_recipe.ipynb, an example notebook for evaluating Evo2 with GFMBench-API via BioNeMo. It covers GFMBench-API setup, loading Evo2 through Evo2BioNeMoModel, and running GFMBench-API tasks. Also updates examples/.gitignore to exclude cloned GFMBench-API, downloaded data, and result files.


#### Usage

Run from the `evo2_megatron/examples` directory inside the BioNeMo container

```bash
cd bionemo-recipes/recipes/evo2_megatron/examples
jupyter notebook evo2_gfmbench_recipe.ipynb
```

### Type of changes

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [X] Documentation update
- [ ] Other (please describe):


### CI Pipeline Configuration

Configure CI behavior by applying the relevant labels. By default, only basic unit tests are run.

- [ciflow:skip](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:skip) - Skip all CI tests for this PR
- [ciflow:notebooks](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:notebooks) - Run Jupyter notebooks execution tests
- [ciflow:slow](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:slow) - Run slow single GPU integration tests marked as @pytest.mark.slow
- [ciflow:all](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:all) - Run all tests (unit tests, slow tests, and notebooks). This label can be used to enforce running all framework tests.
- [ciflow:all-recipes](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:all-recipes) - Run tests for all recipes (under bionemo-recipes). This label can be used to enforce running tests for all recipes.

Unit tests marked as `@pytest.mark.multi_gpu` or `@pytest.mark.distributed` are not run in the PR pipeline.

For more details, see [CONTRIBUTING](CONTRIBUTING.md)

> [!NOTE]
> By default, only basic unit tests are run. Add appropriate labels to enable an additional test coverage.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

#### Triggering Code Rabbit AI Review

To trigger a code review from code rabbit, comment on a pull request with one of these commands:

- @coderabbitai review - Triggers a standard review
- @coderabbitai full review - Triggers a comprehensive review

See https://docs.coderabbit.ai/reference/review-commands for a full list of commands.

### Pre-submit Checklist

<!--- Ensure all items are completed before submitting -->

- [X] I have tested these changes locally
- [X] I have updated the documentation accordingly
- [X] I have added/updated tests as needed (notebook saved with outputs for CI)
- [X] All existing tests pass successfully
