### PR TITLE
Add tokens/sec throughput logging and multi-size/TP support to evo2 classifier

### DIFF
--- a/recipes/evo2_megatron/examples/evo2_classifier.py
+++ b/recipes/evo2_megatron/examples/evo2_classifier.py
@@ -86,6 +86,9 @@ from bionemo.evo2.data.dataset_tokenizer import DEFAULT_HF_TOKENIZER_MODEL_PATH_
 from bionemo.evo2.models.evo2_lora import Evo2LoRA
 from bionemo.evo2.models.evo2_provider import (
     Hyena1bModelProvider,
+    Hyena7bModelProvider,
+    Hyena40bARCLongContextModelProvider,
+    Hyena40bModelProvider,
     HyenaModelProvider,
     HyenaOptimizerConfigOverrideProvider,
 )
@@ -296,6 +299,31 @@ class Hyena1bClassifierProvider(Hyena1bModelProvider, HyenaForSequenceClassifica
     """1B Evo2 backbone with a classification head."""
 
 
+@dataclass
+class Hyena7bClassifierProvider(Hyena7bModelProvider, HyenaForSequenceClassificationProvider):
+    """7B Evo2 backbone (8k context) with a classification head."""
+
+
+@dataclass
+class Hyena40bBaseClassifierProvider(Hyena40bModelProvider, HyenaForSequenceClassificationProvider):
+    """40B Evo2 backbone (8k context, unpadded FFN) with a classification head."""
+
+
+@dataclass
+class Hyena40bClassifierProvider(Hyena40bARCLongContextModelProvider, HyenaForSequenceClassificationProvider):
+    """40B Evo2 backbone (ARC long-context checkpoint, padded FFN) with a classification head."""
+
+
+# Maps the --model-size key to the classifier provider that wraps that backbone with a
+# sequence-classification head.
+CLASSIFIER_PROVIDER_OPTIONS: dict[str, type[HyenaForSequenceClassificationProvider]] = {
+    "evo2_1b_base": Hyena1bClassifierProvider,
+    "evo2_7b_base": Hyena7bClassifierProvider,
+    "evo2_40b_base": Hyena40bBaseClassifierProvider,
+    "evo2_40b": Hyena40bClassifierProvider,
+}
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Dataset
 # ─────────────────────────────────────────────────────────────────────────────
@@ -482,6 +510,8 @@ def evo2_1b_classifier_config(  # noqa: D417
     num_classes: int,
     result_dir: Path,
     experiment_name: str,
+    model_size: str = "evo2_1b_base",
+    tensor_model_parallel_size: int = 1,
     seq_length_tokens: int = 512,
     backbone_seq_length: int = 8192,
     train_iters: int = 300,
@@ -508,6 +538,8 @@ def evo2_1b_classifier_config(  # noqa: D417
     tokenizer_path: str = DEFAULT_HF_TOKENIZER_MODEL_PATH_512,
     no_activation_checkpointing: bool = True,
     precision_recipe: str = "bf16_mixed",
+    log_throughput_to_tensorboard: bool = True,
+    throughput_window_size: int = 20,
     wandb_project: Optional[str] = None,
     wandb_entity: Optional[str] = None,
     wandb_run_name: Optional[str] = None,
@@ -519,10 +551,23 @@ def evo2_1b_classifier_config(  # noqa: D417
         base_ckpt_dir: Path to a pretrained MBridge backbone checkpoint
             (parent of ``iter_*`` subdirs is auto-resolved).
         num_classes: Number of classification labels.
+        model_size: Backbone-size key in :data:`CLASSIFIER_PROVIDER_OPTIONS`
+            (e.g. ``"evo2_1b_base"``, ``"evo2_7b_base"``, ``"evo2_40b"``). Must
+            match the ``--model-size`` used to convert ``base_ckpt_dir``,
+            otherwise the backbone weight shapes will not line up.
+        tensor_model_parallel_size: Shard the backbone across this many GPUs with
+            tensor parallelism. Needed for backbones that do not fit on one GPU
+            (e.g. 40b). The classification head runs on the full (TP-replicated)
+            hidden state, so no pipeline parallelism is involved. ``world_size``
+            must be divisible by this value.
         use_lora: If ``False``, run the head-only baseline — backbone is
             loaded and frozen, but no LoRA adapters are added.
         no_activation_checkpointing: Disable Hyena's full recompute. Short
             sequences fit comfortably without it.
+        log_throughput_to_tensorboard: Emit ``throughput/tokens_per_sec``.
+        throughput_window_size: Rolling-average window (in iterations) for the
+            throughput metrics; the first point is logged once this many
+            iterations have elapsed.
 
     Remaining keyword arguments are forwarded to the corresponding fields of
     the underlying mbridge config dataclasses (``TrainingConfig``,
@@ -536,13 +581,16 @@ def evo2_1b_classifier_config(  # noqa: D417
         raise ValueError(f"num_classes must be ≥ 2 for classification, got {num_classes}.")
 
     # ── Model provider ────────────────────────────────────────────────────
-    model_cfg = Hyena1bClassifierProvider(
+    if model_size not in CLASSIFIER_PROVIDER_OPTIONS:
+        raise ValueError(f"Unknown model_size {model_size!r}. Options: {sorted(CLASSIFIER_PROVIDER_OPTIONS)}.")
+    classifier_provider_cls = CLASSIFIER_PROVIDER_OPTIONS[model_size]
+    model_cfg = classifier_provider_cls(
         num_classes=num_classes,
         classifier_hidden_size=classifier_hidden_size,
         classifier_dropout=classifier_dropout,
         pool=pool,
         seq_length=backbone_seq_length,
-        tensor_model_parallel_size=1,
+        tensor_model_parallel_size=tensor_model_parallel_size,
         pipeline_model_parallel_size=1,
         context_parallel_size=1,
         sequence_parallel=False,
@@ -628,6 +676,8 @@ def evo2_1b_classifier_config(  # noqa: D417
             tensorboard_dir=str(tensorboard_dir),
             log_params_norm=False,
             log_throughput=False,
+            log_throughput_to_tensorboard=log_throughput_to_tensorboard,
+            throughput_window_size=throughput_window_size,
             log_progress=True,
             wandb_project=wandb_project or "",
             wandb_exp_name=wandb_run_name or experiment_name,
@@ -952,10 +1002,14 @@ def predict(
 
 
 __all__ = [
+    "CLASSIFIER_PROVIDER_OPTIONS",
     "DEFAULT_LORA_TARGET_MODULES",
     "Evo2ClassifierDataset",
     "Evo2ClassifierDatasetProvider",
     "Hyena1bClassifierProvider",
+    "Hyena7bClassifierProvider",
+    "Hyena40bBaseClassifierProvider",
+    "Hyena40bClassifierProvider",
     "HyenaForSequenceClassification",
     "HyenaForSequenceClassificationProvider",
     "classifier_forward_step",
@@ -990,6 +1044,19 @@ def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     )
     p.add_argument("--experiment-name", required=True, help="Subdirectory of --result-dir for this run.")
     p.add_argument("--num-classes", type=int, required=True)
+    p.add_argument(
+        "--model-size",
+        choices=sorted(CLASSIFIER_PROVIDER_OPTIONS.keys()),
+        default="evo2_1b_base",
+        help="Backbone size. Must match the --model-size used to convert --base-ckpt-dir.",
+    )
+    p.add_argument(
+        "--tensor-model-parallel-size",
+        type=int,
+        default=1,
+        help="Shard the backbone across this many GPUs via tensor parallelism "
+        "(--nproc_per_node must be a multiple of this).",
+    )
     p.add_argument("--seq-length-tokens", type=int, default=512)
     p.add_argument("--backbone-seq-length", type=int, default=8192)
     p.add_argument("--train-iters", type=int, default=300)
@@ -1025,6 +1092,25 @@ def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     )
     p.add_argument("--tokenizer-path", default=DEFAULT_HF_TOKENIZER_MODEL_PATH_512)
     p.add_argument("--precision-recipe", default="bf16_mixed")
+    p.add_argument(
+        "--activation-checkpointing",
+        action="store_true",
+        help="Enable full activation recomputation in the backbone.",
+    )
+    p.add_argument(
+        "--log-token-throughput",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        dest="log_throughput_to_tensorboard",
+        help="Log throughput/tokens_per_sec (and samples/batches per sec) to W&B.",
+    )
+    p.add_argument(
+        "--throughput-window-size",
+        type=int,
+        default=20,
+        help="Rolling-average window (in iterations) for throughput metrics. The first "
+        "throughput point is logged once this many iterations have elapsed.",
+    )
     p.add_argument("--wandb-project", default=None, help="W&B project name. Disables wandb when omitted.")
     p.add_argument("--wandb-entity", default=None, help="W&B team/user posting the run.")
     p.add_argument("--wandb-run-name", default=None, help="W&B run name. Defaults to --experiment-name.")
@@ -1044,6 +1130,8 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         num_classes=args.num_classes,
         result_dir=args.result_dir,
         experiment_name=args.experiment_name,
+        model_size=args.model_size,
+        tensor_model_parallel_size=args.tensor_model_parallel_size,
         seq_length_tokens=args.seq_length_tokens,
         backbone_seq_length=args.backbone_seq_length,
         train_iters=args.train_iters,
@@ -1068,7 +1156,10 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         lora_dropout=args.lora_dropout,
         lora_target_modules=args.lora_target_modules,
         tokenizer_path=args.tokenizer_path,
+        no_activation_checkpointing=not args.activation_checkpointing,
         precision_recipe=args.precision_recipe,
+        log_throughput_to_tensorboard=args.log_throughput_to_tensorboard,
+        throughput_window_size=args.throughput_window_size,
         wandb_project=args.wandb_project,
         wandb_entity=args.wandb_entity,
         wandb_run_name=args.wandb_run_name,
@@ -1079,5 +1170,8 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 
 if __name__ == "__main__":
     Hyena1bClassifierProvider.__module__ = "evo2_classifier"
+    Hyena7bClassifierProvider.__module__ = "evo2_classifier"
+    Hyena40bBaseClassifierProvider.__module__ = "evo2_classifier"
+    Hyena40bClassifierProvider.__module__ = "evo2_classifier"
     Evo2ClassifierDatasetProvider.__module__ = "evo2_classifier"
     main(sys.argv[1:])

--- a/recipes/evo2_megatron/examples/lora-fine-tuning-tutorial.ipynb
+++ b/recipes/evo2_megatron/examples/lora-fine-tuning-tutorial.ipynb
@@ -337,13 +337,21 @@
     "from bionemo.evo2.data.dataset_tokenizer import DEFAULT_HF_TOKENIZER_MODEL_PATH_512\n",
     "\n",
     "\n",
+    "# This tutorial uses the 1b backbone. The same download + convert flow works for the larger\n",
+    "# Evo2 backbones \u2014 switch MODEL_SIZE and the load() tag together (and, for 40b, bump\n",
+    "# TENSOR_PARALLEL_SIZE in the hyperparameter cell below):\n",
+    "#   1b : load(\"evo2/1b-8k-bf16:1.0\")       MODEL_SIZE=\"evo2_1b_base\"   (TP 1)\n",
+    "#   7b : load(\"evo2/7b-8k:1.0\")            MODEL_SIZE=\"evo2_7b_base\"   (TP 1)\n",
+    "#   40b: load(\"evo2/40b-1m-fp8-bf16:1.0\")  MODEL_SIZE=\"evo2_40b\"       (TP >= 2)\n",
+    "# Run `download_bionemo_data --list-resources | grep evo2` for the full list of checkpoints.\n",
+    "MODEL_SIZE = \"evo2_1b_base\"\n",
     "mbridge_ckpt_path = Path(\"evo2_1b_bf16_mbridge\")\n",
     "if not mbridge_ckpt_path.exists():\n",
     "    nemo2_ckpt_path = load(\"evo2/1b-8k-bf16:1.0\")\n",
     "    convert_cmd = f\"\"\"evo2_convert_nemo2_to_mbridge \\\n",
     "        --nemo2-ckpt-dir {nemo2_ckpt_path} \\\n",
     "        --mbridge-ckpt-dir {mbridge_ckpt_path} \\\n",
-    "        --model-size evo2_1b_base \\\n",
+    "        --model-size {MODEL_SIZE} \\\n",
     "        --mixed-precision-recipe bf16_mixed \\\n",
     "        --seq-length 8192 \\\n",
     "        --tokenizer-path {DEFAULT_HF_TOKENIZER_MODEL_PATH_512}\"\"\"\n",
@@ -369,7 +377,7 @@
    "id": "cell-012",
    "metadata": {},
    "outputs": [],
-   "source": "import math\n\nimport torch\n\n\nSEQ_LEN_TOKENS = ((SEQ_BP + 7) // 8) * 8\nprint(f\"Padding to {SEQ_LEN_TOKENS} tokens (raw sequence is {SEQ_BP} bp).\")\n\nNUM_GPUS = max(1, torch.cuda.device_count())\nTRAIN_ITERS_BASELINE = 40 if FAST_CI_MODE else 1000\nTRAIN_ITERS_LORA = 40 if FAST_CI_MODE else 1000\nMICRO_BATCH_SIZE_BASELINE = 32 if FAST_CI_MODE else 128\nMICRO_BATCH_SIZE_LORA = 4 if FAST_CI_MODE else 32\nGRAD_ACCUM_STEPS = 1\nGLOBAL_BATCH_SIZE_BASELINE = MICRO_BATCH_SIZE_BASELINE * NUM_GPUS * GRAD_ACCUM_STEPS\nGLOBAL_BATCH_SIZE_LORA = MICRO_BATCH_SIZE_LORA * NUM_GPUS * GRAD_ACCUM_STEPS\n\nWARMUP_ITERS_BASELINE = 5 if FAST_CI_MODE else 20\nWARMUP_ITERS_LORA = 5 if FAST_CI_MODE else 30\n\nEVAL_ITERS_BASELINE = math.ceil(len(val_df_s) / GLOBAL_BATCH_SIZE_BASELINE)\nEVAL_ITERS_LORA = math.ceil(len(val_df_s) / GLOBAL_BATCH_SIZE_LORA)\n\nSAVE_INTERVAL_BASELINE = max(TRAIN_ITERS_BASELINE // 5, 1)\nSAVE_INTERVAL_LORA = max(TRAIN_ITERS_LORA // 5, 1)\n\nDECAY_STEPS_LORA = 100000\n\nRESULT_DIR = Path(\"splice_run\").absolute()\nEXP_BASELINE = \"baseline_head_only\"\nEXP_LORA = \"lora_finetune\"\nRESULT_DIR.mkdir(parents=True, exist_ok=True)"
+   "source": "import math\n\nimport torch\n\n\nSEQ_LEN_TOKENS = ((SEQ_BP + 7) // 8) * 8\nprint(f\"Padding to {SEQ_LEN_TOKENS} tokens (raw sequence is {SEQ_BP} bp).\")\n\nNUM_GPUS = max(1, torch.cuda.device_count())\n\n# Backbone parallelism / memory knobs. The defaults are correct for the 1b model; the\n# larger 7b / 40b backbones (see the checkpoint cell) need these turned up:\n#   - TENSOR_PARALLEL_SIZE shards the backbone across this many GPUs (40b needs >= 2).\n#     NUM_GPUS must be a multiple of it; the remaining GPUs are used for data parallelism.\n#   - USE_ACTIVATION_CHECKPOINTING recomputes activations to cut memory at some throughput cost.\nTENSOR_PARALLEL_SIZE = 1\nUSE_ACTIVATION_CHECKPOINTING = False\nassert NUM_GPUS % TENSOR_PARALLEL_SIZE == 0, \"NUM_GPUS must be a multiple of TENSOR_PARALLEL_SIZE.\"\nDP_SIZE = NUM_GPUS // TENSOR_PARALLEL_SIZE\nACTIVATION_CHECKPOINTING_FLAG = \"--activation-checkpointing\" if USE_ACTIVATION_CHECKPOINTING else \"\"\n\nTRAIN_ITERS_BASELINE = 40 if FAST_CI_MODE else 1000\nTRAIN_ITERS_LORA = 40 if FAST_CI_MODE else 1000\nMICRO_BATCH_SIZE_BASELINE = 32 if FAST_CI_MODE else 128\nMICRO_BATCH_SIZE_LORA = 4 if FAST_CI_MODE else 32\nGRAD_ACCUM_STEPS = 1\nGLOBAL_BATCH_SIZE_BASELINE = MICRO_BATCH_SIZE_BASELINE * DP_SIZE * GRAD_ACCUM_STEPS\nGLOBAL_BATCH_SIZE_LORA = MICRO_BATCH_SIZE_LORA * DP_SIZE * GRAD_ACCUM_STEPS\n\nWARMUP_ITERS_BASELINE = 5 if FAST_CI_MODE else 20\nWARMUP_ITERS_LORA = 5 if FAST_CI_MODE else 30\n\nEVAL_ITERS_BASELINE = math.ceil(len(val_df_s) / GLOBAL_BATCH_SIZE_BASELINE)\nEVAL_ITERS_LORA = math.ceil(len(val_df_s) / GLOBAL_BATCH_SIZE_LORA)\n\nSAVE_INTERVAL_BASELINE = max(TRAIN_ITERS_BASELINE // 5, 1)\nSAVE_INTERVAL_LORA = max(TRAIN_ITERS_LORA // 5, 1)\n\nDECAY_STEPS_LORA = 100000\n\nRESULT_DIR = Path(\"splice_run\").absolute()\nEXP_BASELINE = \"baseline_head_only\"\nEXP_LORA = \"lora_finetune\"\nRESULT_DIR.mkdir(parents=True, exist_ok=True)"
   },
   {
    "cell_type": "markdown",
@@ -434,7 +442,7 @@
    "id": "cell-014",
    "metadata": {},
    "outputs": [],
-   "source": "from bionemo.common.utils.subprocess_utils import run_subprocess_safely\n\n\nbaseline_cmd = f\"\"\"torchrun --nproc_per_node={NUM_GPUS} evo2_classifier.py \\\n    --train-jsonl splice_train.jsonl \\\n    --val-jsonl   splice_val.jsonl \\\n    --test-jsonl  splice_test.jsonl \\\n    --base-ckpt-dir {mbridge_ckpt_path} \\\n    --result-dir {RESULT_DIR} \\\n    --experiment-name {EXP_BASELINE} \\\n    --num-classes {len(LABEL_NAMES)} \\\n    --seq-length-tokens {SEQ_LEN_TOKENS} \\\n    --train-iters {TRAIN_ITERS_BASELINE} \\\n    --global-batch-size {GLOBAL_BATCH_SIZE_BASELINE} \\\n    --micro-batch-size {MICRO_BATCH_SIZE_BASELINE} \\\n    --lr 1e-3 --min-lr 1e-4 --warmup-iters {WARMUP_ITERS_BASELINE} \\\n    --eval-interval {min(TRAIN_ITERS_BASELINE // 4, 25)} \\\n    --eval-iters {EVAL_ITERS_BASELINE} \\\n    --save-interval {SAVE_INTERVAL_BASELINE} {WANDB_FLAGS_BASELINE}\"\"\"\n\nprint(f\"Running:\\n{baseline_cmd}\\n\")\nresult = run_subprocess_safely(baseline_cmd)\nif result[\"returncode\"] != 0:\n    raise RuntimeError(\n        f\"Head-only baseline run failed\\nSTDOUT:\\n{result['stdout'][-2000:]}\\nSTDERR:\\n{result['stderr'][-2000:]}\"\n    )"
+   "source": "from bionemo.common.utils.subprocess_utils import run_subprocess_safely\n\n\nbaseline_cmd = f\"\"\"torchrun --nproc_per_node={NUM_GPUS} evo2_classifier.py \\\n    --train-jsonl splice_train.jsonl \\\n    --val-jsonl   splice_val.jsonl \\\n    --test-jsonl  splice_test.jsonl \\\n    --base-ckpt-dir {mbridge_ckpt_path} \\\n    --model-size {MODEL_SIZE} \\\n    --tensor-model-parallel-size {TENSOR_PARALLEL_SIZE} \\\n    --result-dir {RESULT_DIR} \\\n    --experiment-name {EXP_BASELINE} \\\n    --num-classes {len(LABEL_NAMES)} \\\n    --seq-length-tokens {SEQ_LEN_TOKENS} \\\n    --train-iters {TRAIN_ITERS_BASELINE} \\\n    --global-batch-size {GLOBAL_BATCH_SIZE_BASELINE} \\\n    --micro-batch-size {MICRO_BATCH_SIZE_BASELINE} \\\n    --lr 1e-3 --min-lr 1e-4 --warmup-iters {WARMUP_ITERS_BASELINE} \\\n    --eval-interval {min(TRAIN_ITERS_BASELINE // 4, 25)} \\\n    --eval-iters {EVAL_ITERS_BASELINE} \\\n    --save-interval {SAVE_INTERVAL_BASELINE} {ACTIVATION_CHECKPOINTING_FLAG} {WANDB_FLAGS_BASELINE}\"\"\"\n\nprint(f\"Running:\\n{baseline_cmd}\\n\")\nresult = run_subprocess_safely(baseline_cmd)\nif result[\"returncode\"] != 0:\n    raise RuntimeError(\n        f\"Head-only baseline run failed\\nSTDOUT:\\n{result['stdout'][-2000:]}\\nSTDERR:\\n{result['stderr'][-2000:]}\"\n    )"
   },
   {
    "cell_type": "markdown",
@@ -452,7 +460,7 @@
    "id": "cell-016",
    "metadata": {},
    "outputs": [],
-   "source": "lora_cmd = f\"\"\"torchrun --nproc_per_node={NUM_GPUS} evo2_classifier.py \\\n    --train-jsonl splice_train.jsonl \\\n    --val-jsonl   splice_val.jsonl \\\n    --test-jsonl  splice_test.jsonl \\\n    --base-ckpt-dir {mbridge_ckpt_path} \\\n    --result-dir {RESULT_DIR} \\\n    --experiment-name {EXP_LORA} \\\n    --num-classes {len(LABEL_NAMES)} \\\n    --seq-length-tokens {SEQ_LEN_TOKENS} \\\n    --train-iters {TRAIN_ITERS_LORA} \\\n    --global-batch-size {GLOBAL_BATCH_SIZE_LORA} \\\n    --micro-batch-size {MICRO_BATCH_SIZE_LORA} \\\n    --lr 5e-4 --min-lr 5e-5 --warmup-iters {WARMUP_ITERS_LORA} --decay-steps {DECAY_STEPS_LORA} \\\n    --eval-interval {min(TRAIN_ITERS_LORA // 4, 25)} \\\n    --eval-iters {EVAL_ITERS_LORA} \\\n    --save-interval {SAVE_INTERVAL_LORA} \\\n    --lora-finetune --lora-dim 16 --lora-alpha 32 --lora-dropout 0.1 {WANDB_FLAGS_LORA}\"\"\"\n\nprint(f\"Running:\\n{lora_cmd}\\n\")\nresult = run_subprocess_safely(lora_cmd)\nif result[\"returncode\"] != 0:\n    raise RuntimeError(\n        f\"LoRA fine-tune run failed\\nSTDOUT:\\n{result['stdout'][-2000:]}\\nSTDERR:\\n{result['stderr'][-2000:]}\"\n    )"
+   "source": "lora_cmd = f\"\"\"torchrun --nproc_per_node={NUM_GPUS} evo2_classifier.py \\\n    --train-jsonl splice_train.jsonl \\\n    --val-jsonl   splice_val.jsonl \\\n    --test-jsonl  splice_test.jsonl \\\n    --base-ckpt-dir {mbridge_ckpt_path} \\\n    --model-size {MODEL_SIZE} \\\n    --tensor-model-parallel-size {TENSOR_PARALLEL_SIZE} \\\n    --result-dir {RESULT_DIR} \\\n    --experiment-name {EXP_LORA} \\\n    --num-classes {len(LABEL_NAMES)} \\\n    --seq-length-tokens {SEQ_LEN_TOKENS} \\\n    --train-iters {TRAIN_ITERS_LORA} \\\n    --global-batch-size {GLOBAL_BATCH_SIZE_LORA} \\\n    --micro-batch-size {MICRO_BATCH_SIZE_LORA} \\\n    --lr 5e-4 --min-lr 5e-5 --warmup-iters {WARMUP_ITERS_LORA} --decay-steps {DECAY_STEPS_LORA} \\\n    --eval-interval {min(TRAIN_ITERS_LORA // 4, 25)} \\\n    --eval-iters {EVAL_ITERS_LORA} \\\n    --save-interval {SAVE_INTERVAL_LORA} \\\n    --lora-finetune --lora-dim 16 --lora-alpha 32 --lora-dropout 0.1 {ACTIVATION_CHECKPOINTING_FLAG} {WANDB_FLAGS_LORA}\"\"\"\n\nprint(f\"Running:\\n{lora_cmd}\\n\")\nresult = run_subprocess_safely(lora_cmd)\nif result[\"returncode\"] != 0:\n    raise RuntimeError(\n        f\"LoRA fine-tune run failed\\nSTDOUT:\\n{result['stdout'][-2000:]}\\nSTDERR:\\n{result['stderr'][-2000:]}\"\n    )"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
### Description

Add tokens/sec throughput logging and multi-size/TP support to evo2 classifier

- Log throughput/tokens_per_sec (+ samples/batches per sec) to W&B/TensorBoard via LoggerConfig.log_throughput_to_tensorboard (--log-token-throughput, --throughput-window-size).
- Add 7b and 40b sequence-classification providers p
- Add --tensor-model-parallel-size and --activation-checkpointing CLI flags.


### Type of changes

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

### CI Pipeline Configuration

Configure CI behavior by applying the relevant labels. By default, only basic unit tests are run.

- [ciflow:skip](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:skip) - Skip all CI tests for this PR
- [ciflow:notebooks](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:notebooks) - Run Jupyter notebooks execution tests
- [ciflow:slow](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:slow) - Run slow single GPU integration tests marked as @pytest.mark.slow
- [ciflow:all](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:all) - Run all tests, including unit tests, slow tests, notebooks, and every recipe/model directory.

Unit tests marked as `@pytest.mark.multi_gpu` or `@pytest.mark.distributed` are not run in the PR pipeline.

For more details, see [CONTRIBUTING](CONTRIBUTING.md)

> [!NOTE]
> By default, only basic unit tests are run. Add appropriate labels to enable an additional test coverage.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

#### Triggering Code Rabbit AI Review

To trigger a code review from code rabbit, comment on a pull request with one of these commands:

- @coderabbitai review - Triggers a standard review
- @coderabbitai full review - Triggers a comprehensive review

See https://docs.coderabbit.ai/reference/review-commands for a full list of commands.

### Pre-submit Checklist

<!--- Ensure all items are completed before submitting -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly
- [x] I have added/updated tests as needed
- [x] All existing tests pass successfully
