### PR TITLE
Update interp recipe workflow to match the others

### DIFF
--- a/.github/workflows/unit-tests-interpretability-recipes.yaml
+++ b/.github/workflows/unit-tests-interpretability-recipes.yaml
@@ -84,8 +84,8 @@ jobs:
           fi
           echo "Recipes to run: $DIRS"
 
-          # Attach the runner image (the dockerhub-cached squashed pytorch, like the repo-wide lane).
-          IMG="svcbionemo023/bionemo-framework:pytorch26.04-py3-squashed"
+          # Attach the same default runner image as the repo-wide recipe lane.
+          IMG="nvcr.io/nvidia/pytorch:26.06-py3"
           MATRIX=$(echo "$DIRS" | jq -c --arg img "$IMG" \
             'map({dir: ., name: (. | split("/") | last), image: $img})')
           echo "dirs=$MATRIX" >> "$GITHUB_OUTPUT"
@@ -137,6 +137,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-huggingface-interp-${{ matrix.recipe.name }}-
             ${{ runner.os }}-huggingface-
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         working-directory: ${{ matrix.recipe.dir }}


### PR DESCRIPTION
### Description

Do the same Dockerfile change to the interpretability workflow in CI that was recently done to other workflows. Split out of https://github.com/NVIDIA-BioNeMo/bionemo-recipes/pull/1699 

### Type of changes

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Documentation update
- [x] Other (please describe): CI update

### CI Pipeline Configuration

Configure CI behavior by applying the relevant labels. By default, only basic unit tests are run.

- [ciflow:skip](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:skip) - Skip all CI tests for this PR
- [ciflow:notebooks](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:notebooks) - Run Jupyter notebooks execution tests
- [ciflow:slow](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:slow) - Run slow single GPU integration tests marked as @pytest.mark.slow
- [ciflow:all](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:all) - Run all tests, including unit tests, slow tests, notebooks, and every recipe/model directory.

Unit tests marked as `@pytest.mark.multi_gpu` or `@pytest.mark.distributed` are not run in the PR pipeline.

For more details, see [CONTRIBUTING](CONTRIBUTING.md)

> [!NOTE]
> By default, only basic unit tests are run. Add appropriate labels to enable an additional test coverage.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

#### Triggering Code Rabbit AI Review

To trigger a code review from code rabbit, comment on a pull request with one of these commands:

- @coderabbitai review - Triggers a standard review
- @coderabbitai full review - Triggers a comprehensive review

See https://docs.coderabbit.ai/reference/review-commands for a full list of commands.

### Pre-submit Checklist

<!--- Ensure all items are completed before submitting -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration environment for interpretability recipe checks.
  * Improved dependency setup and caching for automated test runs.
  * Refreshed the underlying test environment to support more consistent and reliable validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->