### PR TITLE
ci: GPU matrix lane for interpretability SAE recipes (merge-first, presence-guarded)

### DIFF
--- a/.github/workflows/unit-tests-interpretability-recipes.yaml
+++ b/.github/workflows/unit-tests-interpretability-recipes.yaml
@@ -14,9 +14,9 @@ name: "BioNeMo Interpretability Recipes CI"
 #     auto-activates once that recipe is on the ref under test.
 #   * Relevance guard - there is NO workflow-level `paths:` filter (it doesn't match the blossom
 #     mirror push, so the lane would never trigger). Instead the gate diffs against origin/main
-#     and only runs the GPU suite when the evo2 SAE recipe / shared `sae` lib / evo2_megatron
-#     actually changed - otherwise every PR push and merge would build the Evo2 1B. schedule
-#     (nightly) always runs the full suite.
+#     and only runs the GPU suite when the evo2 SAE recipe OR evo2_megatron (its base model)
+#     actually changed - otherwise every PR push and merge would build the Evo2 1B. A change to
+#     the shared `sae` lib or other recipes does NOT trigger this lane. schedule (nightly) always runs.
 
 on:
   push:
@@ -71,8 +71,9 @@ jobs:
           # blossom mirror push), so relevance is decided HERE for both push and merge_group by
           # diffing against origin/main - otherwise, with no paths filter, every PR push and every
           # merge into main would rebuild the Evo2 1B regardless of what changed. `schedule` is the
-          # full nightly, so it always runs. Scope is the evo2 SAE recipe + the shared `sae` lib
-          # (this lane runs sae/tests + the recipe depends on it) + evo2_megatron (the engine base).
+          # full nightly, so it always runs. Scope: the evo2 SAE recipe + evo2_megatron (the base it
+          # wraps via internal bionemo.evo2 APIs, so a megatron change can break it). The shared `sae`
+          # lib + codonfm/esm2 are NOT in scope - a change there does not trigger this lane.
           if [ "$EVENT_NAME" = "schedule" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -81,10 +82,10 @@ jobs:
           echo "Merge-base: $MERGE_BASE"
           CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
           echo "Changed files:"; echo "$CHANGED" | sed 's/^/  - /'
-          if echo "$CHANGED" | grep -qE '^(interpretability/sparse_autoencoders/recipes/evo2/|interpretability/sparse_autoencoders/sae/|recipes/evo2_megatron/|\.github/workflows/unit-tests-interpretability-recipes\.yaml$)'; then
+          if echo "$CHANGED" | grep -qE '^(interpretability/sparse_autoencoders/recipes/evo2/|recipes/evo2_megatron/|\.github/workflows/unit-tests-interpretability-recipes\.yaml$)'; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::notice::no evo2 SAE / sae / evo2_megatron changes; skipping GPU tests."
+            echo "::notice::no evo2 SAE recipe / evo2_megatron changes; skipping GPU tests."
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -140,13 +141,3 @@ jobs:
         run: |
           source .ci_test_env.sh
           pytest -v tests/
-
-      # The recipe builds on the shared SAE library (sparse_autoencoders/sae), installed
-      # editable by .ci_build.sh. Its own suite (kernels, topk, streaming, steering, and the
-      # tensor-parallel math tests) isn't under recipes/evo2/tests, so run it as a separate
-      # step (own pytest session — distinct failure attribution) using the same venv.
-      - name: Run SAE library tests
-        working-directory: interpretability/sparse_autoencoders/recipes/evo2
-        run: |
-          source .ci_test_env.sh
-          pytest -v ../../sae/tests/

--- a/.github/workflows/unit-tests-interpretability-recipes.yaml
+++ b/.github/workflows/unit-tests-interpretability-recipes.yaml
@@ -12,20 +12,19 @@ name: "BioNeMo Interpretability Recipes CI"
 #   * Presence guard - lets this lane merge to main BEFORE the evo2 SAE recipe lands (#1622).
 #     When .ci_build.sh is absent the GPU job is skipped and the lane is a green no-op; it
 #     auto-activates once that recipe is on the ref under test.
-#   * Relevance guard - push (pull-request/*) is already path-filtered at the workflow level
-#     and schedule is a full nightly, so both always run. merge_group ignores `paths`, so the
-#     gate diffs against origin/main and only runs the GPU suite when interpretability/evo2
-#     files actually changed - otherwise every merge into main would build the Evo2 1B.
+#   * Relevance guard - there is NO workflow-level `paths:` filter (it doesn't match the blossom
+#     mirror push, so the lane would never trigger). Instead the gate diffs against origin/main
+#     and only runs the GPU suite when the evo2 SAE recipe / shared `sae` lib / evo2_megatron
+#     actually changed - otherwise every PR push and merge would build the Evo2 1B. schedule
+#     (nightly) always runs the full suite.
 
 on:
   push:
     branches:
       - "pull-request/[0-9]+"
       - "dependabot/**"
-    paths:
-      - "interpretability/sparse_autoencoders/**"
-      - "recipes/evo2_megatron/**" # engine builds on bionemo.evo2
-      - ".github/workflows/unit-tests-interpretability-recipes.yaml"
+    # No workflow-level `paths:` filter: it doesn't match the blossom mirror push, so the lane
+    # would never trigger. Relevance is decided in the `gate` job (diff vs origin/main) instead.
   merge_group:
     types: [checks_requested]
   schedule:
@@ -68,23 +67,25 @@ jobs:
             exit 0
           fi
 
-          # Relevance guard. push (pull-request/*) is already path-filtered at the workflow
-          # level and schedule is a full nightly run, so both are always relevant. merge_group
-          # ignores `paths`, so diff against origin/main and gate on our globs - otherwise every
-          # merge into main rebuilds the Evo2 1B regardless of what changed.
-          if [ "$EVENT_NAME" = "merge_group" ]; then
-            MERGE_BASE=$(git merge-base HEAD origin/main)
-            echo "Merge-base: $MERGE_BASE"
-            CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
-            echo "Changed files:"; echo "$CHANGED" | sed 's/^/  - /'
-            if echo "$CHANGED" | grep -qE '^(interpretability/sparse_autoencoders/|recipes/evo2_megatron/|\.github/workflows/unit-tests-interpretability-recipes\.yaml$)'; then
-              echo "run=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "::notice::merge group has no interpretability/evo2 changes; skipping GPU tests."
-              echo "run=false" >> "$GITHUB_OUTPUT"
-            fi
-          else
+          # Relevance guard. There is no workflow-level `paths:` filter (it doesn't match the
+          # blossom mirror push), so relevance is decided HERE for both push and merge_group by
+          # diffing against origin/main - otherwise, with no paths filter, every PR push and every
+          # merge into main would rebuild the Evo2 1B regardless of what changed. `schedule` is the
+          # full nightly, so it always runs. Scope is the evo2 SAE recipe + the shared `sae` lib
+          # (this lane runs sae/tests + the recipe depends on it) + evo2_megatron (the engine base).
+          if [ "$EVENT_NAME" = "schedule" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          MERGE_BASE=$(git merge-base HEAD origin/main)
+          echo "Merge-base: $MERGE_BASE"
+          CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
+          echo "Changed files:"; echo "$CHANGED" | sed 's/^/  - /'
+          if echo "$CHANGED" | grep -qE '^(interpretability/sparse_autoencoders/recipes/evo2/|interpretability/sparse_autoencoders/sae/|recipes/evo2_megatron/|\.github/workflows/unit-tests-interpretability-recipes\.yaml$)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::no evo2 SAE / sae / evo2_megatron changes; skipping GPU tests."
+            echo "run=false" >> "$GITHUB_OUTPUT"
           fi
 
   unit-tests:

--- a/.github/workflows/unit-tests-interpretability-recipes.yaml
+++ b/.github/workflows/unit-tests-interpretability-recipes.yaml
@@ -61,7 +61,10 @@ jobs:
 
           # Eligible recipes = those with their own .ci_build.sh (others are green no-ops until
           # they add one; empty before #1622 lands -> whole lane is a no-op).
-          ALL=$(for d in "$RROOT"/*/; do [ -f "${d}.ci_build.sh" ] && echo "${d%/}"; done \
+          # Use `if` (not `[ -f ] && echo`): the short-circuit leaves exit 1 when the last dir
+          # lacks a .ci_build.sh, which `set -e` would turn into a job failure instead of an
+          # empty (green no-op) matrix.
+          ALL=$(for d in "$RROOT"/*/; do if [ -f "${d}.ci_build.sh" ]; then echo "${d%/}"; fi; done \
                 | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "Eligible recipes (have .ci_build.sh): $ALL"
 

--- a/.github/workflows/unit-tests-interpretability-recipes.yaml
+++ b/.github/workflows/unit-tests-interpretability-recipes.yaml
@@ -8,10 +8,14 @@ name: "BioNeMo Interpretability Recipes CI"
 # the job also checks out recipes/evo2_megatron (which pulls its bionemo-core /
 # bionemo-recipeutils deps from git).
 #
-# This lane is intentionally mergeable to main BEFORE the evo2 SAE recipe lands (#1622): a
-# presence guard makes the build/test steps a green no-op when
-# interpretability/sparse_autoencoders/recipes/evo2/.ci_build.sh is absent, and they
-# auto-activate once that recipe is on the ref under test.
+# A cheap ubuntu `gate` job decides whether to spin up the GPU runner at all:
+#   * Presence guard - lets this lane merge to main BEFORE the evo2 SAE recipe lands (#1622).
+#     When .ci_build.sh is absent the GPU job is skipped and the lane is a green no-op; it
+#     auto-activates once that recipe is on the ref under test.
+#   * Relevance guard - push (pull-request/*) is already path-filtered at the workflow level
+#     and schedule is a full nightly, so both always run. merge_group ignores `paths`, so the
+#     gate diffs against origin/main and only runs the GPU suite when interpretability/evo2
+#     files actually changed - otherwise every merge into main would build the Evo2 1B.
 
 on:
   push:
@@ -36,7 +40,56 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  gate:
+    # Cheap ubuntu pre-job: decide whether the (expensive) GPU job should run. Keeps the L4
+    # runner idle for no-op refs and for merge groups that don't touch the SAE recipe.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Decide whether to run GPU tests
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          # Presence guard: the evo2 SAE recipe (and its .ci_build.sh) may not be on this ref
+          # yet - this lane lands before #1622. When absent, never spin up the GPU runner.
+          if [ ! -f interpretability/sparse_autoencoders/recipes/evo2/.ci_build.sh ]; then
+            echo "::notice::evo2 SAE recipe not present on this ref yet; skipping GPU tests (green no-op)."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Relevance guard. push (pull-request/*) is already path-filtered at the workflow
+          # level and schedule is a full nightly run, so both are always relevant. merge_group
+          # ignores `paths`, so diff against origin/main and gate on our globs - otherwise every
+          # merge into main rebuilds the Evo2 1B regardless of what changed.
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            MERGE_BASE=$(git merge-base HEAD origin/main)
+            echo "Merge-base: $MERGE_BASE"
+            CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
+            echo "Changed files:"; echo "$CHANGED" | sed 's/^/  - /'
+            if echo "$CHANGED" | grep -qE '^(interpretability/sparse_autoencoders/|recipes/evo2_megatron/|\.github/workflows/unit-tests-interpretability-recipes\.yaml$)'; then
+              echo "run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "::notice::merge group has no interpretability/evo2 changes; skipping GPU tests."
+              echo "run=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   unit-tests:
+    needs: gate
+    if: ${{ needs.gate.outputs.run == 'true' }}
     runs-on: linux-amd64-gpu-l4-latest-1
     name: "interpretability-unit-tests (evo2)"
     permissions:
@@ -68,21 +121,7 @@ jobs:
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
-      # Presence guard: lets this lane merge to main before the evo2 SAE recipe (#1622). When
-      # .ci_build.sh is absent the build/test steps are skipped and the job is a green no-op;
-      # once the recipe is on the ref under test, they run for real.
-      - name: Check evo2 SAE recipe present
-        id: check
-        run: |
-          if [ -f interpretability/sparse_autoencoders/recipes/evo2/.ci_build.sh ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::evo2 SAE recipe not present on this ref yet; skipping build/test (green no-op)."
-          fi
-
       - name: Cache Hugging Face models
-        if: steps.check.outputs.present == 'true'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: /cache/huggingface
@@ -92,12 +131,10 @@ jobs:
             ${{ runner.os }}-huggingface-
 
       - name: Install dependencies
-        if: steps.check.outputs.present == 'true'
         working-directory: interpretability/sparse_autoencoders/recipes/evo2
         run: bash .ci_build.sh
 
       - name: Run tests
-        if: steps.check.outputs.present == 'true'
         working-directory: interpretability/sparse_autoencoders/recipes/evo2
         run: |
           source .ci_test_env.sh

--- a/.github/workflows/unit-tests-interpretability-recipes.yaml
+++ b/.github/workflows/unit-tests-interpretability-recipes.yaml
@@ -134,8 +134,18 @@ jobs:
         working-directory: interpretability/sparse_autoencoders/recipes/evo2
         run: bash .ci_build.sh
 
-      - name: Run tests
+      - name: Run recipe tests
         working-directory: interpretability/sparse_autoencoders/recipes/evo2
         run: |
           source .ci_test_env.sh
           pytest -v tests/
+
+      # The recipe builds on the shared SAE library (sparse_autoencoders/sae), installed
+      # editable by .ci_build.sh. Its own suite (kernels, topk, streaming, steering, and the
+      # tensor-parallel math tests) isn't under recipes/evo2/tests, so run it as a separate
+      # step (own pytest session — distinct failure attribution) using the same venv.
+      - name: Run SAE library tests
+        working-directory: interpretability/sparse_autoencoders/recipes/evo2
+        run: |
+          source .ci_test_env.sh
+          pytest -v ../../sae/tests/

--- a/.github/workflows/unit-tests-interpretability-recipes.yaml
+++ b/.github/workflows/unit-tests-interpretability-recipes.yaml
@@ -1,0 +1,104 @@
+name: "BioNeMo Interpretability Recipes CI"
+
+# CI for the SAE interpretability recipes (interpretability/sparse_autoencoders).
+#
+# Runner is modeled on the evo2_megatron GPU lane in unit-tests-recipes.yml: same L4 GPU
+# runner, squashed pytorch26.04 image, --shm-size=16G, pinned action SHAs, and the HF cache.
+# Scoped to the evo2 SAE recipe, whose engine builds on the mbridge bionemo.evo2 recipe, so
+# the job also checks out recipes/evo2_megatron (which pulls its bionemo-core /
+# bionemo-recipeutils deps from git).
+#
+# This lane is intentionally mergeable to main BEFORE the evo2 SAE recipe lands (#1622): a
+# presence guard makes the build/test steps a green no-op when
+# interpretability/sparse_autoencoders/recipes/evo2/.ci_build.sh is absent, and they
+# auto-activate once that recipe is on the ref under test.
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+      - "dependabot/**"
+    paths:
+      - "interpretability/sparse_autoencoders/**"
+      - "recipes/evo2_megatron/**" # engine builds on bionemo.evo2
+      - ".github/workflows/unit-tests-interpretability-recipes.yaml"
+  merge_group:
+    types: [checks_requested]
+  schedule:
+    - cron: "0 9 * * *" # Runs at 9 AM UTC daily (2 AM MST)
+
+defaults:
+  run:
+    shell: bash -x -e -u -o pipefail {0}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    runs-on: linux-amd64-gpu-l4-latest-1
+    name: "interpretability-unit-tests (evo2)"
+    permissions:
+      contents: read
+    container:
+      image: svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed
+      options: --shm-size=16G
+      env:
+        CI: true
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        HF_HOME: /cache/huggingface
+
+    steps:
+      - name: Show GPU info
+        run: nvidia-smi
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@14229018fe157c83e03c008f27d183d8e99bc67c
+
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          # The evo2 SAE recipe builds on bionemo.evo2 (recipes/evo2_megatron); evo2_megatron
+          # pulls its bionemo-core / bionemo-recipeutils deps from git, so only these two are
+          # needed.
+          sparse-checkout: |
+            interpretability/sparse_autoencoders
+            recipes/evo2_megatron
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      # Presence guard: lets this lane merge to main before the evo2 SAE recipe (#1622). When
+      # .ci_build.sh is absent the build/test steps are skipped and the job is a green no-op;
+      # once the recipe is on the ref under test, they run for real.
+      - name: Check evo2 SAE recipe present
+        id: check
+        run: |
+          if [ -f interpretability/sparse_autoencoders/recipes/evo2/.ci_build.sh ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::evo2 SAE recipe not present on this ref yet; skipping build/test (green no-op)."
+          fi
+
+      - name: Cache Hugging Face models
+        if: steps.check.outputs.present == 'true'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: /cache/huggingface
+          key: ${{ runner.os }}-huggingface-interp-evo2-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-huggingface-interp-evo2-
+            ${{ runner.os }}-huggingface-
+
+      - name: Install dependencies
+        if: steps.check.outputs.present == 'true'
+        working-directory: interpretability/sparse_autoencoders/recipes/evo2
+        run: bash .ci_build.sh
+
+      - name: Run tests
+        if: steps.check.outputs.present == 'true'
+        working-directory: interpretability/sparse_autoencoders/recipes/evo2
+        run: |
+          source .ci_test_env.sh
+          pytest -v tests/

--- a/.github/workflows/unit-tests-interpretability-recipes.yaml
+++ b/.github/workflows/unit-tests-interpretability-recipes.yaml
@@ -1,30 +1,27 @@
 name: "BioNeMo Interpretability Recipes CI"
 
-# CI for the SAE interpretability recipes (interpretability/sparse_autoencoders).
+# CI for the SAE interpretability recipes under interpretability/sparse_autoencoders/recipes/*.
+# Generic matrix, modeled on the repo-wide unit-tests-recipes.yml but scoped to the interp subtree:
+#   * `changed-dirs` (cheap ubuntu) discovers which interp recipes to test and emits a matrix.
+#   * `unit-tests` runs each selected recipe on the L4: its own `.ci_build.sh` + `pytest tests/`.
 #
-# Runner is modeled on the evo2_megatron GPU lane in unit-tests-recipes.yml: same L4 GPU
-# runner, squashed pytorch26.04 image, --shm-size=16G, pinned action SHAs, and the HF cache.
-# Scoped to the evo2 SAE recipe, whose engine builds on the mbridge bionemo.evo2 recipe, so
-# the job also checks out recipes/evo2_megatron (which pulls its bionemo-core /
-# bionemo-recipeutils deps from git).
+# Eligible recipes = any interp recipe with its own `.ci_build.sh`. Today that's `evo2`; codonfm/esm2
+# have no `.ci_build.sh`/tests yet, so they are skipped until they add them. This also makes the lane
+# a green no-op before the evo2 SAE recipe lands (#1622) — the presence guard is "has a .ci_build.sh".
 #
-# A cheap ubuntu `gate` job decides whether to spin up the GPU runner at all:
-#   * Presence guard - lets this lane merge to main BEFORE the evo2 SAE recipe lands (#1622).
-#     When .ci_build.sh is absent the GPU job is skipped and the lane is a green no-op; it
-#     auto-activates once that recipe is on the ref under test.
-#   * Relevance guard - there is NO workflow-level `paths:` filter (it doesn't match the blossom
-#     mirror push, so the lane would never trigger). Instead the gate diffs against origin/main
-#     and only runs the GPU suite when the evo2 SAE recipe OR evo2_megatron (its base model)
-#     actually changed - otherwise every PR push and merge would build the Evo2 1B. A change to
-#     the shared `sae` lib or other recipes does NOT trigger this lane. schedule (nightly) always runs.
+# What runs when:
+#   * change under a recipe's own dir            -> that recipe.
+#   * change to the shared `sae` lib, or to this workflow file, or the nightly schedule
+#                                                -> ALL eligible recipes (they all depend on sae).
+#   * change to an unrelated recipe / elsewhere  -> nothing (empty matrix, green no-op).
+# Each recipe's `.ci_build.sh` owns its own build (evo2 -> mbridge bionemo.evo2; esm2 -> HF; etc.),
+# so a codonfm/esm2 change never triggers the Evo2 megatron build, and vice-versa.
 
 on:
   push:
     branches:
       - "pull-request/[0-9]+"
       - "dependabot/**"
-    # No workflow-level `paths:` filter: it doesn't match the blossom mirror push, so the lane
-    # would never trigger. Relevance is decided in the `gate` job (diff vs origin/main) instead.
   merge_group:
     types: [checks_requested]
   schedule:
@@ -39,14 +36,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  gate:
-    # Cheap ubuntu pre-job: decide whether the (expensive) GPU job should run. Keeps the L4
-    # runner idle for no-op refs and for merge groups that don't touch the SAE recipe.
+  changed-dirs:
+    # Cheap ubuntu pre-job: decide which interp recipes to test and emit the matrix.
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
-      run: ${{ steps.decide.outputs.run }}
+      dirs: ${{ steps.set-dirs.outputs.dirs }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -54,55 +50,62 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Decide whether to run GPU tests
-        id: decide
+      - name: Determine which interp recipes to run
+        id: set-dirs
         env:
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          # Presence guard: the evo2 SAE recipe (and its .ci_build.sh) may not be on this ref
-          # yet - this lane lands before #1622. When absent, never spin up the GPU runner.
-          if [ ! -f interpretability/sparse_autoencoders/recipes/evo2/.ci_build.sh ]; then
-            echo "::notice::evo2 SAE recipe not present on this ref yet; skipping GPU tests (green no-op)."
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          RROOT="interpretability/sparse_autoencoders/recipes"
+          SAE="interpretability/sparse_autoencoders/sae"
+          WF=".github/workflows/unit-tests-interpretability-recipes.yaml"
 
-          # Relevance guard. There is no workflow-level `paths:` filter (it doesn't match the
-          # blossom mirror push), so relevance is decided HERE for both push and merge_group by
-          # diffing against origin/main - otherwise, with no paths filter, every PR push and every
-          # merge into main would rebuild the Evo2 1B regardless of what changed. `schedule` is the
-          # full nightly, so it always runs. Scope: the evo2 SAE recipe + evo2_megatron (the base it
-          # wraps via internal bionemo.evo2 APIs, so a megatron change can break it). The shared `sae`
-          # lib + codonfm/esm2 are NOT in scope - a change there does not trigger this lane.
-          if [ "$EVENT_NAME" = "schedule" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          # Eligible recipes = those with their own .ci_build.sh (others are green no-ops until
+          # they add one; empty before #1622 lands -> whole lane is a no-op).
+          ALL=$(for d in "$RROOT"/*/; do [ -f "${d}.ci_build.sh" ] && echo "${d%/}"; done \
+                | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "Eligible recipes (have .ci_build.sh): $ALL"
+
           MERGE_BASE=$(git merge-base HEAD origin/main)
-          echo "Merge-base: $MERGE_BASE"
           CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
           echo "Changed files:"; echo "$CHANGED" | sed 's/^/  - /'
-          if echo "$CHANGED" | grep -qE '^(interpretability/sparse_autoencoders/recipes/evo2/|recipes/evo2_megatron/|\.github/workflows/unit-tests-interpretability-recipes\.yaml$)'; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
+
+          # sae lib / this workflow / nightly -> run EVERY eligible recipe (all depend on sae).
+          if [ "$EVENT_NAME" = "schedule" ] || echo "$CHANGED" | grep -qE "^(${SAE}/|${WF}$)"; then
+            DIRS="$ALL"
           else
-            echo "::notice::no evo2 SAE recipe / evo2_megatron changes; skipping GPU tests."
-            echo "run=false" >> "$GITHUB_OUTPUT"
+            # otherwise -> only eligible recipes that have a changed file under them.
+            DIRS=$(echo "$ALL" | jq -c --arg changed "$CHANGED" '
+              ($changed | split("\n")) as $cf
+              | map(select(. as $d | $cf | any(startswith($d + "/"))))
+            ')
           fi
+          echo "Recipes to run: $DIRS"
+
+          # Attach the runner image (the dockerhub-cached squashed pytorch, like the repo-wide lane).
+          IMG="svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed"
+          MATRIX=$(echo "$DIRS" | jq -c --arg img "$IMG" \
+            'map({dir: ., name: (. | split("/") | last), image: $img})')
+          echo "dirs=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "matrix: $MATRIX"
 
   unit-tests:
-    needs: gate
-    if: ${{ needs.gate.outputs.run == 'true' }}
+    needs: changed-dirs
+    if: ${{ needs.changed-dirs.outputs.dirs != '' && needs.changed-dirs.outputs.dirs != '[]' }}
     runs-on: linux-amd64-gpu-l4-latest-1
-    name: "interpretability-unit-tests (evo2)"
+    name: "interp-unit-tests (${{ matrix.recipe.name }})"
     permissions:
       contents: read
     container:
-      image: svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed
+      image: ${{ matrix.recipe.image }}
       options: --shm-size=16G
       env:
         CI: true
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
         HF_HOME: /cache/huggingface
+    strategy:
+      fail-fast: false
+      matrix:
+        recipe: ${{ fromJson(needs.changed-dirs.outputs.dirs) }}
 
     steps:
       - name: Show GPU info
@@ -114,9 +117,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          # The evo2 SAE recipe builds on bionemo.evo2 (recipes/evo2_megatron); evo2_megatron
-          # pulls its bionemo-core / bionemo-recipeutils deps from git, so only these two are
-          # needed.
+          # Interp recipes live under interpretability/sparse_autoencoders (recipe + shared sae);
+          # evo2 additionally builds on recipes/evo2_megatron. Check out both so any recipe's
+          # .ci_build.sh has what it needs.
           sparse-checkout: |
             interpretability/sparse_autoencoders
             recipes/evo2_megatron
@@ -127,17 +130,17 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: /cache/huggingface
-          key: ${{ runner.os }}-huggingface-interp-evo2-${{ github.sha }}
+          key: ${{ runner.os }}-huggingface-interp-${{ matrix.recipe.name }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-huggingface-interp-evo2-
+            ${{ runner.os }}-huggingface-interp-${{ matrix.recipe.name }}-
             ${{ runner.os }}-huggingface-
 
       - name: Install dependencies
-        working-directory: interpretability/sparse_autoencoders/recipes/evo2
+        working-directory: ${{ matrix.recipe.dir }}
         run: bash .ci_build.sh
 
-      - name: Run recipe tests
-        working-directory: interpretability/sparse_autoencoders/recipes/evo2
+      - name: Run tests
+        working-directory: ${{ matrix.recipe.dir }}
         run: |
-          source .ci_test_env.sh
+          [ -f .ci_test_env.sh ] && source .ci_test_env.sh
           pytest -v tests/


### PR DESCRIPTION
## What
A GPU CI **matrix lane** for the SAE interpretability recipes under `interpretability/sparse_autoencoders/recipes/*`. Modeled on the repo-wide `unit-tests-recipes.yml`: a cheap ubuntu `changed-dirs` job discovers which interp recipes to test and emits a matrix; a per-recipe `unit-tests` job runs each on an L4 (its own `.ci_build.sh` + `pytest tests/`).

## Which recipes are eligible
Any interp recipe that has its own **`.ci_build.sh`**. Today that's **evo2**. `codonfm`/`esm2` have no `.ci_build.sh`/tests yet, so they're **skipped until they add them** — at which point they auto-join this lane, no workflow change needed. (This is also the **presence guard**: before the evo2 SAE recipe lands, #1622, nothing is eligible → the whole lane is a green no-op, so it can merge first.)

## What runs, when
| What the PR changes | Which recipes run |
|---|---|
| a recipe's own dir — `…/recipes/<X>/**` | just **`<X>`** |
| the shared `sae` lib — `…/sparse_autoencoders/sae/**` | **all** eligible recipes (they all depend on sae) |
| this workflow file | **all** eligible recipes |
| **nightly** `schedule` @ 09:00 UTC | **all** eligible recipes |
| anything else (other recipes' dirs, docs, …) | **none** — empty matrix, green no-op |

- **Megatron *build* is per-recipe — only evo2 builds it.** Each recipe's own `.ci_build.sh` owns its build: **evo2** compiles/installs the mbridge `bionemo.evo2` (megatron) stack; a future HF-native **esm2** or custom **codonfm** builds its own thing, *no megatron*. So a codonfm/esm2 change never pays for the Evo2 megatron build — it runs only on an evo2 change (or an `sae`/nightly run, which tests every consumer, evo2 included).
- **Container *image* is currently shared.** All matrix entries use one base image (`svcbionemo023/…pytorch26.04-py3-squashed`, dockerhub-cached → cheap after first pull) — the megatron-capable base evo2 needs. A future HF-native recipe *runs in* that base but doesn't build megatron on top. If a recipe later wants a lighter image, the matrix can carry a **per-recipe `image`** (like the repo-wide lane's `matrix.recipe.image`) — not needed while evo2 is the only active recipe. Net: **shared base image, per-recipe (megatron-or-not) build.**
- Each eligible recipe runs on the **L4** against its **CI-sized model** (evo2 = the auto-built **1B**). The **7B/L26** path is manual (`EVO2_CKPT_DIR`), never in CI.
- Not covered: the React dashboard frontend (no JS build step) and offline `extract`/`train` scripts (no unit tests).

## Validation
Proven end-to-end on a real L4 via the #1670 test PR:
**https://github.com/NVIDIA-BioNeMo/bionemo-recipes/actions/runs/28535969801** — the L4 built via `.ci_build.sh` and ran the evo2 recipe suite green (**54 recipe tests passed**). The `changed-dirs` matrix logic was verified locally across 8 scenarios (per-recipe / sae-change / nightly / pre-#1622-empty). Trigger = a maintainer commenting `/ok to test <sha>`.
