### PR TITLE
docs: replace obsolete --experiment-dir with --result-dir in SLURM guide (#1128)

### DIFF
--- a/docs/docs/main/getting-started/using-slurm.md
+++ b/docs/docs/main/getting-started/using-slurm.md
@@ -87,7 +87,7 @@ cd /workspace/bionemo/recipes/evo2_megatron \
     --hidden-dropout $HDO \
     --limit-val-batches=20 \
     --val-check-interval=${VAL_CHECK} \
-    --experiment-dir=/workspace/bionemo/model/checkpoints/${EXPERIMENT_NAME} \
+    --result-dir=${RESULTS_PATH} \
     --seq-length=${SEQ_LEN} \
     --tensor-parallel-size=${TP_SIZE} \
     --context-parallel-size=${CP_SIZE} \


### PR DESCRIPTION
## Summary

The `--experiment-dir` parameter was removed from `train_evo2` as part of PR #740, but one reference remained in the SLURM documentation.

## What was broken

The [SLURM guide](https://github.com/NVIDIA-BioNeMo/bionemo-framework/blob/main/docs/docs/main/getting-started/using-slurm.md) contained an obsolete `--experiment-dir` parameter in the example training command (line 90). Users following this guide would get an unknown parameter error.

## What the fix does

Replaces `--experiment-dir=/workspace/bionemo/model/checkpoints/${EXPERIMENT_NAME}` with `--result-dir=${RESULTS_PATH}`, which:
1. Uses the correct current parameter name (`--result-dir`)
2. Uses the already-defined `RESULTS_PATH` variable for consistency with the rest of the script

## Verification

- Confirmed `--result-dir` is the current parameter in `recipes/evo2_megatron/src/bionemo/evo2/run/train.py:315`
- Confirmed no other references to `--experiment-dir` remain in the codebase
- The `RESULTS_PATH` variable is already defined at line 62 of the same file

Fixes #1128

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
