### PR TITLE
fix: remove deprecated target_device argument from gather_uneven_dtensor_to_full_tensor

### DIFF
--- a/recipes/esm2_native_te/checkpoint.py
+++ b/recipes/esm2_native_te/checkpoint.py
@@ -320,9 +320,7 @@ def save_final_model_mfsdp(
     # Parameter gathering must happen on ALL processes
     unsharded_state_dict = {
         # Gather all parameters to CPU, and remove the "module." prefix from the Megatron-FSDP class wrapper.
-        k.removeprefix("module."): gather_uneven_dtensor_to_full_tensor(
-            v, target_device=torch.device("cpu")
-        ).to_local()
+        k.removeprefix("module."): gather_uneven_dtensor_to_full_tensor(v).to_local().to("cpu")
         if isinstance(v, torch.distributed.tensor.DTensor)
         else v
         for k, v in model.state_dict().items()


### PR DESCRIPTION
The megatron_fsdp.uneven_dtensor.gather_uneven_dtensor_to_full_tensor function no longer accepts a target_device parameter. It now returns a replicated DTensor instead of a full tensor on a specific device.

Fix by:
1. Removing the target_device=torch.device("cpu") argument
2. Adding .to("cpu") after .to_local() to move the gathered tensor to CPU

This fixes the TypeError: gather_uneven_dtensor_to_full_tensor() got an unexpected keyword argument "target_device" error in test_final_model_save_mfsdp.

Related to failed nightly CI run #28019158813.