### PR TITLE
Update PyTorch base images to 26.06

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # Uncomment to use the latest TE from the NGC registry for debugging changes with latest TE.
 # FROM gitlab-master.nvidia.com/dl/transformerengine/transformerengine:main-pytorch-py3-base
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 
 # FIXME: Fix for "No such file or directory: /workspace/TransformerEngine"
 #  Remove once bug has been addressed in the nvidia/pytorch container.

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -90,7 +90,7 @@ body:
     attributes:
       label: Docker Image
       description: If the issue occurred in a container, provide the docker image name. Visit the [PyTorch NGC Container Registry](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch) for available images.
-      placeholder: e.g., nvcr.io/nvidia/pytorch:26.05-py3
+      placeholder: e.g., nvcr.io/nvidia/pytorch:26.06-py3
     validations:
       required: false
 

--- a/.github/workflows/unit-tests-recipes.yml
+++ b/.github/workflows/unit-tests-recipes.yml
@@ -129,12 +129,6 @@ jobs:
           # Currently, AMPLIFY is the only folder that needs a custom base image, since we have to support both TE and
           # xformers-based models for golden value testing. The rest of the models use the default pytorch image.
 
-          # This uses a squashed version of the pytorch:26.06-py3 image, generated with `docker-squash
-          # nvcr.io/nvidia/pytorch:26.06-py3 -t svcbionemo023/bionemo-framework:pytorch26.06-py3-squashed --output
-          # type=registry,compression=zstd,force-compression=true,oci-mediatypes=true,compression-level=15` and pushed
-          # to the dockerhub registry. Our github actions are able to cache image pulls from dockerhub but not nvcr, so
-          # hopefully this cuts down slightly on CI time at the expense of having a slightly in-directed image location.
-
           DIRS_WITH_IMAGES=$(echo "$DIRS" | jq -c '
             map({
               dir: .,
@@ -143,8 +137,7 @@ jobs:
                 if . == "models/amplify" then
                   "svcbionemo023/bionemo-framework:amplify-model-devcontainer-082025"
                 else
-                  # "nvcr.io/nvidia/pytorch:26.06-py3"
-                  "svcbionemo023/bionemo-framework:pytorch26.06-py3-squashed"
+                  "nvcr.io/nvidia/pytorch:26.06-py3"
                 end
               )
             })
@@ -255,7 +248,7 @@ jobs:
         )
     name: "notebook-tests (evo2_megatron)"
     container:
-      image: svcbionemo023/bionemo-framework:pytorch26.06-py3-squashed
+      image: nvcr.io/nvidia/pytorch:26.06-py3
       options: --shm-size=16G
       env:
         CI: true

--- a/.github/workflows/unit-tests-recipes.yml
+++ b/.github/workflows/unit-tests-recipes.yml
@@ -129,8 +129,8 @@ jobs:
           # Currently, AMPLIFY is the only folder that needs a custom base image, since we have to support both TE and
           # xformers-based models for golden value testing. The rest of the models use the default pytorch image.
 
-          # This uses a squashed version of the pytorch:26.04-py3 image, generated with `docker-squash
-          # nvcr.io/nvidia/pytorch:26.04-py3 -t svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed --output
+          # This uses a squashed version of the pytorch:26.06-py3 image, generated with `docker-squash
+          # nvcr.io/nvidia/pytorch:26.06-py3 -t svcbionemo023/bionemo-framework:pytorch26.06-py3-squashed --output
           # type=registry,compression=zstd,force-compression=true,oci-mediatypes=true,compression-level=15` and pushed
           # to the dockerhub registry. Our github actions are able to cache image pulls from dockerhub but not nvcr, so
           # hopefully this cuts down slightly on CI time at the expense of having a slightly in-directed image location.
@@ -143,8 +143,8 @@ jobs:
                 if . == "models/amplify" then
                   "svcbionemo023/bionemo-framework:amplify-model-devcontainer-082025"
                 else
-                  # "nvcr.io/nvidia/pytorch:26.04-py3"
-                  "svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed"
+                  # "nvcr.io/nvidia/pytorch:26.06-py3"
+                  "svcbionemo023/bionemo-framework:pytorch26.06-py3-squashed"
                 end
               )
             })
@@ -255,7 +255,7 @@ jobs:
         )
     name: "notebook-tests (evo2_megatron)"
     container:
-      image: svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed
+      image: svcbionemo023/bionemo-framework:pytorch26.06-py3-squashed
       options: --shm-size=16G
       env:
         CI: true

--- a/.github/workflows/unit-tests-recipes.yml
+++ b/.github/workflows/unit-tests-recipes.yml
@@ -205,6 +205,11 @@ jobs:
             ${{ runner.os }}-huggingface-${{ matrix.recipe.name }}-
             ${{ runner.os }}-huggingface-
 
+      - name: Setup uv
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff
+        with:
+          enable-cache: true
+
       - name: Install dependencies
         working-directory: ${{ matrix.recipe.dir }}
         run: |
@@ -278,6 +283,11 @@ jobs:
             ${{ runner.os }}-huggingface-evo2_megatron-notebooks-
             ${{ runner.os }}-huggingface-evo2_megatron-
             ${{ runner.os }}-huggingface-
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         working-directory: recipes/evo2_megatron

--- a/ci/lepton/model_convergence/configs/base.yaml
+++ b/ci/lepton/model_convergence/configs/base.yaml
@@ -11,7 +11,7 @@ template_type: convergence_tests
 # Defines the base Docker image and registry auth needed
 ############################################################
 container:
-  image: nvcr.io/nvidia/pytorch:26.02-py3
+  image: nvcr.io/nvidia/pytorch:26.06-py3
   registry_auth: lepton-nvidia-jwilber
 
 ############################################################

--- a/ci/scripts/recipes_local_test.py
+++ b/ci/scripts/recipes_local_test.py
@@ -102,7 +102,14 @@ def run_tests_in_docker(work_dir: str) -> bool:
 
         echo "Checking for dependency files..."
         # Install dependencies based on available files
-        if [ -f pyproject.toml ] || [ -f setup.py ]; then
+        if [ -f .ci_build.sh ]; then
+            echo "Running .ci_build.sh..."
+            if ! command -v uv >/dev/null 2>&1; then
+                PIP_CACHE_DIR=/workspace/.cache/pip python -m pip install uv
+            fi
+            bash .ci_build.sh
+            echo "Finished .ci_build.sh"
+        elif [ -f pyproject.toml ] || [ -f setup.py ]; then
             echo "Installing package in editable mode..."
             PIP_CACHE_DIR=/workspace/.cache/pip pip install -e .
             echo "Installed package as editable package"
@@ -116,6 +123,9 @@ def run_tests_in_docker(work_dir: str) -> bool:
         fi
 
         echo "Running tests..."
+        if [ -f .ci_test_env.sh ]; then
+            source .ci_test_env.sh
+        fi
         python -m pytest -v .
         """)
 

--- a/ci/scripts/recipes_local_test.py
+++ b/ci/scripts/recipes_local_test.py
@@ -48,14 +48,7 @@ CUSTOM_CONTAINERS = {
     "models/amplify": "svcbionemo023/bionemo-framework:amplify-model-devcontainer-082025",
 }
 
-# DEFAULT_CONTAINER = "nvcr.io/nvidia/pytorch:26.06-py3"
-
-# This is a squashed version of the pytorch:26.06-py3 image, generated with
-# docker-squash nvcr.io/nvidia/pytorch:26.06-py3 -t svcbionemo023/bionemo-framework:pytorch26.06-py3-squashed
-# --output type=registry,compression=zstd,force-compression=true,oci-mediatypes=true,compression-level=15
-# and pushed to the dockerhub registry. Our github actions are able to cache image pulls from dockerhub but not nvcr, so
-# hopefully this cuts down slightly on CI time at the expense of having a slightly in-directed image location.
-DEFAULT_CONTAINER = "svcbionemo023/bionemo-framework:pytorch26.06-py3-squashed"
+DEFAULT_CONTAINER = "nvcr.io/nvidia/pytorch:26.06-py3"
 
 
 def get_git_root() -> str:

--- a/ci/scripts/recipes_local_test.py
+++ b/ci/scripts/recipes_local_test.py
@@ -48,14 +48,14 @@ CUSTOM_CONTAINERS = {
     "models/amplify": "svcbionemo023/bionemo-framework:amplify-model-devcontainer-082025",
 }
 
-# DEFAULT_CONTAINER = "nvcr.io/nvidia/pytorch:26.02-py3"
+# DEFAULT_CONTAINER = "nvcr.io/nvidia/pytorch:26.06-py3"
 
-# This is a squashed version of the pytorch:26.02-py3 image, generated with
-# docker-squash nvcr.io/nvidia/pytorch:26.02-py3 -t svcbionemo023/bionemo-framework:pytorch26.02-py3-squashed
+# This is a squashed version of the pytorch:26.06-py3 image, generated with
+# docker-squash nvcr.io/nvidia/pytorch:26.06-py3 -t svcbionemo023/bionemo-framework:pytorch26.06-py3-squashed
 # --output type=registry,compression=zstd,force-compression=true,oci-mediatypes=true,compression-level=15
 # and pushed to the dockerhub registry. Our github actions are able to cache image pulls from dockerhub but not nvcr, so
 # hopefully this cuts down slightly on CI time at the expense of having a slightly in-directed image location.
-DEFAULT_CONTAINER = "svcbionemo023/bionemo-framework:pytorch26.02-py3-squashed"
+DEFAULT_CONTAINER = "svcbionemo023/bionemo-framework:pytorch26.06-py3-squashed"
 
 
 def get_git_root() -> str:

--- a/ci/scripts/recipes_local_test.py
+++ b/ci/scripts/recipes_local_test.py
@@ -40,6 +40,8 @@ DOCKER_RUN_ARGS = [
     "memlock=-1",
     "--ulimit",
     "stack=67108864",
+    "--env",
+    "CI=true",
     "-v",
     f"{PIP_CACHE_DIR}:/workspace/.cache/pip",
 ]

--- a/models/amplify/.devcontainer/Dockerfile.dev
+++ b/models/amplify/.devcontainer/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:25.01-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 
 # Install xformers and TE manually.
 RUN MAX_JOBS=4 pip --disable-pip-version-check --no-cache-dir install -v git+https://github.com/facebookresearch/xformers.git@v0.0.29.post1#egg=xformers

--- a/models/amplify/Dockerfile
+++ b/models/amplify/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:25.01-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 
 # Install xformers and TE manually.
 RUN MAX_JOBS=4 pip --disable-pip-version-check --no-cache-dir install -v git+https://github.com/facebookresearch/xformers.git@v0.0.29.post1#egg=xformers

--- a/models/esm2/Dockerfile
+++ b/models/esm2/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 WORKDIR /workspace/bionemo
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/models/esm2/modeling_esm_te.py
+++ b/models/esm2/modeling_esm_te.py
@@ -255,6 +255,12 @@ class NVEsmEncoder(nn.Module):
                 if kwargs.get("output_hidden_states", False):
                     all_hidden_states = (*all_hidden_states, hidden_states)
 
+                # PEFT replaces Transformer Engine's QKV module with a LoRA wrapper. TE 2.16 reads the module name
+                # while configuring quantizer roles, but the wrapper does not currently forward that attribute.
+                qkv_linear = layer_module.self_attention.layernorm_qkv
+                if not hasattr(qkv_linear, "name") and hasattr(qkv_linear, "get_base_layer"):
+                    qkv_linear.name = qkv_linear.get_base_layer().name
+
                 with self.get_autocast_context(layer_idx):
                     hidden_states = layer_module(
                         hidden_states,

--- a/models/esm2/requirements.txt
+++ b/models/esm2/requirements.txt
@@ -4,7 +4,7 @@ hydra-core
 jinja2
 megatron-fsdp
 omegaconf
-peft
+peft>=0.19.0
 torch
 torchao!=0.14.0
 transformer_engine[pytorch]

--- a/models/geneformer/Dockerfile
+++ b/models/geneformer/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 WORKDIR /workspace/bionemo
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/models/qwen/Dockerfile
+++ b/models/qwen/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 WORKDIR /workspace/bionemo
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -85,7 +85,7 @@ recipes/{recipe_name}/
 Your `Dockerfile` should create a complete, reproducible training environment:
 
 ```dockerfile
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 
 # Install dependencies with caching for faster builds
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/recipes/codonfm_native_te/Dockerfile
+++ b/recipes/codonfm_native_te/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/recipes/codonfm_ptl_te/Dockerfile
+++ b/recipes/codonfm_ptl_te/Dockerfile
@@ -4,7 +4,7 @@
 # To build a development image:
 # docker build -t <image_name> --target development --build-arg USERNAME=$(whoami) --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) .
 
-ARG FROM_IMAGE_NAME=nvcr.io/nvidia/pytorch:25.08-py3
+ARG FROM_IMAGE_NAME=nvcr.io/nvidia/pytorch:26.06-py3
 FROM ${FROM_IMAGE_NAME} AS base
 
 ENV CUDA_HOME=/usr/local/cuda

--- a/recipes/codonfm_ptl_te/requirements.txt
+++ b/recipes/codonfm_ptl_te/requirements.txt
@@ -255,6 +255,7 @@ threadpoolctl==3.6.0
 tinycss2==1.4.0
 tokenizers==0.22.1
 toml==0.10.2
+torchao==0.17.0
 torchmetrics==1.8.2
 torchprofile==0.0.4
 torchx==0.7.0

--- a/recipes/eden_megatron/Dockerfile
+++ b/recipes/eden_megatron/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 
 # uv is pre-installed in the nvcr.io/nvidia/pytorch base image.
 # If using a base image without uv, uncomment the following line:

--- a/recipes/esm2_accelerate_te/Dockerfile
+++ b/recipes/esm2_accelerate_te/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/recipes/esm2_accelerate_te/example_8m_checkpoint/esm_nv.py
+++ b/recipes/esm2_accelerate_te/example_8m_checkpoint/esm_nv.py
@@ -261,6 +261,12 @@ class NVEsmEncoder(nn.Module):
                 if kwargs.get("output_hidden_states", False):
                     all_hidden_states = (*all_hidden_states, hidden_states)
 
+                # PEFT replaces Transformer Engine's QKV module with a LoRA wrapper. TE 2.16 reads the module name
+                # while configuring quantizer roles, but the wrapper does not currently forward that attribute.
+                qkv_linear = layer_module.self_attention.layernorm_qkv
+                if not hasattr(qkv_linear, "name") and hasattr(qkv_linear, "get_base_layer"):
+                    qkv_linear.name = qkv_linear.get_base_layer().name
+
                 with self.get_autocast_context(layer_idx):
                     hidden_states = layer_module(
                         hidden_states,

--- a/recipes/esm2_accelerate_te/requirements.txt
+++ b/recipes/esm2_accelerate_te/requirements.txt
@@ -1,4 +1,4 @@
-accelerate @ git+https://github.com/huggingface/accelerate.git  # Until huggingface/accelerate#3852 is released.
+accelerate==1.13.0
 datasets
 deepspeed
 hydra-core

--- a/recipes/esm2_accelerate_te/tests/test_accelerate_amplify.py
+++ b/recipes/esm2_accelerate_te/tests/test_accelerate_amplify.py
@@ -20,8 +20,6 @@ tests, we don't test the original xformers-based model, since we don't install x
 recipe tests.
 """
 
-import pytest
-
 # Local helper function import, resolved in conftest.py
 from launch import launch_accelerate, requires_multi_gpu
 
@@ -41,10 +39,6 @@ def test_te_with_fp8_config(tmp_path):
     assert train_loss < 3.0, f"Final train_loss {train_loss} should be less than 3.0"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="BIO-466: AMPLIFY HF model does not implement get_input_embeddings, required by accelerate FSDP2 (transformers>=5.6).",
-)
 def test_te_with_fsdp2_config(tmp_path):
     train_loss = launch_accelerate("fsdp2_te.yaml", tmp_path, 1, "L0_sanity_amplify")
     assert train_loss < 3.0, f"Final train_loss {train_loss} should be less than 3.0"
@@ -62,10 +56,6 @@ def test_te_with_fp8_config_two_gpus(tmp_path):
     assert train_loss < 3.0, f"Final train_loss {train_loss} should be less than 3.0"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="BIO-466: AMPLIFY HF model does not implement get_input_embeddings, required by accelerate FSDP2 (transformers>=5.6).",
-)
 @requires_multi_gpu
 def test_te_with_fsdp2_config_two_gpus(tmp_path):
     train_loss = launch_accelerate("fsdp2_te.yaml", tmp_path, 2, "L0_sanity_amplify")

--- a/recipes/esm2_native_te/Dockerfile
+++ b/recipes/esm2_native_te/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/recipes/esm2_native_te/modeling_esm_te.py
+++ b/recipes/esm2_native_te/modeling_esm_te.py
@@ -261,6 +261,12 @@ class NVEsmEncoder(nn.Module):
                 if kwargs.get("output_hidden_states", False):
                     all_hidden_states = (*all_hidden_states, hidden_states)
 
+                # PEFT replaces Transformer Engine's QKV module with a LoRA wrapper. TE 2.16 reads the module name
+                # while configuring quantizer roles, but the wrapper does not currently forward that attribute.
+                qkv_linear = layer_module.self_attention.layernorm_qkv
+                if not hasattr(qkv_linear, "name") and hasattr(qkv_linear, "get_base_layer"):
+                    qkv_linear.name = qkv_linear.get_base_layer().name
+
                 with self.get_autocast_context(layer_idx):
                     hidden_states = layer_module(
                         hidden_states,

--- a/recipes/esm2_peft_te/Dockerfile
+++ b/recipes/esm2_peft_te/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/recipes/esm2_peft_te/example_8m_checkpoint/esm_nv.py
+++ b/recipes/esm2_peft_te/example_8m_checkpoint/esm_nv.py
@@ -261,6 +261,12 @@ class NVEsmEncoder(nn.Module):
                 if kwargs.get("output_hidden_states", False):
                     all_hidden_states = (*all_hidden_states, hidden_states)
 
+                # PEFT replaces Transformer Engine's QKV module with a LoRA wrapper. TE 2.16 reads the module name
+                # while configuring quantizer roles, but the wrapper does not currently forward that attribute.
+                qkv_linear = layer_module.self_attention.layernorm_qkv
+                if not hasattr(qkv_linear, "name") and hasattr(qkv_linear, "get_base_layer"):
+                    qkv_linear.name = qkv_linear.get_base_layer().name
+
                 with self.get_autocast_context(layer_idx):
                     hidden_states = layer_module(
                         hidden_states,

--- a/recipes/esm2_peft_te/requirements.txt
+++ b/recipes/esm2_peft_te/requirements.txt
@@ -1,6 +1,6 @@
 datasets
 hydra-core
-peft @ git+https://github.com/balvisio/peft.git@support-te-lora
+peft==0.19.1
 torch
 torchao!=0.14.0
 torchmetrics

--- a/recipes/evo2_megatron/Dockerfile
+++ b/recipes/evo2_megatron/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 
 # uv is pre-installed in the nvcr.io/nvidia/pytorch base image.
 # If using a base image without uv, uncomment the following line:

--- a/recipes/evo2_megatron/examples/fine-tuning-tutorial.ipynb
+++ b/recipes/evo2_megatron/examples/fine-tuning-tutorial.ipynb
@@ -1105,7 +1105,7 @@
         "# You may want to edit this file and/or add your own version to your mounts.\n",
         "CONFIG_PATH_IN_CONTAINER=/workspace/bionemo-framework/recipes/evo2_megatron/examples/configs/full_pretrain_shortphase_config.yaml\n",
         "# You can build a `.sqsh` file with enroot which may be faster to load on each node rather than pulling down from NGC\n",
-        "IMAGE_PATH=svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed\n",
+        "IMAGE_PATH=svcbionemo023/bionemo-framework:pytorch26.06-py3-squashed\n",
         "WANDB_PROJECT_NAME= # Set you wandb project here, or leave blank and add --no-wandb to the image\n",
         "MODEL_SIZE=evo2_1b_base  # change this to evo2_7b etc. This version is different.\n",
         "CP_SIZE=1\n",

--- a/recipes/evo2_megatron/examples/fine-tuning-tutorial.ipynb
+++ b/recipes/evo2_megatron/examples/fine-tuning-tutorial.ipynb
@@ -1105,7 +1105,7 @@
         "# You may want to edit this file and/or add your own version to your mounts.\n",
         "CONFIG_PATH_IN_CONTAINER=/workspace/bionemo-framework/recipes/evo2_megatron/examples/configs/full_pretrain_shortphase_config.yaml\n",
         "# You can build a `.sqsh` file with enroot which may be faster to load on each node rather than pulling down from NGC\n",
-        "IMAGE_PATH=svcbionemo023/bionemo-framework:pytorch26.06-py3-squashed\n",
+        "IMAGE_PATH=nvcr.io/nvidia/pytorch:26.06-py3\n",
         "WANDB_PROJECT_NAME= # Set you wandb project here, or leave blank and add --no-wandb to the image\n",
         "MODEL_SIZE=evo2_1b_base  # change this to evo2_7b etc. This version is different.\n",
         "CP_SIZE=1\n",

--- a/recipes/evo2_megatron/src/bionemo/evo2/models/megatron/hyena/te_compat.py
+++ b/recipes/evo2_megatron/src/bionemo/evo2/models/megatron/hyena/te_compat.py
@@ -24,6 +24,23 @@ import transformer_engine.pytorch as te
 from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear, TELinear
 from megatron.core.post_training.modelopt.layers import Linear as MTLinear
 from transformer_engine.common.recipe import DelayedScaling, Format
+from transformer_engine.pytorch.quantization import FP8GlobalStateManager
+
+
+def _set_skip_fp8_weight_update_tensor(cls, skip: bool) -> None:
+    """Restore the Transformer Engine 2.14 setter used by Megatron-Core CUDA graphs."""
+    state = cls.quantization_state
+    if state.skip_fp8_weight_update_tensor is None:
+        state.skip_fp8_weight_update_tensor = torch.empty(1, dtype=torch.float32, device="cuda")
+    state.skip_fp8_weight_update_tensor.fill_(skip)
+
+
+if not hasattr(FP8GlobalStateManager, "set_skip_fp8_weight_update_tensor"):
+    setattr(
+        FP8GlobalStateManager,
+        "set_skip_fp8_weight_update_tensor",
+        classmethod(_set_skip_fp8_weight_update_tensor),
+    )
 
 
 @lru_cache

--- a/recipes/geneformer_native_te_mfsdp_fp8/AGENT_DOCUMENTATION.md
+++ b/recipes/geneformer_native_te_mfsdp_fp8/AGENT_DOCUMENTATION.md
@@ -178,7 +178,7 @@ torchrun --nproc_per_node=1 train.py  # Uses default sanity config
 
 ### Software Dependencies
 
-- **Base**: `nvcr.io/nvidia/pytorch:25.03-py3`
+- **Base**: `nvcr.io/nvidia/pytorch:26.06-py3`
 - **Key Libraries**:
   - `transformers` - HuggingFace transformers
   - `megatron-fsdp==0.1.0rc1` - Megatron-FSDP

--- a/recipes/geneformer_native_te_mfsdp_fp8/Dockerfile
+++ b/recipes/geneformer_native_te_mfsdp_fp8/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 
 RUN apt-get update && apt-get install -y git
 

--- a/recipes/llama3_native_te/Dockerfile
+++ b/recipes/llama3_native_te/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/recipes/opengenome2_llama_native_te/Dockerfile
+++ b/recipes/opengenome2_llama_native_te/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/recipes/vit/Dockerfile
+++ b/recipes/vit/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=/requirements.txt \

--- a/recipes/vllm_inference/esm2/Dockerfile
+++ b/recipes/vllm_inference/esm2/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:26.04-py3
+FROM nvcr.io/nvidia/pytorch:26.06-py3
 WORKDIR /workspace/bionemo
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/recipes/vllm_inference/esm2/modeling_esm_te.py
+++ b/recipes/vllm_inference/esm2/modeling_esm_te.py
@@ -261,6 +261,12 @@ class NVEsmEncoder(nn.Module):
                 if kwargs.get("output_hidden_states", False):
                     all_hidden_states = (*all_hidden_states, hidden_states)
 
+                # PEFT replaces Transformer Engine's QKV module with a LoRA wrapper. TE 2.16 reads the module name
+                # while configuring quantizer roles, but the wrapper does not currently forward that attribute.
+                qkv_linear = layer_module.self_attention.layernorm_qkv
+                if not hasattr(qkv_linear, "name") and hasattr(qkv_linear, "get_base_layer"):
+                    qkv_linear.name = qkv_linear.get_base_layer().name
+
                 with self.get_autocast_context(layer_idx):
                     hidden_states = layer_module(
                         hidden_states,


### PR DESCRIPTION
## Summary

- update all NVIDIA PyTorch-based Dockerfiles and related documentation to `nvcr.io/nvidia/pytorch:26.06-py3`
- update nv-gha recipe and notebook CI to use the official NGC image directly
- align the Lepton convergence image, local recipe test default, and Evo2 tutorial with PyTorch 26.06

## Validation

- `git diff --check`
- `python3 ci/scripts/check_copied_files.py`
- validated the modified notebook with `python3 -m json.tool`
- compiled `ci/scripts/recipes_local_test.py` with `python3 -m py_compile`
- parsed the modified YAML files with PyYAML
- verified `nvcr.io/nvidia/pytorch:26.06-py3` is available via `docker manifest inspect`