### PR TITLE
docs(esm2_native_te): add torch.compile troubleshooting note 

### DIFF
--- a/recipes/esm2_native_te/README.md
+++ b/recipes/esm2_native_te/README.md
@@ -265,6 +265,24 @@ model tag:
 ```bash
 python train_fsdp2.py --config-name L0_sanity model_tag=facebook/esm2_t6_8M_UR50D
 ```
+### Troubleshooting
+
+#### `AssertionError: assert len(self.block_stack) == 1` with `torch.compile`
+
+If you hit this error during training:
+
+```bash
+AssertionError: assert len(self.block_stack) == 1
+File "/workspace/bionemo/modeling_esm_te.py", line 259, in forward
+with self.get_autocast_context(None, outer=True):
+```
+
+This is caused by TorchDynamo being unable to trace through a context manager returned by a method
+(`self.get_autocast_context(...)`). Disable `torch.compile` as a workaround:
+
+```bash
+torchrun --nproc_per_node=8 train_fsdp2.py use_torch_compile=false
+```
 
 ## Downloading Pre-Training Data For Offline Training
 


### PR DESCRIPTION
### Description

<!-- Provide a detailed description of the changes in this PR -->

#### Problem
When running multi-GPU training with torchrun, users may hit the following error:

AssertionError: assert len(self.block_stack) == 1
  File "/workspace/bionemo/modeling_esm_te.py", line 259, in forward
    with self.get_autocast_context(None, outer=True):

This is a torch.compile incompatibility: TorchDynamo cannot trace through a context manager returned by a method call (self.get_autocast_context(...)). Dynamo has limited support for dynamic context managers, especially ones that wrap torch.autocast in non-trivial ways. As a result, the compilation graph breaks and raises an AssertionError from within the block stack tracker.

#### Fix
This PR adds a Troubleshooting subsection under ## Commands to Launch Training documenting the known workaround: passing use_torch_compile=false to disable torch.compile at launch time:

torchrun --nproc_per_node=8 train_fsdp2.py use_torch_compile=false

#### Changes
recipes/esm2_native_te/README.md: added a ### Troubleshooting section with the error signature, root cause explanation, and the workaround command.

#### Notes
No code changes are included. This is a docs-only PR. The underlying issue — making get_autocast_context compatible with TorchDynamo tracing — would require a separate fix in modeling_esm_te.py

### Type of changes

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor
- [x] Documentation update
- [ ] Other (please describe):

### CI Pipeline Configuration
[ciflow:skip]
Configure CI behavior by applying the relevant labels. By default, only basic unit tests are run.

- [ciflow:skip](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:skip) - Skip all CI tests for this PR
- [ciflow:notebooks](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:notebooks) - Run Jupyter notebooks execution tests
- [ciflow:slow](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:slow) - Run slow single GPU integration tests marked as @pytest.mark.slow
- [ciflow:all](https://github.com/NVIDIA/bionemo-framework/blob/main/docs/docs/main/contributing/contributing.md#ciflow:all) - Run all tests, including unit tests, slow tests, notebooks, and every recipe/model directory.

Unit tests marked as `@pytest.mark.multi_gpu` or `@pytest.mark.distributed` are not run in the PR pipeline.

For more details, see [CONTRIBUTING](CONTRIBUTING.md)

> [!NOTE]
> By default, only basic unit tests are run. Add appropriate labels to enable an additional test coverage.

#### Authorizing CI Runs

We use [copy-pr-bot](https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#automation) to manage authorization of CI
runs on NVIDIA's compute resources.

- If a pull request is opened by a trusted user and contains only trusted changes, the pull request's code will
  automatically be copied to a pull-request/ prefixed branch in the source repository (e.g. pull-request/123)
- If a pull request is opened by an untrusted user or contains untrusted changes, an NVIDIA org member must leave an
  `/ok to test` comment on the pull request to trigger CI. This will need to be done for each new commit.

#### Triggering Code Rabbit AI Review

To trigger a code review from code rabbit, comment on a pull request with one of these commands:

- @coderabbitai review - Triggers a standard review
- @coderabbitai full review - Triggers a comprehensive review

See https://docs.coderabbit.ai/reference/review-commands for a full list of commands.

### Pre-submit Checklist

<!--- Ensure all items are completed before submitting -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass successfully
