### PR TITLE
fix: sync eden_megatron copied file banners

### DIFF
--- a/recipes/eden_megatron/src/bionemo/common/__init__.py
+++ b/recipes/eden_megatron/src/bionemo/common/__init__.py
@@ -19,9 +19,6 @@
 #     python ci/scripts/check_copied_files.py --fix
 # --- END COPIED FILE NOTICE ---
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """Shared recipe utilities used by BioNeMo recipes."""
 
 import os

--- a/recipes/eden_megatron/src/bionemo/common/checkpoint/__init__.py
+++ b/recipes/eden_megatron/src/bionemo/common/checkpoint/__init__.py
@@ -19,22 +19,4 @@
 #     python ci/scripts/check_copied_files.py --fix
 # --- END COPIED FILE NOTICE ---
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """Checkpoint helper utilities."""
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2

--- a/recipes/eden_megatron/src/bionemo/common/checkpoint/__init__.py
+++ b/recipes/eden_megatron/src/bionemo/common/checkpoint/__init__.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 # --- BEGIN COPIED FILE NOTICE ---
 # This file is copied from: recipes/evo2_megatron/src/bionemo/common/checkpoint/__init__.py
 # Do not modify this file directly. Instead, modify the source and run:
 #     python ci/scripts/check_copied_files.py --fix
 # --- END COPIED FILE NOTICE ---
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
 
 """Checkpoint helper utilities."""
 #

--- a/recipes/eden_megatron/src/bionemo/common/data/__init__.py
+++ b/recipes/eden_megatron/src/bionemo/common/data/__init__.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 # --- BEGIN COPIED FILE NOTICE ---
 # This file is copied from: recipes/evo2_megatron/src/bionemo/common/data/__init__.py
 # Do not modify this file directly. Instead, modify the source and run:
 #     python ci/scripts/check_copied_files.py --fix
 # --- END COPIED FILE NOTICE ---
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
 
 """Data loading and dataset helper utilities."""
 #

--- a/recipes/eden_megatron/src/bionemo/common/data/__init__.py
+++ b/recipes/eden_megatron/src/bionemo/common/data/__init__.py
@@ -19,22 +19,4 @@
 #     python ci/scripts/check_copied_files.py --fix
 # --- END COPIED FILE NOTICE ---
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """Data loading and dataset helper utilities."""
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2

--- a/recipes/eden_megatron/src/bionemo/common/data/basecamp/__init__.py
+++ b/recipes/eden_megatron/src/bionemo/common/data/basecamp/__init__.py
@@ -19,22 +19,4 @@
 #     python ci/scripts/check_copied_files.py --fix
 # --- END COPIED FILE NOTICE ---
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """Basecamp sharded dataset helper utilities."""
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2

--- a/recipes/eden_megatron/src/bionemo/common/data/basecamp/__init__.py
+++ b/recipes/eden_megatron/src/bionemo/common/data/basecamp/__init__.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 # --- BEGIN COPIED FILE NOTICE ---
 # This file is copied from: recipes/evo2_megatron/src/bionemo/common/data/basecamp/__init__.py
 # Do not modify this file directly. Instead, modify the source and run:
 #     python ci/scripts/check_copied_files.py --fix
 # --- END COPIED FILE NOTICE ---
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
 
 """Basecamp sharded dataset helper utilities."""
 #

--- a/recipes/eden_megatron/src/bionemo/common/fasta/__init__.py
+++ b/recipes/eden_megatron/src/bionemo/common/fasta/__init__.py
@@ -19,9 +19,6 @@
 #     python ci/scripts/check_copied_files.py --fix
 # --- END COPIED FILE NOTICE ---
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """Pure-Python FASTA indexing helpers."""
 
 from bionemo.common.fasta.nvfaidx import (

--- a/recipes/eden_megatron/src/bionemo/common/fasta/nvfaidx.py
+++ b/recipes/eden_megatron/src/bionemo/common/fasta/nvfaidx.py
@@ -19,9 +19,6 @@
 #     python ci/scripts/check_copied_files.py --fix
 # --- END COPIED FILE NOTICE ---
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 # ruff: noqa: D102,D105,D107
 
 from __future__ import annotations

--- a/recipes/eden_megatron/src/bionemo/common/inference/__init__.py
+++ b/recipes/eden_megatron/src/bionemo/common/inference/__init__.py
@@ -19,22 +19,4 @@
 #     python ci/scripts/check_copied_files.py --fix
 # --- END COPIED FILE NOTICE ---
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """Inference helper utilities."""
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2

--- a/recipes/eden_megatron/src/bionemo/common/inference/__init__.py
+++ b/recipes/eden_megatron/src/bionemo/common/inference/__init__.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 # --- BEGIN COPIED FILE NOTICE ---
 # This file is copied from: recipes/evo2_megatron/src/bionemo/common/inference/__init__.py
 # Do not modify this file directly. Instead, modify the source and run:
 #     python ci/scripts/check_copied_files.py --fix
 # --- END COPIED FILE NOTICE ---
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
 
 """Inference helper utilities."""
 #

--- a/recipes/eden_megatron/src/bionemo/common/io/__init__.py
+++ b/recipes/eden_megatron/src/bionemo/common/io/__init__.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 # --- BEGIN COPIED FILE NOTICE ---
 # This file is copied from: recipes/evo2_megatron/src/bionemo/common/io/__init__.py
 # Do not modify this file directly. Instead, modify the source and run:
 #     python ci/scripts/check_copied_files.py --fix
 # --- END COPIED FILE NOTICE ---
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
 
 """Input and output conversion helpers."""
 #

--- a/recipes/eden_megatron/src/bionemo/common/io/__init__.py
+++ b/recipes/eden_megatron/src/bionemo/common/io/__init__.py
@@ -19,22 +19,4 @@
 #     python ci/scripts/check_copied_files.py --fix
 # --- END COPIED FILE NOTICE ---
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """Input and output conversion helpers."""
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2

--- a/recipes/eden_megatron/src/bionemo/common/utils/__init__.py
+++ b/recipes/eden_megatron/src/bionemo/common/utils/__init__.py
@@ -19,22 +19,4 @@
 #     python ci/scripts/check_copied_files.py --fix
 # --- END COPIED FILE NOTICE ---
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """General utility helpers."""
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2

--- a/recipes/eden_megatron/src/bionemo/common/utils/__init__.py
+++ b/recipes/eden_megatron/src/bionemo/common/utils/__init__.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 # --- BEGIN COPIED FILE NOTICE ---
 # This file is copied from: recipes/evo2_megatron/src/bionemo/common/utils/__init__.py
 # Do not modify this file directly. Instead, modify the source and run:
 #     python ci/scripts/check_copied_files.py --fix
 # --- END COPIED FILE NOTICE ---
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
 
 """General utility helpers."""
 #

--- a/recipes/evo2_megatron/src/bionemo/common/__init__.py
+++ b/recipes/evo2_megatron/src/bionemo/common/__init__.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """Shared recipe utilities used by BioNeMo recipes."""
 
 import os

--- a/recipes/evo2_megatron/src/bionemo/common/checkpoint/__init__.py
+++ b/recipes/evo2_megatron/src/bionemo/common/checkpoint/__init__.py
@@ -13,22 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """Checkpoint helper utilities."""
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2

--- a/recipes/evo2_megatron/src/bionemo/common/data/__init__.py
+++ b/recipes/evo2_megatron/src/bionemo/common/data/__init__.py
@@ -13,22 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """Data loading and dataset helper utilities."""
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2

--- a/recipes/evo2_megatron/src/bionemo/common/data/basecamp/__init__.py
+++ b/recipes/evo2_megatron/src/bionemo/common/data/basecamp/__init__.py
@@ -13,22 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """Basecamp sharded dataset helper utilities."""
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2

--- a/recipes/evo2_megatron/src/bionemo/common/fasta/__init__.py
+++ b/recipes/evo2_megatron/src/bionemo/common/fasta/__init__.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """Pure-Python FASTA indexing helpers."""
 
 from bionemo.common.fasta.nvfaidx import (

--- a/recipes/evo2_megatron/src/bionemo/common/fasta/nvfaidx.py
+++ b/recipes/evo2_megatron/src/bionemo/common/fasta/nvfaidx.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 # ruff: noqa: D102,D105,D107
 
 from __future__ import annotations

--- a/recipes/evo2_megatron/src/bionemo/common/inference/__init__.py
+++ b/recipes/evo2_megatron/src/bionemo/common/inference/__init__.py
@@ -13,22 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """Inference helper utilities."""
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2

--- a/recipes/evo2_megatron/src/bionemo/common/io/__init__.py
+++ b/recipes/evo2_megatron/src/bionemo/common/io/__init__.py
@@ -13,22 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """Input and output conversion helpers."""
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2

--- a/recipes/evo2_megatron/src/bionemo/common/utils/__init__.py
+++ b/recipes/evo2_megatron/src/bionemo/common/utils/__init__.py
@@ -13,22 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2
-
 """General utility helpers."""
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: LicenseRef-Apache2


### PR DESCRIPTION
## Summary
- Fast-forwarded to latest `upstream/main`
- Ran `python ci/scripts/check_copied_files.py --fix`, which reordered SPDX headers to follow the copied-file notice banner in six `eden_megatron` common module `__init__.py` files

## Test plan
- [x] `python ci/scripts/check_copied_files.py --fix` (no further changes)
- [x] Pre-commit hooks pass on committed files


Made with [Cursor](https://cursor.com)