### PR TITLE
Fix `Evo2TaxonomyLineage.kingdom` -> `domain` rename in docs

### DIFF
--- a/recipes/evo2_megatron/src/bionemo/evo2/data/README.md
+++ b/recipes/evo2_megatron/src/bionemo/evo2/data/README.md
@@ -37,7 +37,7 @@ class Evo2PreprocessingConfig(BaseModel):
     embed_reverse_complement: bool = False
     # For every sequence, randomly reverse complement the sequence with the specified probability instead of using the original sequence.
     random_reverse_complement: float = 0.0
-    # For sequences associated with taxonomic lineages specified in `taxonomy_data`, randomly drop out nodes of the lineage with the specified probability. For instance: |d__KINGDOM;p__None;c__CLASS;o__None;f__None;g__None;s__None|
+    # For sequences associated with taxonomic lineages specified in `taxonomy_data`, randomly drop out nodes of the lineage with the specified probability. For instance: |d__DOMAIN;p__None;c__CLASS;o__None;f__None;g__None;s__None|
     random_lineage_dropout: float = 0.0
     # Transcribe (DNA -> RNA) or Back-Transcribe (RNA -> DNA) the sequence before tokenization.
     transcribe: None | Literal["transcribe", "back_transcribe"] = None
@@ -97,7 +97,7 @@ Furthermore, the `taxonomy_data` field contains a map from sequence ID substring
 class Evo2TaxonomyLineage(BaseModel):
     """Pydantic model class that defines the source lineage of a DNA sequence."""
 
-    kingdom: None | str = None
+    domain: None | str = None
     phylum: None | str = None
     clazz: None | str = None
     order: None | str = None


### PR DESCRIPTION
### Description

The Evo 2 data docs still have the old `kingdom` property documented but it's [now called `domain`](https://github.com/jannis-baum/bionemo-framework/blob/247c0a1e56479292315c8bc23ad4179cd97a17c7/recipes/evo2_megatron/src/bionemo/evo2/utils/config.py#L38)

#### Usage

no code required

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [x] Documentation update
- [ ] Other (please describe):

### CI Pipeline Configuration

Configure CI behavior by applying the relevant labels. By default, only basic unit tests are run.

- [ciflow:skip](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:skip) - Skip all CI tests for this PR

Unit tests marked as `@pytest.mark.multi_gpu` or `@pytest.mark.distributed` are not run in the PR pipeline.

For more details, see [CONTRIBUTING](CONTRIBUTING.md)

> [!NOTE]
> By default, only basic unit tests are run. Add appropriate labels to enable an additional test coverage.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

#### Triggering Code Rabbit AI Review

To trigger a code review from code rabbit, comment on a pull request with one of these commands:

- @coderabbitai review - Triggers a standard review
- @coderabbitai full review - Triggers a comprehensive review

See https://docs.coderabbit.ai/reference/review-commands for a full list of commands.

### Pre-submit Checklist

<!--- Ensure all items are completed before submitting -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly
- [x] I have added/updated tests as needed
- [x] All existing tests pass successfully
