### PR TITLE
fix: remove deprecated target_device argument from gather_uneven_dtensor_to_full_tensor

### DIFF
--- a/recipes/esm2_native_te/checkpoint.py
+++ b/recipes/esm2_native_te/checkpoint.py
@@ -320,9 +320,7 @@ def save_final_model_mfsdp(
     # Parameter gathering must happen on ALL processes
     unsharded_state_dict = {
         # Gather all parameters to CPU, and remove the "module." prefix from the Megatron-FSDP class wrapper.
-        k.removeprefix("module."): gather_uneven_dtensor_to_full_tensor(
-            v, target_device=torch.device("cpu")
-        ).to_local()
+        k.removeprefix("module."): gather_uneven_dtensor_to_full_tensor(v).to_local().to("cpu")
         if isinstance(v, torch.distributed.tensor.DTensor)
         else v
         for k, v in model.state_dict().items()


### PR DESCRIPTION
## Root Cause

The scheduled CI run [#28091039899](https://github.com/NVIDIA-BioNeMo/bionemo-recipes/actions/runs/28091039899) failed in `test_final_model_save_mfsdp` with:

```
TypeError: gather_uneven_dtensor_to_full_tensor() got an unexpected keyword argument 'target_device'
```

The `megatron_fsdp.uneven_dtensor.gather_uneven_dtensor_to_full_tensor` function no longer accepts a `target_device` parameter. It now returns a replicated DTensor instead of a full tensor on a specific device.

## Fix

1. Removed the deprecated `target_device=torch.device('cpu')` argument
2. Added `.to('cpu')` after `.to_local()` to move the gathered tensor to CPU

## Affected File

- `recipes/esm2_native_te/checkpoint.py` (line 323)

## Verification

Commit `462d94e0` is GitHub-verified with SSH signature from svc-bionemo.