### PR TITLE
fix(opengenome2): pin transformers<5.13 to restore scaled-init tests

### DIFF
--- a/recipes/opengenome2_llama_native_te/requirements.txt
+++ b/recipes/opengenome2_llama_native_te/requirements.txt
@@ -6,7 +6,7 @@ torchdata
 torchmetrics
 tqdm
 transformer_engine[pytorch]
-transformers
+transformers>=5.12.1,<5.13
 wandb
 zstandard
 nvdlfw_inspect @ git+https://github.com/NVIDIA/nvidia-dlfw-inspect


### PR DESCRIPTION
## Summary

Pins `transformers>=5.12.1,<5.13` in `recipes/opengenome2_llama_native_te/requirements.txt` to restore the nightly CI suite, which regressed on 2026-07-04.

## Root cause

The 2026-07-04 scheduled run of `unit-tests-recipes.yml` failed the `unit-tests (recipes/opengenome2_llama_native_te)` job:

```
FAILED tests/test_train.py::test_megatron_scaled_init - AssertionError: Layer 0 proj std=0.019727, expected ~0.007071
FAILED tests/test_train.py::test_scaled_init_with_spike_no_more - AssertionError: proj std=0.019727, expected ~0.007071
====== 2 failed, 34 passed, 4 skipped ======
```

Both tests assert the attention `proj` weight std is `initializer_range / sqrt(2*num_layers)` (= `0.02/sqrt(8)` ≈ `0.007071`) when `use_megatron_scaled_init=True`. The measured `0.019727` ≈ `0.02` means the **scaled-init code path was not applied** — the proj kept the regular `initializer_range` init.

The model's custom `_init_weights` (`opengenome_modeling_llama_te.py`) applies scaled init to TE `TransformerLayer.self_attention.proj` via an `isinstance(module, transformer_engine.pytorch.TransformerLayer)` branch. With identical commit (`fdce924b`) and identical NGC PyTorch 26.04 image (PyTorch `2.12.0a0+0291f96`, TE `2.14.0`, driver `595.58.03`), the run **passed on 2026-07-03 and failed on 2026-07-04**. The only diff is the `transformers` library, which is listed **unpinned** in this recipe's `requirements.txt`:

| Run | `transformers` | Result |
|-----|---------------|--------|
| 2026-07-03 | `5.12.1` | ✅ all 36 tests passed |
| 2026-07-04 | `5.13.0` | ❌ 2 scaled-init tests failed |

pip resolves the latest each run. The `transformers 5.13.0` weight-init flow overwrites the model's custom `_init_weights` scaled-init for `proj`/`fc2`, leaving them at the regular `initializer_range`. Only the two scaled-init tests are affected — `test_regular_init_without_scaled` (proj ≈ 0.02 ✓) and the embedding-init tests all pass, confirming `_init_weights` runs but the scaled branch is overridden.

## Fix

Pin `transformers>=5.12.1,<5.13` for the opengenome2 recipe. This restores the exact 2026-07-03 green state (the only version verified to pass this recipe's init tests) while allowing `5.12.x` patch releases. Targeted to this recipe only — all other recipes passed with `5.13.0`.

This is a targeted mitigation. The underlying fragility is that `_init_weights` relies on the module-traversal order / assumes no upstream re-init after `apply(self._init_weights)`. A follow-up should make the scaled-init application robust to upstream `transformers` init-flow changes so the pin can be relaxed.

## Verification

- Head commit is GitHub-verified (`verified: true`, `reason: valid`).
- One-line diff, scoped to `recipes/opengenome2_llama_native_te/requirements.txt`.
- Base: `main` @ `fdce924b` (same commit as the failing nightly run).

## Related

- Failed run: https://github.com/NVIDIA-BioNeMo/bionemo-recipes/actions/runs/28702327832
- Autogenerated by the nightly CI monitor (svc-bionemo).
